### PR TITLE
Make admin dashboard metrics resilient to missing DB objects

### DIFF
--- a/PSA.WebAPI/Controllers/DashboardController.cs
+++ b/PSA.WebAPI/Controllers/DashboardController.cs
@@ -52,11 +52,11 @@ WHERE FechaAccion >= DATEADD(HOUR, -24, GETDATE());";
             using var connection = new SqlConnection(connectionString);
             await connection.OpenAsync();
 
-            var usuariosActivos = await EjecutarEscalarAsync(connection, sqlUsuariosActivos);
-            var usuariosPendientes = await EjecutarEscalarAsync(connection, sqlUsuariosPendientes);
-            var usuariosNuevosHoy = await EjecutarEscalarAsync(connection, sqlUsuariosNuevosHoy);
-            var cuentasPendientes = await EjecutarEscalarAsync(connection, sqlCuentasPendientes);
-            var eventosAuditoria = await EjecutarEscalarAsync(connection, sqlAuditoria24h);
+            var usuariosActivos = await EjecutarEscalarSeguroAsync(connection, sqlUsuariosActivos);
+            var usuariosPendientes = await EjecutarEscalarSeguroAsync(connection, sqlUsuariosPendientes);
+            var usuariosNuevosHoy = await EjecutarEscalarSeguroAsync(connection, sqlUsuariosNuevosHoy);
+            var cuentasPendientes = await EjecutarEscalarSeguroAsync(connection, sqlCuentasPendientes);
+            var eventosAuditoria = await EjecutarEscalarSeguroAsync(connection, sqlAuditoria24h);
             var actividadReciente = await ObtenerActividadAuditoriaAsync(connection);
 
             return Ok(new ResumenDashboardAdministradorDTO
@@ -85,30 +85,80 @@ WHERE FechaAccion >= DATEADD(HOUR, -24, GETDATE());";
 
         private static async Task<List<ActividadAuditoriaDTO>> ObtenerActividadAuditoriaAsync(SqlConnection connection)
         {
-            const string sqlActividad = @"
-SELECT TOP 10
-    ISNULL(Modulo, 'General') AS Modulo,
-    ISNULL(Accion, 'Cambio') AS Accion,
-    ISNULL(Detalle, CONCAT(TablaAfectada, ' #', ISNULL(CONVERT(varchar(20), IdRegistroAfectado), 's/d'))) AS Detalle,
-    FechaAccion
-FROM dbo.AuditoriaLog
-ORDER BY FechaAccion DESC;";
-
             var actividad = new List<ActividadAuditoriaDTO>();
-            using var cmd = new SqlCommand(sqlActividad, connection);
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            const string sqlActividad = @"
+IF OBJECT_ID('dbo.AuditoriaLog', 'U') IS NULL
+BEGIN
+    SELECT TOP 0
+        CAST('General' AS varchar(50)) AS Modulo,
+        CAST('Cambio' AS varchar(50)) AS Accion,
+        CAST('Sin detalle' AS varchar(250)) AS Detalle,
+        CAST(GETDATE() AS datetime2) AS FechaAccion;
+END
+ELSE IF COL_LENGTH('dbo.AuditoriaLog', 'FechaAccion') IS NOT NULL
+BEGIN
+    SELECT TOP 10
+        ISNULL(Modulo, 'General') AS Modulo,
+        ISNULL(Accion, 'Cambio') AS Accion,
+        ISNULL(Detalle, CONCAT(ISNULL(TablaAfectada, 'General'), ' #', ISNULL(CONVERT(varchar(20), IdRegistroAfectado), 's/d'))) AS Detalle,
+        FechaAccion
+    FROM dbo.AuditoriaLog
+    ORDER BY FechaAccion DESC;
+END
+ELSE IF COL_LENGTH('dbo.AuditoriaLog', 'FechaEvento') IS NOT NULL
+BEGIN
+    SELECT TOP 10
+        ISNULL(Modulo, 'General') AS Modulo,
+        ISNULL(Accion, 'Cambio') AS Accion,
+        ISNULL(Detalle, CONCAT(ISNULL(TablaAfectada, 'General'), ' #', ISNULL(CONVERT(varchar(20), IdRegistroAfectado), 's/d'))) AS Detalle,
+        FechaEvento AS FechaAccion
+    FROM dbo.AuditoriaLog
+    ORDER BY FechaEvento DESC;
+END
+ELSE
+BEGIN
+    SELECT TOP 10
+        ISNULL(Modulo, 'General') AS Modulo,
+        ISNULL(Accion, 'Cambio') AS Accion,
+        ISNULL(Detalle, CONCAT(ISNULL(TablaAfectada, 'General'), ' #', ISNULL(CONVERT(varchar(20), IdRegistroAfectado), 's/d'))) AS Detalle,
+        CAST(GETDATE() AS datetime2) AS FechaAccion
+    FROM dbo.AuditoriaLog
+    ORDER BY IdLog DESC;
+END;";
+
+            try
             {
-                actividad.Add(new ActividadAuditoriaDTO
+                using var cmd = new SqlCommand(sqlActividad, connection);
+                using var reader = await cmd.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
                 {
-                    Modulo = reader["Modulo"]?.ToString() ?? "General",
-                    Accion = reader["Accion"]?.ToString() ?? "Cambio",
-                    Detalle = reader["Detalle"]?.ToString() ?? "Sin detalle",
-                    FechaAccion = reader.GetDateTime(reader.GetOrdinal("FechaAccion"))
-                });
+                    actividad.Add(new ActividadAuditoriaDTO
+                    {
+                        Modulo = reader["Modulo"]?.ToString() ?? "General",
+                        Accion = reader["Accion"]?.ToString() ?? "Cambio",
+                        Detalle = reader["Detalle"]?.ToString() ?? "Sin detalle",
+                        FechaAccion = reader.GetDateTime(reader.GetOrdinal("FechaAccion"))
+                    });
+                }
+            }
+            catch
+            {
+                return actividad;
             }
 
             return actividad;
+        }
+
+        private static async Task<int> EjecutarEscalarSeguroAsync(SqlConnection connection, string sql)
+        {
+            try
+            {
+                return await EjecutarEscalarAsync(connection, sql);
+            }
+            catch
+            {
+                return 0;
+            }
         }
     }
 }

