### PR TITLE
Incluir AuditoriaLogDAO y corregir duplicados para compilar en Windows

### DIFF
--- a/PSA.AppCore/Managers/AutenticacionManager.cs
+++ b/PSA.AppCore/Managers/AutenticacionManager.cs
@@ -9,13 +9,16 @@ namespace PSA.AppCore.Managers
     {
         private readonly IServicioHashContrasena _servicioHashContrasena;
         private readonly UsuarioDAO _usuarioDAO;
+        private readonly AuditoriaLogDAO _auditoriaLogDAO;
 
         public AutenticacionManager(
             IServicioHashContrasena servicioHashContrasena,
-            UsuarioDAO usuarioDAO)
+            UsuarioDAO usuarioDAO,
+            AuditoriaLogDAO auditoriaLogDAO)
         {
             _servicioHashContrasena = servicioHashContrasena;
             _usuarioDAO = usuarioDAO;
+            _auditoriaLogDAO = auditoriaLogDAO;
         }
 
         public async Task<int> RegistrarUsuarioAsync(RegistrarUsuarioDTO dto)
@@ -68,7 +71,17 @@ namespace PSA.AppCore.Managers
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(dto.Email.Trim());
 
             if (usuario == null)
+            {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    accion: "LOGIN_FALLIDO",
+                    detalle: $"Intento fallido para correo no registrado: {dto.Email.Trim()}"
+                );
+
                 throw new Exception("Credenciales inválidas.");
+            }
 
             var contrasenaValida = _servicioHashContrasena.VerificarHash(
                 usuario.PasswordHash,
@@ -76,10 +89,30 @@ namespace PSA.AppCore.Managers
             );
 
             if (!contrasenaValida)
+            {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: usuario.IdUsuario,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    idRegistroAfectado: usuario.IdUsuario,
+                    accion: "LOGIN_FALLIDO",
+                    detalle: $"Contraseña inválida para el usuario {usuario.Email}"
+                );
+
                 throw new Exception("Credenciales inválidas.");
+            }
 
             var fechaAcceso = DateTime.Now;
             await _usuarioDAO.ActualizarUltimoAccesoAsync(usuario.IdUsuario, fechaAcceso);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "LOGIN_EXITOSO",
+                detalle: $"Inicio de sesión exitoso para {usuario.Email}"
+            );
 
             return new RespuestaInicioSesionDTO
             {

--- a/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
+++ b/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
@@ -9,15 +9,18 @@ namespace PSA.AppCore.Managers
         private readonly UsuarioDAO _usuarioDAO;
         private readonly TokenRecuperacionDAO _tokenRecuperacionDAO;
         private readonly IServicioHashContrasena _servicioHash;
+        private readonly AuditoriaLogDAO _auditoriaLogDAO;
 
         public RecuperacionContrasenaManager(
             UsuarioDAO usuarioDAO,
             TokenRecuperacionDAO tokenRecuperacionDAO,
-            IServicioHashContrasena servicioHash)
+            IServicioHashContrasena servicioHash,
+            AuditoriaLogDAO auditoriaLogDAO)
         {
             _usuarioDAO = usuarioDAO;
             _tokenRecuperacionDAO = tokenRecuperacionDAO;
             _servicioHash = servicioHash;
+            _auditoriaLogDAO = auditoriaLogDAO;
         }
 
         public async Task<(string Token, string NombreUsuario)> GenerarTokenConNombreAsync(string email)
@@ -25,6 +28,14 @@ namespace PSA.AppCore.Managers
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(email);
             if (usuario == null)
             {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "TokensRecuperacion",
+                    accion: "TOKEN_RECUPERACION_FALLIDO",
+                    detalle: $"Solicitud de recuperación para correo inexistente: {email}"
+                );
+
                 throw new InvalidOperationException("No existe una cuenta asociada al correo indicado.");
             }
 
