### PR TITLE
Pin Microsoft.AspNetCore.OpenApi and add NuGet.config to fix NETSDK1064

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -11,6 +11,7 @@
 		<ProjectReference Include="..\PSA.AppCore\PSA.AppCore.csproj" />
 		<ProjectReference Include="..\PSA.DataAccess\PSA.DataAccess.csproj" />
 		<ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
### Motivation
- The build/clean was failing with `NETSDK1064` because `Microsoft.AspNetCore.OpenApi` v10.0.4 could not be resolved, which commonly happens when package sources are missing or restore is partial.

### Description
- Added a repository-level `NuGet.config` that explicitly sets `nuget.org` as the package source to ensure restores can reach the official feed.
- Added an explicit `PackageReference` for `Microsoft.AspNetCore.OpenApi` pinned to `10.0.0` in `PSA.WebAPI/PSA.WebAPI.csproj` to avoid implicit/unexpected version resolution.

### Testing
- Repository inspection commands (`rg`, `sed`) were run to locate projects and verify the edits and those commands succeeded.  
- Attempts to run `dotnet --info` failed in this environment with `dotnet: command not found`, so CLI-based validation could not be executed here.  
- Attempts to run `dotnet clean` also could not be performed for the same reason, so restore/build validation should be run locally where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc7913fc08832d8156aa899c64dab0)