### PR TITLE
Corregir conteo de Eventos de Auditoría en dashboard de Administrador

### DIFF
--- a/PSA.WebAPI/Controllers/DashboardController.cs
+++ b/PSA.WebAPI/Controllers/DashboardController.cs
@@ -45,9 +45,18 @@ FROM dbo.CuentasBancarias
 WHERE UPPER(LTRIM(RTRIM(ISNULL(EstadoValidacion, '')))) = 'PENDIENTE';";
 
             const string sqlAuditoria24h = @"
-SELECT COUNT(1)
-FROM dbo.AuditoriaLog
-WHERE FechaAccion >= DATEADD(HOUR, -24, GETDATE());";
+IF OBJECT_ID('dbo.AuditoriaLog', 'U') IS NULL
+    SELECT 0;
+ELSE IF COL_LENGTH('dbo.AuditoriaLog', 'FechaAccion') IS NOT NULL
+    SELECT COUNT(1)
+    FROM dbo.AuditoriaLog
+    WHERE FechaAccion >= DATEADD(HOUR, -24, GETDATE());
+ELSE IF COL_LENGTH('dbo.AuditoriaLog', 'FechaEvento') IS NOT NULL
+    SELECT COUNT(1)
+    FROM dbo.AuditoriaLog
+    WHERE FechaEvento >= DATEADD(HOUR, -24, GETDATE());
+ELSE
+    SELECT COUNT(1) FROM dbo.AuditoriaLog;";
 
             using var connection = new SqlConnection(connectionString);
             await connection.OpenAsync();


### PR DESCRIPTION
### Motivation
- El KPI “Eventos de auditoría” podía devolver `0` porque la consulta asumía la existencia de la columna `FechaAccion` en `dbo.AuditoriaLog` y fallaba en esquemas diferentes. 
- Se buscó hacer la consulta resistente a variaciones de esquema para que funcione en distintos entornos sin depender de una sola columna. 
- La intención es reproducir la lógica defensiva ya usada en la WebApp y evitar falsos ceros en el resumen administrativo. 

### Description
- Actualizado `PSA.WebAPI/Controllers/DashboardController.cs` para reemplazar la consulta `sqlAuditoria24h` por una versión que comprueba si la tabla existe con `OBJECT_ID` y si existen las columnas `FechaAccion` o `FechaEvento` con `COL_LENGTH`, usando la columna disponible para contar eventos en las últimas 24 horas y cayendo a un `SELECT COUNT(1)` como último recurso. 
- Se mantiene el comportamiento posterior donde, si el conteo resultante es `0` pero hay actividad reciente, se recalcula el KPI contando entradas de `ActividadAuditoria` dentro de las últimas 24 horas. 
- Solo se modificó `PSA.WebAPI/Controllers/DashboardController.cs` (inserciones para robustecer la consulta SQL). 

### Testing
- Intenté ejecutar `dotnet build PSA.WebAPI/PSA.WebAPI.csproj -v minimal` pero no pudo ejecutarse en este contenedor porque `dotnet` no está instalado (`dotnet: command not found`). 
- No se pudieron correr builds o tests automatizados en este entorno; el cambio fue verificado mediante inspección estática del archivo y commit del archivo modificado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc14cf153c832d8797cc1e54942a2e)