### PR TITLE
feat: integrar WebApp con WebAPI para autenticación, recuperación y registro de finca

### DIFF
--- a/MILESTONE2_VALIDACION.md
+++ b/MILESTONE2_VALIDACION.md
@@ -1,0 +1,35 @@
+# Validación de cierre técnico - Milestone 2 (PSA Costa Rica)
+
+## Objetivo
+Consolidar la verificación funcional del Milestone 2 con énfasis en integración **frontend (WebApp)** ↔ **backend (WebAPI)**, usando como base los criterios del ERS e IAS.
+
+## Issues cubiertos en esta rama
+
+### ISSUE-11 - Inicio de sesión
+- WebApp consume `POST /api/Autenticacion/iniciar-sesion`.
+- Se mantiene fallback local vía `AutenticacionManager` si el API no está disponible.
+- Se crea sesión cookie con `IdUsuario`, `Email` e `IdRol` para navegación por rol.
+
+### ISSUE-13 - Registro de usuario
+- WebApp consume `POST /api/Autenticacion/registrar`.
+- Se conserva fallback local para persistencia mediante AppCore/DataAccess.
+- Manejo de errores de negocio devueltos por API.
+
+### Integración de recuperación de contraseña (RF-AUT-04/05/06)
+- WebApp consume `POST /api/RecuperacionContrasena/solicitar`.
+- WebApp consume `POST /api/RecuperacionContrasena/restablecer`.
+- Formularios de recuperación y restablecimiento pasaron de flujo visual a flujo funcional contra backend.
+
+### Integración de registro de finca (RF-FIN-01/03/05)
+- Formulario `RegistrarFinca` ahora envía datos reales a backend con `POST /api/Finca/Create`.
+- Se aplica validación básica de hectáreas en cliente y validaciones de DTO en servidor.
+- Se mantiene fallback local con `FincaDAO.Create` para resiliencia en entorno de desarrollo.
+
+## Alineación con IAS
+- Respeta arquitectura por capas del IAS: WebApp no accede a SQL en primera opción, usa WebAPI y mantiene fallback controlado para desarrollo.
+- Se elimina estado "solo maqueta" en formularios críticos al conectarlos con endpoints existentes.
+- Se mantiene separación de responsabilidades: controladores ligeros y consumo de servicios API.
+
+## Riesgos o alcance pendiente para siguientes issues
+- Evaluaciones técnicas, pagos, auditoría y notificaciones aún requieren endpoints de escritura dedicados en WebAPI para cerrar completamente todos los RF del ERS.
+- Este milestone deja operativo el bloque de autenticación y registro de finca con integración real FE/BE.

--- a/PSA.WebApp/Controllers/AutenticacionController.cs
+++ b/PSA.WebApp/Controllers/AutenticacionController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using PSA.AppCore.Managers;
 using PSA.EntidadesDTO.DTOs;
+using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
+using PSA.WebApp.Models;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -64,7 +66,7 @@ namespace PSA.WebApp.Controllers
                 if (!response.IsSuccessStatusCode)
                 {
                     var errorBody = await response.Content.ReadAsStringAsync();
-                    ModelState.AddModelError(string.Empty, $"No fue posible iniciar sesión. {errorBody}");
+                    ModelState.AddModelError(string.Empty, TryReadErrorMessage(errorBody));
                     return View(dto);
                 }
 
@@ -116,8 +118,7 @@ namespace PSA.WebApp.Controllers
                 if (!response.IsSuccessStatusCode)
                 {
                     var errorBody = await response.Content.ReadAsStringAsync();
-                    var errorMensaje = TryReadErrorMessage(errorBody);
-                    ModelState.AddModelError(string.Empty, errorMensaje);
+                    ModelState.AddModelError(string.Empty, TryReadErrorMessage(errorBody));
                     return View(dto);
                 }
 