@@ -32,12 +43,34 @@ namespace PSA.AppCore.Managers
 
             var token = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
             await _tokenRecuperacionDAO.CrearTokenAsync(usuario.IdUsuario, token, DateTime.UtcNow.AddMinutes(3));
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "TokensRecuperacion",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "TOKEN_RECUPERACION_GENERADO",
+                detalle: "Se generó token de recuperación de contraseña."
+            );
+
             return (token, usuario.NombreCompleto);
         }
 
         public async Task<bool> TokenEsValidoAsync(string token)
         {
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: registro?.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "TokensRecuperacion",
+                idRegistroAfectado: registro?.IdToken,
+                accion: registro == null ? "TOKEN_RECUPERACION_INVALIDO" : "TOKEN_RECUPERACION_VALIDADO",
+                detalle: registro == null
+                    ? "Se intentó usar un token inválido o expirado."
+                    : "Se validó un token de recuperación."
+            );
+
             return registro != null;
         }
 
@@ -58,6 +91,14 @@ namespace PSA.AppCore.Managers
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
             if (registro == null)
             {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    accion: "CAMBIO_CONTRASENA_FALLIDO",
+                    detalle: "Se intentó restablecer contraseña con token inválido o expirado."
+                );
+
                 throw new InvalidOperationException("El token es inválido o expiró.");
             }
 
@@ -70,6 +111,15 @@ namespace PSA.AppCore.Managers
             var hash = _servicioHash.GenerarHash(nuevaContrasena);
             await _usuarioDAO.ActualizarPasswordHashPorEmailAsync(usuario.Email, hash);
             await _tokenRecuperacionDAO.MarcarTokenComoUsadoAsync(registro.IdToken);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "CAMBIO_CONTRASENA_EXITOSO",
+                detalle: "Se restableció la contraseña usando token de recuperación."
+            );
         }
     }
 }