--- a/PSA.WebApp/Controllers/DashboardController.cs
+++ b/PSA.WebApp/Controllers/DashboardController.cs
@@ -275,11 +275,11 @@ ELSE
                 using var connection = new SqlConnection(connectionString);
                 await connection.OpenAsync();
 
-                var usuariosActivos = await EjecutarEscalarAsync(connection, sqlUsuariosActivos);
-                var usuariosPendientes = await EjecutarEscalarAsync(connection, sqlUsuariosPendientesAprobacion);
-                var usuariosNuevosHoy = await EjecutarEscalarAsync(connection, sqlUsuariosNuevosHoy);
-                var cuentasPorValidar = await EjecutarEscalarAsync(connection, sqlCuentasPorValidar);
-                var eventosAuditoria24h = await EjecutarEscalarAsync(connection, sqlEventosAuditoria24h);
+                var usuariosActivos = await EjecutarEscalarSeguroAsync(connection, sqlUsuariosActivos);
+                var usuariosPendientes = await EjecutarEscalarSeguroAsync(connection, sqlUsuariosPendientesAprobacion);
+                var usuariosNuevosHoy = await EjecutarEscalarSeguroAsync(connection, sqlUsuariosNuevosHoy);
+                var cuentasPorValidar = await EjecutarEscalarSeguroAsync(connection, sqlCuentasPorValidar);
+                var eventosAuditoria24h = await EjecutarEscalarSeguroAsync(connection, sqlEventosAuditoria24h);
                 var actividadAuditoria = await ObtenerActividadAuditoriaAsync(connection);
 
                 return new ResumenDashboardAdministradorDTO
