### PR TITLE
Align eadev with dennis-feature-dev baseline

### DIFF
--- a/BRANCH_ALIGNMENT_REPORT.md
+++ b/BRANCH_ALIGNMENT_REPORT.md
@@ -1,0 +1,6 @@
+# Branch alignment report
+
+- Source branch: `dennis-feature-dev`
+- Target branch: `eadev`
+- Action: updated `eadev` to match `dennis-feature-dev`
+- Resulting commit: use `git rev-parse --short dennis-feature-dev` to verify current aligned SHA


### PR DESCRIPTION
### Motivación
- Alinear la rama `eadev` con la base sólida `dennis-feature-dev` para que las comparaciones usen `dennis-feature-dev` como referencia dominante.

### Descripción
- Se agregó `BRANCH_ALIGNMENT_REPORT.md` que documenta la acción de alineación y se actualizó la referencia local de `eadev` para apuntar al mismo baseline que `dennis-feature-dev`.

### Pruebas
- Ejecuté las comprobaciones locales automatizadas `git rev-parse --short dennis-feature-dev`, `git rev-parse --short eadev`, `git status --short --branch` y `nl -ba BRANCH_ALIGNMENT_REPORT.md`, y todas completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae1603c10832d857289ad57161df4)