### PR TITLE
Refactor password-recovery DTOs, enable default compilation, add DbContext helper to DataAccess, and update controllers

### DIFF
--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -10,6 +10,7 @@
 
 	<ItemGroup>
 		<Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+		<Compile Include="DbContextHelper.cs" />
 		<Compile Include="DAO\FincaDAO.cs" />
 		<Compile Include="DAO\TokenRecuperacionDAO.cs" />
 		<Compile Include="DAO\UsuarioDAO.cs" />

--- a/PSA.EntidadesDTO/DTOs/RecuperacionContrasena/RecuperarContrasenaDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/RecuperacionContrasena/RecuperarContrasenaDTO.cs
@@ -1,7 +1,0 @@
-﻿namespace PSA.EntidadesDTO.DTOs
-{
-    public class RecuperarContrasenaDTO
-    {
-        public string Correo { get; set; } = string.Empty;
-    }
-}

--- a/PSA.EntidadesDTO/DTOs/RecuperacionContrasena/RestablecerContrasenaDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/RecuperacionContrasena/RestablecerContrasenaDTO.cs
@@ -1,9 +1,0 @@
-﻿namespace PSA.EntidadesDTO.DTOs
-{
-    public class RestablecerContrasenaDTO
-    {
-        public string Token { get; set; } = string.Empty;
-        public string NuevaContrasena { get; set; } = string.Empty;
-        public string ConfirmarContrasena { get; set; } = string.Empty;
-    }
-}

--- a/PSA.EntidadesDTO/DTOs/RecuperarContrasenaDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/RecuperarContrasenaDTO.cs
@@ -7,5 +7,12 @@ namespace PSA.EntidadesDTO.DTOs
         [Required(ErrorMessage = "El correo es obligatorio.")]
         [EmailAddress(ErrorMessage = "Ingrese un correo válido.")]
         public string Email { get; set; } = string.Empty;
+
+        // Compatibilidad con llamadas que aún usan la propiedad Correo
+        public string Correo
+        {
+            get => Email;
+            set => Email = value;
+        }
     }
 }

--- a/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
+++ b/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
@@ -5,7 +5,6 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<RootNamespace>PSA.EntidadesDTO</RootNamespace>
-		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 	</PropertyGroup>
 
 </Project>

--- a/PSA.WebApp/Controllers/AutenticacionController.cs
+++ b/PSA.WebApp/Controllers/AutenticacionController.cs
@@ -4,8 +4,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using PSA.AppCore.Managers;
 using PSA.EntidadesDTO.DTOs;
-using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
-using PSA.WebApp.Models;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -429,50 +427,5 @@ Cuenta automática Do-Not-Reply";
                 });
         }
 
-        private IActionResult RecuperarContrasenaConFallbackLocal(RecuperarContrasenaViewModel model)
-        {
-            try
-            {
-                var payload = new RecuperarContrasenaDTO { Correo = model.Correo.Trim() };
-                var baseUrlWebApp = $"{Request.Scheme}://{Request.Host}";
-                var respuesta = _recuperacionContrasenaManager.GenerarToken(payload, baseUrlWebApp);
-
-                TempData["MensajeExito"] = $"{respuesta.Mensaje} (modo local, sin envío SMTP automático)";
-                return RedirectToAction(nameof(IniciarSesion));
-            }
-            catch (Exception ex)
-            {
-                ModelState.AddModelError(string.Empty, $"No fue posible procesar la recuperación: {ex.Message}");
-                return View(nameof(RecuperarContrasena), model);
-            }
-        }
-
-        private IActionResult RestablecerContrasenaConFallbackLocal(RestablecerContrasenaViewModel model)
-        {
-            try
-            {
-                var payload = new RestablecerContrasenaDTO
-                {
-                    Token = model.Token.Trim(),
-                    NuevaContrasena = model.NuevaContrasena,
-                    ConfirmarContrasena = model.ConfirmarContrasena
-                };
-
-                var respuesta = _recuperacionContrasenaManager.RestablecerContrasena(payload);
-                if (!respuesta.Exito)
-                {
-                    ModelState.AddModelError(string.Empty, respuesta.Mensaje);
-                    return View(nameof(RestablecerContrasena), model);
-                }
-
-                TempData["MensajeExito"] = $"{respuesta.Mensaje} (modo local)";
-                return RedirectToAction(nameof(IniciarSesion));
-            }
-            catch (Exception ex)
-            {
-                ModelState.AddModelError(string.Empty, $"No fue posible restablecer la contraseña: {ex.Message}");
-                return View(nameof(RestablecerContrasena), model);
-            }
-        }
     }
 }

--- a/PSA.WebApp/Controllers/FincasController.cs
+++ b/PSA.WebApp/Controllers/FincasController.cs
@@ -71,7 +71,7 @@ namespace PSA.WebApp.Controllers
             {
                 var client = _serviceProvider.GetService<IHttpClientFactory>()?.CreateClient("AuthApi")
                     ?? throw new InvalidOperationException("IHttpClientFactory no está disponible.");
-                var baseUrl = GetApiBaseUrl();
+                var baseUrl = GetApiBaseUrls().First();
                 var response = await client.PostAsJsonAsync($"{baseUrl}/api/Fincas", dto);
 
                 if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
### Motivation

- Consolidate and modernize password recovery DTOs to use a single validated `RecuperarContrasenaDTO` with an `Email` property while preserving backwards compatibility with the previous `Correo` name.
- Restore default SDK compile behaviour and explicitly include a new `DbContextHelper.cs` in the DataAccess project so shared helpers are compiled.
- Remove local fallback password-recovery methods and update API base URL resolution to support multiple configured base URLs.

### Description

- Replaced the older DTO files under `PSA.EntidadesDTO/DTOs/RecuperacionContrasena` by deleting `RecuperarContrasenaDTO.cs` and `RestablecerContrasenaDTO.cs`, and updated `PSA.EntidadesDTO/DTOs/RecuperarContrasenaDTO.cs` to expose a validated `Email` property with an accessor `Correo` for compatibility.
- Removed `EnableDefaultCompileItems=false` from `PSA.EntidadesDTO.csproj` to re-enable default compilation of items.
- Added `DbContextHelper.cs` to `PSA.DataAccess/PSA.DataAccess.csproj` via a `<Compile Include="DbContextHelper.cs" />` entry.
- Cleaned up `AutenticacionController` by removing the local fallback methods `RecuperarContrasenaConFallbackLocal` and `RestablecerContrasenaConFallbackLocal` and removed unused `using` directives.
- Updated `FincasController` to use `GetApiBaseUrls().First()` instead of `GetApiBaseUrl()` when constructing the API request base URL.

### Testing

- Built the solution with `dotnet build` and the build completed successfully.
- Executed the automated test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9b090038832d96684fa3471e9bca)