@@ -136,17 +137,104 @@ namespace PSA.WebApp.Controllers
             ViewBag.EsAutenticacion = true;
             ViewBag.TituloPagina = "Recuperar contraseña";
             ViewBag.SubtituloPagina = "Ingrese su correo electrónico para iniciar el proceso de recuperación.";
-            return View();
+            return View(new RecuperarContrasenaViewModel());
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> RecuperarContrasena(RecuperarContrasenaViewModel model)
+        {
+            ViewBag.EsAutenticacion = true;
+            ViewBag.TituloPagina = "Recuperar contraseña";
+            ViewBag.SubtituloPagina = "Ingrese su correo electrónico para iniciar el proceso de recuperación.";
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            try
+            {
+                var client = _serviceProvider.GetService<IHttpClientFactory>()?.CreateClient("AuthApi")
+                    ?? throw new InvalidOperationException("IHttpClientFactory no está disponible.");
+
+                var payload = new RecuperarContrasenaDTO { Correo = model.Correo.Trim() };
+                var response = await PostToApiAsync(client, "/api/RecuperacionContrasena/solicitar", payload);
+                var body = await response.Content.ReadFromJsonAsync<RespuestaRecuperacionDTO>();
+
+                if (!response.IsSuccessStatusCode || body == null || !body.Exito)
+                {
+                    ModelState.AddModelError(string.Empty, body?.Mensaje ?? "No fue posible procesar la solicitud de recuperación.");
+                    return View(model);
+                }
+
+                TempData["MensajeExito"] = body.Mensaje;
+                return RedirectToAction(nameof(IniciarSesion));
+            }
+            catch
+            {
+                ModelState.AddModelError(string.Empty, "No fue posible conectar con el servicio de recuperación en este momento.");
+                return View(model);
+            }
         }
 
         [HttpGet]
         public IActionResult RestablecerContrasena(string? token = null)
         {
             ViewBag.EsAutenticacion = true;
-            ViewBag.TokenRecuperacion = token ?? "TOKEN-DE-EJEMPLO";
             ViewBag.TituloPagina = "Restablecer contraseña";
             ViewBag.SubtituloPagina = "Defina una nueva contraseña segura para su cuenta.";
-            return View();
+
+            var model = new RestablecerContrasenaViewModel
+            {
+                Token = token ?? string.Empty
+            };
+
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> RestablecerContrasena(RestablecerContrasenaViewModel model)
+        {
+            ViewBag.EsAutenticacion = true;
+            ViewBag.TituloPagina = "Restablecer contraseña";
+            ViewBag.SubtituloPagina = "Defina una nueva contraseña segura para su cuenta.";
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            try
+            {
+                var client = _serviceProvider.GetService<IHttpClientFactory>()?.CreateClient("AuthApi")
+                    ?? throw new InvalidOperationException("IHttpClientFactory no está disponible.");
+
+                var payload = new RestablecerContrasenaDTO
+                {
+                    Token = model.Token.Trim(),
+                    NuevaContrasena = model.NuevaContrasena,
+                    ConfirmarContrasena = model.ConfirmarContrasena
+                };
+
+                var response = await PostToApiAsync(client, "/api/RecuperacionContrasena/restablecer", payload);
+                var body = await response.Content.ReadFromJsonAsync<RespuestaRecuperacionDTO>();
+
+                if (!response.IsSuccessStatusCode || body == null || !body.Exito)
+                {
+                    ModelState.AddModelError(string.Empty, body?.Mensaje ?? "No fue posible restablecer la contraseña.");
+                    return View(model);
+                }
+
+                TempData["MensajeExito"] = body.Mensaje;
+                return RedirectToAction(nameof(IniciarSesion));
+            }
+            catch
+            {
+                ModelState.AddModelError(string.Empty, "No fue posible conectar con el servicio de recuperación en este momento.");
+                return View(model);
+            }
         }
 
         [HttpPost]
@@ -179,9 +267,15 @@ namespace PSA.WebApp.Controllers
             try
             {
                 using var doc = JsonDocument.Parse(errorBody);
+
                 if (doc.RootElement.TryGetProperty("mensaje", out var mensaje))
                 {
                     return mensaje.GetString() ?? "No fue posible completar la operación.";
+                }
+
+                if (doc.RootElement.TryGetProperty("Mensaje", out var mensajeMayuscula))
+                {
+                    return mensajeMayuscula.GetString() ?? "No fue posible completar la operación.";
                 }
             }
             catch
@@ -203,8 +297,7 @@ namespace PSA.WebApp.Controllers
             {
                 try
                 {
-                    var response = await client.PostAsJsonAsync($"{baseUrl}{path}", payload);
-                    return response;
+                    return await client.PostAsJsonAsync($"{baseUrl}{path}", payload);
                 }
                 catch (Exception ex)
                 {
@@ -213,7 +306,7 @@ namespace PSA.WebApp.Controllers
             }
 
             throw new InvalidOperationException(
-                "No fue posible conectar con el API de autenticación en ninguna URL configurada.",
+                "No fue posible conectar con el API en ninguna URL configurada.",
                 ultimaExcepcion
             );
         }

--- a/PSA.WebApp/Controllers/FincasController.cs
+++ b/PSA.WebApp/Controllers/FincasController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using System.Security.Claims;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
+using PSA.EntidadesDTO.DTOs.Fincas;
 using System.Net.Http.Json;
 
 namespace PSA.WebApp.Controllers
@@ -35,7 +36,59 @@ namespace PSA.WebApp.Controllers
             ViewBag.BreadcrumbPadreTexto = "Mis fincas";
             ViewBag.BreadcrumbPadreUrl = Url.Action("MisFincas", "Fincas");
             ViewBag.BreadcrumbActual = "Registrar finca";
-            return View();
+            return View(new FincaDTO());
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> RegistrarFinca(FincaDTO model)
+        {
+            ViewBag.ModuloActivo = "fincas";
+            ViewBag.RolActivo = "Dueno";
+            ViewBag.TituloPagina = "Registrar finca";
+            ViewBag.SubtituloPagina = "Complete la información principal de la propiedad para iniciar el proceso.";
+            ViewBag.BreadcrumbPadreTexto = "Mis fincas";
+            ViewBag.BreadcrumbPadreUrl = Url.Action("MisFincas", "Fincas");
+            ViewBag.BreadcrumbActual = "Registrar finca";
+
+            model.IdPropietario = ObtenerIdUsuarioSesion();
+            model.EstadoFinca = string.IsNullOrWhiteSpace(model.EstadoFinca) ? "Pendiente" : model.EstadoFinca.Trim();
+
+            if (model.IdPropietario <= 0)
+            {
+                return RedirectToAction("IniciarSesion", "Autenticacion");
+            }
+
+            if (string.IsNullOrWhiteSpace(model.Distrito))
+            {
+                model.Distrito = model.Canton;
+            }
+
+            if (string.IsNullOrWhiteSpace(model.UsoSuelo))
+            {
+                model.UsoSuelo = "Conservación";
+            }
+
+            if (string.IsNullOrWhiteSpace(model.Pendiente))
+            {
+                model.Pendiente = "Media";
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var resultado = await CrearFincaEnApiConFallbackAsync(model);
+
+            if (!resultado.Exito)
+            {
+                ModelState.AddModelError(string.Empty, resultado.Mensaje);
+                return View(model);
+            }
+
+            TempData["MensajeExito"] = "Finca registrada correctamente.";
+            return RedirectToAction(nameof(MisFincas));
         }
 
         [HttpGet]
@@ -90,20 +143,78 @@ namespace PSA.WebApp.Controllers
             return View(detalle);
         }
 
+        private async Task<(bool Exito, string Mensaje)> CrearFincaEnApiConFallbackAsync(FincaDTO model)
+        {
+            try
+            {
+                var client = _serviceProvider.GetService<IHttpClientFactory>()?.CreateClient("AuthApi")
+                    ?? throw new InvalidOperationException("IHttpClientFactory no está disponible.");
+
+                Exception? ultimaExcepcion = null;
+                foreach (var baseUrl in GetApiBaseUrls())
+                {
+                    try
+                    {
+                        var response = await client.PostAsJsonAsync($"{baseUrl}/api/Finca/Create", model);
+                        if (response.IsSuccessStatusCode)
+                        {
+                            return (true, string.Empty);
+                        }
+
+                        var detalle = await response.Content.ReadAsStringAsync();
+                        return (false, $"El API rechazó el registro: {detalle}");
+                    }
+                    catch (Exception ex)
+                    {
+                        ultimaExcepcion = ex;
+                    }
+                }
+
+                if (ultimaExcepcion != null)
+                {
+                    throw ultimaExcepcion;
+                }
+            }
+            catch
+            {
+                try
+                {
+                    _fincaDAO.Create(model);
+                    return (true, string.Empty);
+                }
+                catch (Exception ex)
+                {
+                    return (false, $"No fue posible registrar la finca: {ex.Message}");
+                }
+            }
+
+            return (false, "No fue posible registrar la finca.");
+        }
+
         private async Task<List<FincaResumenDTO>> ObtenerFincasDesdeApiConFallbackAsync(int idPropietario)
         {
             try
             {
                 var client = _serviceProvider.GetService<IHttpClientFactory>()?.CreateClient("AuthApi")
                     ?? throw new InvalidOperationException("IHttpClientFactory no está disponible.");
-                var baseUrl = GetApiBaseUrl();
-                var fincas = await client.GetFromJsonAsync<List<FincaResumenDTO>>(
-                    $"{baseUrl}/api/Fincas/mis-fincas?idPropietario={idPropietario}"
-                );
 
-                if (fincas != null)
+                foreach (var baseUrl in GetApiBaseUrls())
                 {
-                    return fincas;
+                    try
+                    {
+                        var fincas = await client.GetFromJsonAsync<List<FincaResumenDTO>>(
+                            $"{baseUrl}/api/Fincas/mis-fincas?idPropietario={idPropietario}"
+                        );
+
+                        if (fincas != null)
+                        {
+                            return fincas;
+                        }
+                    }
+                    catch
+                    {
+                        // Probar siguiente URL
+                    }
                 }
             }
             catch
@@ -120,14 +231,24 @@ namespace PSA.WebApp.Controllers
             {
                 var client = _serviceProvider.GetService<IHttpClientFactory>()?.CreateClient("AuthApi")
                     ?? throw new InvalidOperationException("IHttpClientFactory no está disponible.");
-                var baseUrl = GetApiBaseUrl();
-                var detalle = await client.GetFromJsonAsync<FincaDetalleDTO>(
-                    $"{baseUrl}/api/Fincas/{idFinca}/detalle?idPropietario={idPropietario}"
-                );
 
-                if (detalle != null)
+                foreach (var baseUrl in GetApiBaseUrls())
                 {
-                    return detalle;
+                    try
+                    {
+                        var detalle = await client.GetFromJsonAsync<FincaDetalleDTO>(
+                            $"{baseUrl}/api/Fincas/{idFinca}/detalle?idPropietario={idPropietario}"
+                        );
+
+                        if (detalle != null)
+                        {
+                            return detalle;
+                        }
+                    }
+                    catch
+                    {
+                        // Probar siguiente URL
+                    }
                 }
             }
             catch
@@ -138,9 +259,16 @@ namespace PSA.WebApp.Controllers
             return await _fincaDAO.ObtenerDetalleAsync(idFinca, idPropietario);
         }
 
-        private string GetApiBaseUrl()
+        private IEnumerable<string> GetApiBaseUrls()
         {
-            return (_configuration["ApiSettings:BaseUrl"] ?? "https://localhost:59665").TrimEnd('/');
+            var configurada = _configuration["ApiSettings:BaseUrl"];
+            if (!string.IsNullOrWhiteSpace(configurada))
+            {
+                yield return configurada.TrimEnd('/');
+            }
+
+            yield return "https://localhost:59665";
+            yield return "http://localhost:59667";
         }
 
         private int ObtenerIdUsuarioSesion()

--- a/PSA.WebApp/Views/Autenticacion/RecuperarContrasena.cshtml
+++ b/PSA.WebApp/Views/Autenticacion/RecuperarContrasena.cshtml
@@ -1,3 +1,4 @@
+@model PSA.WebApp.Models.RecuperarContrasenaViewModel
 @{
     Layout = "~/Views/Shared/_LayoutAutenticacion.cshtml";
     ViewData["Title"] = "Recuperar contraseña";
@@ -9,10 +10,14 @@
         <p>Le enviaremos un enlace o token para restablecer su acceso.</p>
     </div>
 
-    <form class="formulario-base" id="formularioRecuperarContrasena" novalidate method="get" asp-controller="Autenticacion" asp-action="RestablecerContrasena">
+    <form class="formulario-base" id="formularioRecuperarContrasena" method="post" asp-controller="Autenticacion" asp-action="RecuperarContrasena">
+        @Html.AntiForgeryToken()
+        <div asp-validation-summary="ModelOnly" class="mensaje-sistema mensaje-error"></div>
+
         <div class="campo-formulario">
-            <label for="correoRecuperacion">Correo electrónico</label>
-            <input id="correoRecuperacion" name="correoRecuperacion" type="email" placeholder="usuario@correo.com" />
+            <label asp-for="Correo">Correo electrónico</label>
+            <input asp-for="Correo" type="email" placeholder="usuario@correo.com" />
+            <span asp-validation-for="Correo"></span>
         </div>
 
         <div class="fila-acciones-formulario">
@@ -27,3 +32,6 @@
         </p>
     </div>
 </div>
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/PSA.WebApp/Views/Autenticacion/RestablecerContrasena.cshtml
+++ b/PSA.WebApp/Views/Autenticacion/RestablecerContrasena.cshtml
@@ -1,3 +1,4 @@
+@model PSA.WebApp.Models.RestablecerContrasenaViewModel
 @{
     Layout = "~/Views/Shared/_LayoutAutenticacion.cshtml";
     ViewData["Title"] = "Restablecer contraseña";
@@ -6,18 +7,29 @@
     <div class="cabecera-formulario">
         <span class="eyebrow">Cambio seguro</span>
         <h2>Restablecer contraseña</h2>
-        <p>Token de referencia: <strong>@ViewBag.TokenRecuperacion</strong></p>
+        <p>Ingrese el token recibido y su nueva contraseña.</p>
     </div>
 
-    <form class="formulario-base" id="formularioRestablecerContrasena" novalidate method="get" asp-controller="Autenticacion" asp-action="IniciarSesion">
+    <form class="formulario-base" id="formularioRestablecerContrasena" method="post" asp-controller="Autenticacion" asp-action="RestablecerContrasena">
+        @Html.AntiForgeryToken()
+        <div asp-validation-summary="ModelOnly" class="mensaje-sistema mensaje-error"></div>
+
         <div class="campo-formulario">
-            <label for="nuevaContrasena">Nueva contraseña</label>
-            <input id="nuevaContrasena" name="nuevaContrasena" type="password" placeholder="Ingrese la nueva contraseña" />
+            <label asp-for="Token">Token</label>
+            <input asp-for="Token" placeholder="Token de recuperación" />
+            <span asp-validation-for="Token"></span>
         </div>
 
         <div class="campo-formulario">
-            <label for="confirmarNuevaContrasena">Confirmar nueva contraseña</label>
-            <input id="confirmarNuevaContrasena" name="confirmarNuevaContrasena" type="password" placeholder="Repita la contraseña" />
+            <label asp-for="NuevaContrasena">Nueva contraseña</label>
+            <input asp-for="NuevaContrasena" type="password" placeholder="Ingrese la nueva contraseña" />
+            <span asp-validation-for="NuevaContrasena"></span>
+        </div>
+
+        <div class="campo-formulario">
+            <label asp-for="ConfirmarContrasena">Confirmar nueva contraseña</label>
+            <input asp-for="ConfirmarContrasena" type="password" placeholder="Repita la contraseña" />
+            <span asp-validation-for="ConfirmarContrasena"></span>
         </div>
 
         <div class="fila-acciones-formulario">
@@ -31,3 +43,6 @@
         </p>
     </div>
 </div>
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml
+++ b/PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml
@@ -1,3 +1,4 @@
+@model PSA.EntidadesDTO.DTOs.Fincas.FincaDTO
 @{
     ViewData["Title"] = "Registrar finca";
 }
@@ -6,67 +7,126 @@
         <div>
             <span class="eyebrow">Nuevo registro</span>
             <h2>Formulario de finca</h2>
-            <p>Base visual para captura de datos principales, ubicación y características.</p>
+            <p>Registro completo conectado con el backend para crear la finca del propietario autenticado.</p>
         </div>
     </div>
 
-    <form class="formulario-base formulario-modulo" id="formularioRegistrarFinca" novalidate method="get" asp-controller="Fincas" asp-action="MisFincas">
+    <form class="formulario-base formulario-modulo" id="formularioRegistrarFinca" method="post" asp-controller="Fincas" asp-action="RegistrarFinca">
+        @Html.AntiForgeryToken()
+        <div asp-validation-summary="ModelOnly" class="mensaje-sistema mensaje-error"></div>
+
         <div class="seccion-formulario">
             <h3>Datos generales</h3>
             <div class="grid-dos-columnas">
                 <div class="campo-formulario">
-                    <label for="nombreFinca">Nombre de la finca</label>
-                    <input id="nombreFinca" name="nombreFinca" type="text" placeholder="Nombre de la finca" />
+                    <label asp-for="NombreFinca">Nombre de la finca</label>
+                    <input asp-for="NombreFinca" placeholder="Nombre de la finca" />
+                    <span asp-validation-for="NombreFinca"></span>
                 </div>
                 <div class="campo-formulario">
-                    <label for="codigoExpediente">Código de expediente</label>
-                    <input id="codigoExpediente" name="codigoExpediente" type="text" placeholder="PSA-2026-001" />
+                    <label asp-for="Provincia">Provincia</label>
+                    <select asp-for="Provincia">
+                        <option value="">Seleccione una provincia</option>
+                        <option>San José</option>
+                        <option>Alajuela</option>
+                        <option>Cartago</option>
+                        <option>Heredia</option>
+                        <option>Guanacaste</option>
+                        <option>Puntarenas</option>
+                        <option>Limón</option>
+                    </select>
+                    <span asp-validation-for="Provincia"></span>
                 </div>
             </div>
 
             <div class="grid-dos-columnas">
                 <div class="campo-formulario">
-                    <label for="provincia">Provincia</label>
-                    <select id="provincia" name="provincia">
-                        <option>San José</option>
-                        <option>Alajuela</option>
-                        <option>Cartago</option>
-                    </select>
+                    <label asp-for="Canton">Cantón</label>
+                    <input asp-for="Canton" placeholder="Cantón" />
+                    <span asp-validation-for="Canton"></span>
                 </div>
                 <div class="campo-formulario">
-                    <label for="canton">Cantón</label>
-                    <input id="canton" name="canton" type="text" placeholder="Cantón" />
-                </div>
-            </div>
-        </div>
-
-        <div class="seccion-formulario">
-            <h3>Características</h3>
-            <div class="grid-tres-columnas">
-                <div class="campo-formulario">
-                    <label for="hectareas">Hectáreas</label>
-                    <input id="hectareas" name="hectareas" type="number" min="0" step="0.01" />
-                </div>
-                <div class="campo-formulario">
-                    <label for="tipoCobertura">Cobertura</label>
-                    <select id="tipoCobertura" name="tipoCobertura">
-                        <option>Bosque</option>
-                        <option>Protección hídrica</option>
-                        <option>Reforestación</option>
-                    </select>
-                </div>
-                <div class="campo-formulario">
-                    <label for="estadoFinca">Estado inicial</label>
-                    <select id="estadoFinca" name="estadoFinca">
-                        <option>Pendiente</option>
-                        <option>Asignada para evaluación</option>
-                    </select>
+                    <label asp-for="Distrito">Distrito</label>
+                    <input asp-for="Distrito" placeholder="Distrito" />
+                    <span asp-validation-for="Distrito"></span>
                 </div>
             </div>
 
             <div class="campo-formulario">
-                <label for="descripcionFinca">Descripción</label>
-                <textarea id="descripcionFinca" name="descripcionFinca" rows="4" placeholder="Información adicional sobre la propiedad"></textarea>
+                <label asp-for="DireccionExacta">Dirección exacta</label>
+                <textarea asp-for="DireccionExacta" rows="3" placeholder="Señas o referencia de ubicación"></textarea>
+            </div>
+        </div>
+
+        <div class="seccion-formulario">
+            <h3>Ubicación y características</h3>
+            <div class="grid-tres-columnas">
+                <div class="campo-formulario">
+                    <label asp-for="Latitud">Latitud</label>
+                    <input asp-for="Latitud" type="number" step="0.000001" min="-90" max="90" placeholder="9.9333" />
+                    <span asp-validation-for="Latitud"></span>
+                </div>
+                <div class="campo-formulario">
+                    <label asp-for="Longitud">Longitud</label>
+                    <input asp-for="Longitud" type="number" step="0.000001" min="-180" max="180" placeholder="-84.0833" />
+                    <span asp-validation-for="Longitud"></span>
+                </div>
+                <div class="campo-formulario">
+                    <label asp-for="Hectareas">Hectáreas</label>
+                    <input asp-for="Hectareas" id="hectareas" type="number" min="0.01" step="0.01" />
+                    <span asp-validation-for="Hectareas"></span>
+                </div>
+            </div>
+
+            <div class="grid-tres-columnas">
+                <div class="campo-formulario">
+                    <label asp-for="Vegetacion">Vegetación</label>
+                    <select asp-for="Vegetacion">
+                        <option value="">Seleccione</option>
+                        <option>Bosque</option>
+                        <option>Protección hídrica</option>
+                        <option>Reforestación</option>
+                    </select>
+                    <span asp-validation-for="Vegetacion"></span>
+                </div>
+                <div class="campo-formulario">
+                    <label asp-for="UsoSuelo">Uso de suelo</label>
+                    <select asp-for="UsoSuelo">
+                        <option value="">Seleccione</option>
+                        <option>Conservación</option>
+                        <option>Producción sostenible</option>
+                        <option>Protección</option>
+                    </select>
+                    <span asp-validation-for="UsoSuelo"></span>
+                </div>
+                <div class="campo-formulario">
+                    <label asp-for="Pendiente">Pendiente</label>
+                    <select asp-for="Pendiente">
+                        <option value="">Seleccione</option>
+                        <option>Baja</option>
+                        <option>Media</option>
+                        <option>Alta</option>
+                    </select>
+                    <span asp-validation-for="Pendiente"></span>
+                </div>
+            </div>
+
+            <div class="grid-dos-columnas">
+                <div class="campo-formulario">
+                    <label asp-for="TieneRecursosHidricos">Recursos hídricos</label>
+                    <select asp-for="TieneRecursosHidricos">
+                        <option value="false">No</option>
+                        <option value="true">Sí</option>
+                    </select>
+                </div>
+                <div class="campo-formulario">
+                    <label asp-for="EstadoFinca">Estado inicial</label>
+                    <select asp-for="EstadoFinca">
+                        <option>Pendiente</option>
+                        <option>Asignada para evaluación</option>
+                    </select>
+                    <span asp-validation-for="EstadoFinca"></span>
+                </div>
             </div>
         </div>
 
@@ -77,5 +137,6 @@
     </form>
 </section>
 @section Scripts{
+    <partial name="_ValidationScriptsPartial" />
     <script src="~/js/registro-finca.js" asp-append-version="true"></script>
 }

--- a/PSA.WebApp/wwwroot/js/registro-finca.js
+++ b/PSA.WebApp/wwwroot/js/registro-finca.js
@@ -5,9 +5,16 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     formulario.addEventListener("submit", function (evento) {
-        evento.preventDefault();
-        var datos = window.psa ? window.psa.serializarFormulario(formulario) : {};
-        console.log("Formulario de finca listo para integrar con API:", datos);
-        alert("Base del formulario de finca creada. Falta conectar la persistencia.");
+        var campoHectareas = document.getElementById("hectareas");
+        if (!campoHectareas) {
+            return;
+        }
+
+        var valor = Number(campoHectareas.value);
+        if (!Number.isFinite(valor) || valor <= 0) {
+            evento.preventDefault();
+            alert("Las hectáreas deben ser un número positivo mayor a 0.");
+            campoHectareas.focus();
+        }
     });
 });


### PR DESCRIPTION
### Motivation
- Cumplir los objetivos del Milestone 2 enfocando la integración frontend ↔ backend y cerrar los issues de autenticación y registro de finca usando el IAS/ERS como guía.
- Reemplazar flujos visuales/maqueta por formularios funcionales que consuman los endpoints existentes del `WebAPI` para garantizar coherencia con la arquitectura por capas.

### Description
- Conexión de autenticación: `PSA.WebApp/Controllers/AutenticacionController.cs` ahora consume `POST /api/Autenticacion/registrar` y `POST /api/Autenticacion/iniciar-sesion`, maneja errores del API y crea sesión cookie con `IdUsuario`, `Email` e `IdRol` para redirección por rol; mantiene fallback local vía `AutenticacionManager` si el API no está disponible.
- Recuperación de contraseña: vistas y controladores convertidos a flujos reales usando `RecuperarContrasenaViewModel` y `RestablecerContrasenaViewModel`, con llamadas a `POST /api/RecuperacionContrasena/solicitar` y `POST /api/RecuperacionContrasena/restablecer` y validación de respuestas (`PSA.WebApp/Views/Autenticacion/*`, `AutenticacionController`).
- Registro de finca: `PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml` y `PSA.WebApp/Controllers/FincasController.cs` ahora envían `POST /api/Finca/Create`, usan `FincaDTO` model binding, incluyen `@Html.AntiForgeryToken()` y validaciones en servidor y cliente; en caso de indisponibilidad del API se ejecuta fallback local con `FincaDAO.Create`.
- Cliente: `PSA.WebApp/wwwroot/js/registro-finca.js` actualizado para validar que `hectareas > 0` antes de submit en vez de bloquear con una simple alerta de maqueta.
- Soporte de consumos API resilientes: se agregó búsqueda de múltiples `ApiBaseUrls` y lógica para intentar varias URLs antes de fallback local.
- Documentación: agregado `MILESTONE2_VALIDACION.md` que resume los issues cubiertos (ISSUE-11, ISSUE-13) y el alcance pendiente para módulos restantes.

### Testing
- `git diff --check` ejecutado y sin errores de formato (éxito).
- Intento de `dotnet --version && dotnet build psa-costa-rica.slnx` reportó fallo porque `dotnet` no está disponible en el entorno de ejecución (fallido por entorno, no por código).
- Operaciones de control de versión (`git status`, `git commit`) y verificación del último commit se realizaron correctamente (automático en flujo de integración).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c809cb8c5c832daf73ffd9c5b6806c)