### PR TITLE
Conectar dashboard de administrador a métricas reales desde la BD

### DIFF
--- a/PSA.WebApp/Controllers/DashboardController.cs
+++ b/PSA.WebApp/Controllers/DashboardController.cs
@@ -74,13 +74,21 @@ namespace PSA.WebApp.Controllers
 
         [HttpGet]
         [Authorize(Roles = "1")]
-        public IActionResult Administrador()
+        public async Task<IActionResult> Administrador()
         {
             ViewBag.ModuloActivo = "dashboard";
             ViewBag.RolActivo = "Administrador";
             ViewBag.TituloPagina = "Dashboard del administrador";
             ViewBag.SubtituloPagina = "Monitoreo operativo del sistema, usuarios, pagos y auditoría.";
             ViewBag.BreadcrumbActual = "Dashboard";
+
+            var resumen = await ObtenerResumenAdministradorDesdeDbAsync();
+            ViewBag.UsuariosActivos = resumen.UsuariosActivos;
+            ViewBag.UsuariosPendientesAprobacion = resumen.UsuariosPendientesAprobacion;
+            ViewBag.CuentasPorValidar = resumen.CuentasPorValidar;
+            ViewBag.EventosAuditoria24h = resumen.EventosAuditoria24h;
+            ViewBag.AlertasAdministrativas = resumen.Alertas;
+
             return View();
         }
 
@@ -162,6 +170,59 @@ ORDER BY Cantidad DESC, Provincia ASC;";
             using var cmd = new SqlCommand(sql, connection);
             var result = await cmd.ExecuteScalarAsync();
             return result != null ? Convert.ToInt32(result) : 0;
+        }
+
+        private async Task<(int UsuariosActivos, int UsuariosPendientesAprobacion, int CuentasPorValidar, int EventosAuditoria24h, List<string> Alertas)> ObtenerResumenAdministradorDesdeDbAsync()
+        {
+            var connectionString = _configuration.GetConnectionString("PSAConnection");
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                return (0, 0, 0, 0, new List<string>());
+            }
+
+            const string sqlUsuariosActivos = @"
+SELECT COUNT(1)
+FROM Usuarios
+WHERE Estado = 'Activo';";
+
+            const string sqlUsuariosPendientesAprobacion = @"
+SELECT COUNT(1)
+FROM Usuarios
+WHERE Estado IN ('Inactivo', 'Bloqueado');";
+
+            const string sqlCuentasPorValidar = @"
+SELECT COUNT(1)
+FROM CuentasBancarias
+WHERE EstadoValidacion = 'Pendiente';";
+
+            const string sqlEventosAuditoria24h = @"
+SELECT COUNT(1)
+FROM AuditoriaLog
+WHERE FechaEvento >= DATEADD(HOUR, -24, GETDATE());";
+
+            try
+            {
+                using var connection = new SqlConnection(connectionString);
+                await connection.OpenAsync();
+
+                var usuariosActivos = await EjecutarEscalarAsync(connection, sqlUsuariosActivos);
+                var usuariosPendientes = await EjecutarEscalarAsync(connection, sqlUsuariosPendientesAprobacion);
+                var cuentasPorValidar = await EjecutarEscalarAsync(connection, sqlCuentasPorValidar);
+                var eventosAuditoria24h = await EjecutarEscalarAsync(connection, sqlEventosAuditoria24h);
+
+                var alertas = new List<string>
+                {
+                    $"Hay {cuentasPorValidar} cuentas bancarias pendientes de validación administrativa.",
+                    $"Se registraron {eventosAuditoria24h} eventos de auditoría en las últimas 24 horas.",
+                    $"Existen {usuariosPendientes} usuarios inactivos o bloqueados que requieren revisión de acceso."
+                };
+
+                return (usuariosActivos, usuariosPendientes, cuentasPorValidar, eventosAuditoria24h, alertas);
+            }
+            catch
+            {
+                return (0, 0, 0, 0, new List<string>());
+            }
         }
 
         private async Task<Dictionary<string, string>> ObtenerPronosticoProvinciasAsync()