@@ -306,30 +306,80 @@ ELSE
 
         private static async Task<List<ActividadAuditoriaDTO>> ObtenerActividadAuditoriaAsync(SqlConnection connection)
         {
-            const string sqlActividad = @"
-SELECT TOP 10
-    ISNULL(Modulo, 'General') AS Modulo,
-    ISNULL(Accion, 'Cambio') AS Accion,
-    ISNULL(Detalle, CONCAT(TablaAfectada, ' #', ISNULL(CONVERT(varchar(20), IdRegistroAfectado), 's/d'))) AS Detalle,
-    FechaAccion
-FROM dbo.AuditoriaLog
-ORDER BY FechaAccion DESC;";
-
             var actividad = new List<ActividadAuditoriaDTO>();
-            using var cmd = new SqlCommand(sqlActividad, connection);
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            const string sqlActividad = @"
+IF OBJECT_ID('dbo.AuditoriaLog', 'U') IS NULL
+BEGIN
+    SELECT TOP 0
+        CAST('General' AS varchar(50)) AS Modulo,
+        CAST('Cambio' AS varchar(50)) AS Accion,
+        CAST('Sin detalle' AS varchar(250)) AS Detalle,
+        CAST(GETDATE() AS datetime2) AS FechaAccion;
+END
+ELSE IF COL_LENGTH('dbo.AuditoriaLog', 'FechaAccion') IS NOT NULL
+BEGIN
+    SELECT TOP 10
+        ISNULL(Modulo, 'General') AS Modulo,
+        ISNULL(Accion, 'Cambio') AS Accion,
+        ISNULL(Detalle, CONCAT(ISNULL(TablaAfectada, 'General'), ' #', ISNULL(CONVERT(varchar(20), IdRegistroAfectado), 's/d'))) AS Detalle,
+        FechaAccion
+    FROM dbo.AuditoriaLog
+    ORDER BY FechaAccion DESC;
+END
+ELSE IF COL_LENGTH('dbo.AuditoriaLog', 'FechaEvento') IS NOT NULL
+BEGIN
+    SELECT TOP 10
+        ISNULL(Modulo, 'General') AS Modulo,
+        ISNULL(Accion, 'Cambio') AS Accion,
+        ISNULL(Detalle, CONCAT(ISNULL(TablaAfectada, 'General'), ' #', ISNULL(CONVERT(varchar(20), IdRegistroAfectado), 's/d'))) AS Detalle,
+        FechaEvento AS FechaAccion
+    FROM dbo.AuditoriaLog
+    ORDER BY FechaEvento DESC;
+END
+ELSE
+BEGIN
+    SELECT TOP 10
+        ISNULL(Modulo, 'General') AS Modulo,
+        ISNULL(Accion, 'Cambio') AS Accion,
+        ISNULL(Detalle, CONCAT(ISNULL(TablaAfectada, 'General'), ' #', ISNULL(CONVERT(varchar(20), IdRegistroAfectado), 's/d'))) AS Detalle,
+        CAST(GETDATE() AS datetime2) AS FechaAccion
+    FROM dbo.AuditoriaLog
+    ORDER BY IdLog DESC;
+END;";
+
+            try
             {
-                actividad.Add(new ActividadAuditoriaDTO
+                using var cmd = new SqlCommand(sqlActividad, connection);
+                using var reader = await cmd.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
                 {
-                    Modulo = reader["Modulo"]?.ToString() ?? "General",
-                    Accion = reader["Accion"]?.ToString() ?? "Cambio",
-                    Detalle = reader["Detalle"]?.ToString() ?? "Sin detalle",
-                    FechaAccion = reader.GetDateTime(reader.GetOrdinal("FechaAccion"))
-                });
+                    actividad.Add(new ActividadAuditoriaDTO
+                    {
+                        Modulo = reader["Modulo"]?.ToString() ?? "General",
+                        Accion = reader["Accion"]?.ToString() ?? "Cambio",
+                        Detalle = reader["Detalle"]?.ToString() ?? "Sin detalle",
+                        FechaAccion = reader.GetDateTime(reader.GetOrdinal("FechaAccion"))
+                    });
+                }
+            }
+            catch
+            {
+                return actividad;
             }
 
             return actividad;
+        }
+
+        private static async Task<int> EjecutarEscalarSeguroAsync(SqlConnection connection, string sql)
+        {
+            try
+            {
+                return await EjecutarEscalarAsync(connection, sql);
+            }
+            catch
+            {
+                return 0;
+            }
         }
 
         private async Task<Dictionary<string, string>> ObtenerPronosticoProvinciasAsync()


### PR DESCRIPTION
### Motivation
- El dashboard de Administrador mostraba todos los contadores en 0 porque una sola consulta SQL fallida (frecuentemente relacionada con auditoría) provocaba que el resumen devolviera un DTO vacío.
- Es necesario que la vista se alimente con los datos disponibles en la base de datos y que fallos parciales no tiren toda la carga del dashboard.

### Description
- Reemplazado el uso directo de `EjecutarEscalarAsync` por un wrapper seguro `EjecutarEscalarSeguroAsync` en `PSA.WebApp/Controllers/DashboardController.cs` y `PSA.WebAPI/Controllers/DashboardController.cs` para que una consulta fallida devuelva `0` sin abortar el resto de métricas.
- Endurecida la consulta de actividad de auditoría para manejar los casos en que la tabla `AuditoriaLog` no exista y las variantes de columna `FechaAccion` / `FechaEvento` usando `OBJECT_ID` y `COL_LENGTH`.
- Añadido `try/catch` alrededor de la lectura de resultados de auditoría para que errores en ese bloque no anulen los demás KPIs.

### Testing
- Intenté ejecutar `dotnet build psa-costa-rica.slnx` en el contenedor de trabajo, pero falló porque `dotnet` no está instalado en este entorno (`/bin/bash: dotnet: command not found`).
- No se ejecutaron tests automatizados adicionales en CI dentro de este entorno; los cambios se confirmaron localmente (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0b005be0832d96ac96b3f82fec34)