--- a/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
+++ b/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
@@ -1,0 +1,68 @@
+using Microsoft.Data.SqlClient;
+
+namespace PSA.DataAccess.DAO
+{
+    public class AuditoriaLogDAO
+    {
+        private readonly string _connectionString;
+
+        public AuditoriaLogDAO(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public async Task RegistrarEventoAsync(
+            int? idUsuario,
+            string modulo,
+            string tablaAfectada,
+            string accion,
+            string? detalle = null,
+            int? idRegistroAfectado = null,
+            string? ipOrigen = null,
+            string? valorAnterior = null,
+            string? valorNuevo = null)
+        {
+            const string sql = @"
+INSERT INTO AuditoriaLog
+(
+    IdUsuario,
+    Modulo,
+    TablaAfectada,
+    IdRegistroAfectado,
+    Accion,
+    ValorAnterior,
+    ValorNuevo,
+    IpOrigen,
+    Detalle
+)
+VALUES
+(
+    @IdUsuario,
+    @Modulo,
+    @TablaAfectada,
+    @IdRegistroAfectado,
+    @Accion,
+    @ValorAnterior,
+    @ValorNuevo,
+    @IpOrigen,
+    @Detalle
+);";
+
+            using var connection = new SqlConnection(_connectionString);
+            using var command = new SqlCommand(sql, connection);
+
+            command.Parameters.AddWithValue("@IdUsuario", (object?)idUsuario ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Modulo", modulo);
+            command.Parameters.AddWithValue("@TablaAfectada", tablaAfectada);
+            command.Parameters.AddWithValue("@IdRegistroAfectado", (object?)idRegistroAfectado ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Accion", accion);
+            command.Parameters.AddWithValue("@ValorAnterior", (object?)valorAnterior ?? DBNull.Value);
+            command.Parameters.AddWithValue("@ValorNuevo", (object?)valorNuevo ?? DBNull.Value);
+            command.Parameters.AddWithValue("@IpOrigen", (object?)ipOrigen ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Detalle", (object?)detalle ?? DBNull.Value);
+
+            await connection.OpenAsync();
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -10,6 +10,7 @@
 
 	<ItemGroup>
 		<Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+		<Compile Include="DAO\AuditoriaLogDAO.cs" />
 		<Compile Include="DbContextHelper.cs" />
 		<Compile Include="DAO\FincaDAO.cs" />
 		<Compile Include="DAO\RecuperacionContrasenaDAO.cs" />

--- a/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
+++ b/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
@@ -7,4 +7,9 @@
 		<RootNamespace>PSA.EntidadesDTO</RootNamespace>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<!-- Evita compilación duplicada en entornos Windows con carpetas legacy acentuadas -->
+		<Compile Remove="bin\**\*.cs;obj\**\*.cs;DTOs\Auditoría\**\*.cs;DTOs\RecuperacionContraseña\**\*.cs;Entidades\Pagós\**\*.cs" />
+	</ItemGroup>
+
 </Project>

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -54,6 +54,32 @@ builder.Services.AddScoped<FincaDAO>(sp =>
     return new FincaDAO(connectionString);
 });
 
+builder.Services.AddScoped<AuditoriaLogDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection'.");
+    }
+
+    return new AuditoriaLogDAO(connectionString);
+});
+
+builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection'.");
+    }
+
+    return new TokenRecuperacionDAO(connectionString);
+});
+
 builder.Services.AddScoped<RecuperacionContrasenaDAO>(sp =>
 {
     var configuration = sp.GetRequiredService<IConfiguration>();

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -54,6 +54,19 @@ builder.Services.AddScoped<FincaDAO>(sp =>
     return new FincaDAO(connectionString);
 });
 
+builder.Services.AddScoped<AuditoriaLogDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection' en WebApp.");
+    }
+
+    return new AuditoriaLogDAO(connectionString);
+});
+
 builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>
 {
     var configuration = sp.GetRequiredService<IConfiguration>();


### PR DESCRIPTION
### Motivation
- Corregir errores de compilación en cascada (`CS0006`) porque el nuevo `AuditoriaLogDAO` no estaba incluido en el proyecto `PSA.DataAccess`. 
- Evitar tipos duplicados y ambigüedades (`CS0101`/`CS0229`) producidas por carpetas legacy con nombres acentuados que se siguen presentes en el árbol de fuentes. 
- Registrar eventos de trazabilidad de autenticación (logins, tokens y cambios de contraseña) de forma persistente usando la tabla `AuditoriaLog` ya existente.

### Description
- Se añadió la clase `PSA.DataAccess/DAO/AuditoriaLogDAO.cs` con `RegistrarEventoAsync(...)` para insertar registros en la tabla `AuditoriaLog`.
- Se incluyó explícitamente `DAO\AuditoriaLogDAO.cs` en `PSA.DataAccess/PSA.DataAccess.csproj` para que el ensamblado contenga el nuevo DAO cuando `EnableDefaultCompileItems` está en `false`.
- Se agregó una regla de exclusión en `PSA.EntidadesDTO/PSA.EntidadesDTO.csproj` (`<Compile Remove=...>`) para omitir carpetas legacy con acentos y `bin/obj` y así prevenir compilación duplicada de tipos.
- Se instrumentaron los managers de autenticación: `AutenticacionManager` y `RecuperacionContrasenaManager` para invocar a `AuditoriaLogDAO` y registrar los eventos esperados (`LOGIN_FALLIDO`, `LOGIN_EXITOSO`, `TOKEN_RECUPERACION_GENERADO`, `TOKEN_RECUPERACION_VALIDADO`/`INVALIDO`, `CAMBIO_CONTRASENA_EXITOSO`/`FALLIDO`).
- Se registró la dependencia `AuditoriaLogDAO` en los contenedores DI de `PSA.WebAPI/Program.cs` y `PSA.WebApp/Program.cs`.

### Testing
- Intenté ejecutar `dotnet build PSA.sln -v minimal`, pero la verificación automatizada falló porque el entorno no tiene instalado el SDK de .NET (`dotnet: command not found`).
- No se ejecutaron pruebas unitarias automatizadas en este entorno por la falta del SDK, por lo que la corrección se verificó mediante actualización de `.csproj` y revisión estática de archivos fuente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc718de658832dbb2b19816285c3ae)