### PR TITLE
Agregar auditoría de eventos críticos de autenticación

### DIFF
--- a/PSA.AppCore/Managers/AutenticacionManager.cs
+++ b/PSA.AppCore/Managers/AutenticacionManager.cs
@@ -9,13 +9,16 @@ namespace PSA.AppCore.Managers
     {
         private readonly IServicioHashContrasena _servicioHashContrasena;
         private readonly UsuarioDAO _usuarioDAO;
+        private readonly AuditoriaLogDAO _auditoriaLogDAO;
 
         public AutenticacionManager(
             IServicioHashContrasena servicioHashContrasena,
-            UsuarioDAO usuarioDAO)
+            UsuarioDAO usuarioDAO,
+            AuditoriaLogDAO auditoriaLogDAO)
         {
             _servicioHashContrasena = servicioHashContrasena;
             _usuarioDAO = usuarioDAO;
+            _auditoriaLogDAO = auditoriaLogDAO;
         }
 
         public async Task<int> RegistrarUsuarioAsync(RegistrarUsuarioDTO dto)
@@ -68,7 +71,17 @@ namespace PSA.AppCore.Managers
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(dto.Email.Trim());
 
             if (usuario == null)
+            {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    accion: "LOGIN_FALLIDO",
+                    detalle: $"Intento fallido para correo no registrado: {dto.Email.Trim()}"
+                );
+
                 throw new Exception("Credenciales inválidas.");
+            }
 
             var contrasenaValida = _servicioHashContrasena.VerificarHash(
                 usuario.PasswordHash,
@@ -76,10 +89,30 @@ namespace PSA.AppCore.Managers
             );
 
             if (!contrasenaValida)
+            {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: usuario.IdUsuario,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    idRegistroAfectado: usuario.IdUsuario,
+                    accion: "LOGIN_FALLIDO",
+                    detalle: $"Contraseña inválida para el usuario {usuario.Email}"
+                );
+
                 throw new Exception("Credenciales inválidas.");
+            }
 
             var fechaAcceso = DateTime.Now;
             await _usuarioDAO.ActualizarUltimoAccesoAsync(usuario.IdUsuario, fechaAcceso);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "LOGIN_EXITOSO",
+                detalle: $"Inicio de sesión exitoso para {usuario.Email}"
+            );
 
             return new RespuestaInicioSesionDTO
             {

--- a/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
+++ b/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
@@ -9,15 +9,18 @@ namespace PSA.AppCore.Managers
         private readonly UsuarioDAO _usuarioDAO;
         private readonly TokenRecuperacionDAO _tokenRecuperacionDAO;
         private readonly IServicioHashContrasena _servicioHash;
+        private readonly AuditoriaLogDAO _auditoriaLogDAO;
 
         public RecuperacionContrasenaManager(
             UsuarioDAO usuarioDAO,
             TokenRecuperacionDAO tokenRecuperacionDAO,
-            IServicioHashContrasena servicioHash)
+            IServicioHashContrasena servicioHash,
+            AuditoriaLogDAO auditoriaLogDAO)
         {
             _usuarioDAO = usuarioDAO;
             _tokenRecuperacionDAO = tokenRecuperacionDAO;
             _servicioHash = servicioHash;
+            _auditoriaLogDAO = auditoriaLogDAO;
         }
 
         public async Task<(string Token, string NombreUsuario)> GenerarTokenConNombreAsync(string email)
@@ -25,6 +28,14 @@ namespace PSA.AppCore.Managers
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(email);
             if (usuario == null)
             {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "TokensRecuperacion",
+                    accion: "TOKEN_RECUPERACION_FALLIDO",
+                    detalle: $"Solicitud de recuperación para correo inexistente: {email}"
+                );
+
                 throw new InvalidOperationException("No existe una cuenta asociada al correo indicado.");
             }
 
@@ -32,12 +43,34 @@ namespace PSA.AppCore.Managers
 
             var token = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
             await _tokenRecuperacionDAO.CrearTokenAsync(usuario.IdUsuario, token, DateTime.UtcNow.AddMinutes(3));
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "TokensRecuperacion",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "TOKEN_RECUPERACION_GENERADO",
+                detalle: "Se generó token de recuperación de contraseña."
+            );
+
             return (token, usuario.NombreCompleto);
         }
 
         public async Task<bool> TokenEsValidoAsync(string token)
         {
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: registro?.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "TokensRecuperacion",
+                idRegistroAfectado: registro?.IdToken,
+                accion: registro == null ? "TOKEN_RECUPERACION_INVALIDO" : "TOKEN_RECUPERACION_VALIDADO",
+                detalle: registro == null
+                    ? "Se intentó usar un token inválido o expirado."
+                    : "Se validó un token de recuperación."
+            );
+
             return registro != null;
         }
 
@@ -58,6 +91,14 @@ namespace PSA.AppCore.Managers
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
             if (registro == null)
             {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    accion: "CAMBIO_CONTRASENA_FALLIDO",
+                    detalle: "Se intentó restablecer contraseña con token inválido o expirado."
+                );
+
                 throw new InvalidOperationException("El token es inválido o expiró.");
             }
 
@@ -70,6 +111,15 @@ namespace PSA.AppCore.Managers
             var hash = _servicioHash.GenerarHash(nuevaContrasena);
             await _usuarioDAO.ActualizarPasswordHashPorEmailAsync(usuario.Email, hash);
             await _tokenRecuperacionDAO.MarcarTokenComoUsadoAsync(registro.IdToken);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "CAMBIO_CONTRASENA_EXITOSO",