--- a/PSA.WebApp/Views/Dashboard/Administrador.cshtml
+++ b/PSA.WebApp/Views/Dashboard/Administrador.cshtml
@@ -1,5 +1,6 @@
 @{
     ViewData["Title"] = "Dashboard del administrador";
+    var alertas = ViewBag.AlertasAdministrativas as List<string> ?? new List<string>();
 }
 <section class="seccion-pagina administrador-dashboard">
     <div class="cabecera-pagina">
@@ -14,17 +15,17 @@
     <div class="grid-tarjetas-kpi">
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Usuarios activos</span>
-            <strong>28</strong>
-            <small>3 pendientes de aprobación</small>
+            <strong>@(ViewBag.UsuariosActivos ?? 0)</strong>
+            <small>@(ViewBag.UsuariosPendientesAprobacion ?? 0) inactivos o bloqueados</small>
         </article>
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Cuentas por validar</span>
-            <strong>5</strong>
+            <strong>@(ViewBag.CuentasPorValidar ?? 0)</strong>
             <small>Revisión administrativa requerida</small>
         </article>
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Eventos de auditoría</span>
-            <strong>148</strong>
+            <strong>@(ViewBag.EventosAuditoria24h ?? 0)</strong>
             <small>Últimas 24 horas</small>
         </article>
     </div>
@@ -34,9 +35,17 @@
             <h3>Alertas administrativas</h3>
         </div>
         <ul class="lista-timeline">
-            <li><a asp-controller="Administracion" asp-action="ParametrosPago">Se detectaron 2 cambios en parámetros de pago.</a></li>
-            <li><a asp-controller="Pagos" asp-action="PlanesPago">Existe 1 plan de pago sin cuenta bancaria asociada.</a></li>
-            <li><a asp-controller="Administracion" asp-action="GestionUsuarios">Hay 3 usuarios sin rol asignado definitivo.</a></li>
+            @if (alertas.Count == 0)
+            {
+                <li>No hay alertas administrativas registradas en este momento.</li>
+            }
+            else
+            {
+                foreach (var alerta in alertas)
+                {
+                    <li>@alerta</li>
+                }
+            }
         </ul>
     </section>
 </section>


### PR DESCRIPTION
### Motivation
- El dashboard del administrador mostraba datos estáticos en la vista en lugar de métricas reales; es necesario reemplazar esos valores quemados por información proveniente de la base de datos.
- El dashboard del ingeniero ya consumía datos dinámicos, por lo que el cambio objetivo fue normalizar el comportamiento del dashboard administrativo.

### Description
- Convertí la acción `DashboardController.Administrador` a asíncrona y la hago obtener un resumen real desde la BD llamando a `ObtenerResumenAdministradorDesdeDbAsync`.
- Añadí `ObtenerResumenAdministradorDesdeDbAsync` que ejecuta consultas SQL para contar usuarios activos, usuarios inactivos/bloqueados, cuentas bancarias pendientes de validación y eventos de auditoría en las últimas 24 horas, y construye una lista de alertas.
- Paso los resultados al front con `ViewBag.UsuariosActivos`, `ViewBag.UsuariosPendientesAprobacion`, `ViewBag.CuentasPorValidar`, `ViewBag.EventosAuditoria24h` y `ViewBag.AlertasAdministrativas`.
- Actualicé la vista `PSA.WebApp/Views/Dashboard/Administrador.cshtml` para reemplazar los KPIs y las alertas hardcodeadas por los valores dinámicos provenientes de `ViewBag`.

### Testing
- Ejecuté `dotnet build psa-costa-rica.slnx` en el entorno y la compilación no pudo ejecutarse porque `dotnet` no está disponible en este entorno (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf121b7e0832daad91ae593684283)