+                detalle: "Se restableció la contraseña usando token de recuperación."
+            );
         }
     }
 }

--- a/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
+++ b/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
@@ -1,0 +1,68 @@
+using Microsoft.Data.SqlClient;
+
+namespace PSA.DataAccess.DAO
+{
+    public class AuditoriaLogDAO
+    {
+        private readonly string _connectionString;
+
+        public AuditoriaLogDAO(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public async Task RegistrarEventoAsync(
+            int? idUsuario,
+            string modulo,
+            string tablaAfectada,
+            string accion,
+            string? detalle = null,
+            int? idRegistroAfectado = null,
+            string? ipOrigen = null,
+            string? valorAnterior = null,
+            string? valorNuevo = null)
+        {
+            const string sql = @"
+INSERT INTO AuditoriaLog
+(
+    IdUsuario,
+    Modulo,
+    TablaAfectada,
+    IdRegistroAfectado,
+    Accion,
+    ValorAnterior,
+    ValorNuevo,
+    IpOrigen,
+    Detalle
+)
+VALUES
+(
+    @IdUsuario,
+    @Modulo,
+    @TablaAfectada,
+    @IdRegistroAfectado,
+    @Accion,
+    @ValorAnterior,
+    @ValorNuevo,
+    @IpOrigen,
+    @Detalle
+);";
+
+            using var connection = new SqlConnection(_connectionString);
+            using var command = new SqlCommand(sql, connection);
+
+            command.Parameters.AddWithValue("@IdUsuario", (object?)idUsuario ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Modulo", modulo);
+            command.Parameters.AddWithValue("@TablaAfectada", tablaAfectada);
+            command.Parameters.AddWithValue("@IdRegistroAfectado", (object?)idRegistroAfectado ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Accion", accion);
+            command.Parameters.AddWithValue("@ValorAnterior", (object?)valorAnterior ?? DBNull.Value);
+            command.Parameters.AddWithValue("@ValorNuevo", (object?)valorNuevo ?? DBNull.Value);
+            command.Parameters.AddWithValue("@IpOrigen", (object?)ipOrigen ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Detalle", (object?)detalle ?? DBNull.Value);
+
+            await connection.OpenAsync();
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -54,6 +54,32 @@ builder.Services.AddScoped<FincaDAO>(sp =>
     return new FincaDAO(connectionString);
 });
 
+builder.Services.AddScoped<AuditoriaLogDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection'.");
+    }
+
+    return new AuditoriaLogDAO(connectionString);
+});
+
+builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection'.");
+    }
+
+    return new TokenRecuperacionDAO(connectionString);
+});
+
 builder.Services.AddScoped<RecuperacionContrasenaDAO>(sp =>
 {
     var configuration = sp.GetRequiredService<IConfiguration>();

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -54,6 +54,19 @@ builder.Services.AddScoped<FincaDAO>(sp =>
     return new FincaDAO(connectionString);
 });
 
+builder.Services.AddScoped<AuditoriaLogDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection' en WebApp.");
+    }
+
+    return new AuditoriaLogDAO(connectionString);
+});
+
 builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>
 {
     var configuration = sp.GetRequiredService<IConfiguration>();


### PR DESCRIPTION
### Motivation
- Registrar trazabilidad mínima de accesos y movimientos críticos del módulo de autenticación (logins, tokens y cambios de contraseña) para cumplir los criterios del issue. 
- El proyecto ya tiene la tabla `AuditoriaLog` en la base de datos y conviene reutilizarla en lugar de crear una tabla separada. 
- El código no registraba de forma centralizada eventos de autenticación; por eso se añadió persistencia de eventos en los managers correspondientes.

### Description
- Se añadió `PSA.DataAccess/DAO/AuditoriaLogDAO.cs` con `RegistrarEventoAsync(...)` para insertar entradas en la tabla `AuditoriaLog`.
- Se integró el registro de eventos en `PSA.AppCore/Managers/AutenticacionManager.cs` para `LOGIN_FALLIDO` y `LOGIN_EXITOSO` (casos: usuario inexistente, contraseña inválida y login correcto).
- Se integró el registro de eventos en `PSA.AppCore/Managers/RecuperacionContrasenaManager.cs` para `TOKEN_RECUPERACION_GENERADO`, `TOKEN_RECUPERACION_VALIDADO` / `TOKEN_RECUPERACION_INVALIDO` y `CAMBIO_CONTRASENA_EXITOSO` / `CAMBIO_CONTRASENA_FALLIDO`.
- Se registró la nueva dependencia `AuditoriaLogDAO` en el contenedor DI de `PSA.WebApp/Program.cs` y `PSA.WebAPI/Program.cs` (además se añadió registro de `TokenRecuperacionDAO` en WebAPI para compatibilidad de resoluciones de dependencias).

### Testing
- Se intentó compilar con `dotnet build PSA.WebApp/PSA.WebApp.csproj && dotnet build PSA.WebAPI/PSA.WebAPI.csproj` y la verificación automatizada falló porque el entorno no dispone del SDK de .NET (`/bin/bash: dotnet: command not found`).
- No se ejecutaron pruebas unitarias automatizadas en este entorno debido a la falta del runtime/SDK, por lo que los cambios se verificaron mediante inspección de código estático y búsquedas en el árbol del proyecto.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc718de658832dbb2b19816285c3ae)