### PR TITLE
Add auditing for authentication and password recovery and register AuditoriaLogDAO

### DIFF
--- a/PSA.AppCore/Managers/AutenticacionManager.cs
+++ b/PSA.AppCore/Managers/AutenticacionManager.cs
@@ -9,13 +9,16 @@ namespace PSA.AppCore.Managers
     {
         private readonly IServicioHashContrasena _servicioHashContrasena;
         private readonly UsuarioDAO _usuarioDAO;
+        private readonly AuditoriaLogDAO _auditoriaLogDAO;
 
         public AutenticacionManager(
             IServicioHashContrasena servicioHashContrasena,
-            UsuarioDAO usuarioDAO)
+            UsuarioDAO usuarioDAO,
+            AuditoriaLogDAO auditoriaLogDAO)
         {
             _servicioHashContrasena = servicioHashContrasena;
             _usuarioDAO = usuarioDAO;
+            _auditoriaLogDAO = auditoriaLogDAO;
         }
 
         public async Task<int> RegistrarUsuarioAsync(RegistrarUsuarioDTO dto)
@@ -68,7 +71,17 @@ namespace PSA.AppCore.Managers
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(dto.Email.Trim());
 
             if (usuario == null)
+            {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    accion: "LOGIN_FALLIDO",
+                    detalle: $"Intento fallido para correo no registrado: {dto.Email.Trim()}"
+                );
+
                 throw new Exception("Credenciales inválidas.");
+            }
 
             var contrasenaValida = _servicioHashContrasena.VerificarHash(
                 usuario.PasswordHash,
@@ -76,10 +89,30 @@ namespace PSA.AppCore.Managers
             );
 
             if (!contrasenaValida)
+            {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: usuario.IdUsuario,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    idRegistroAfectado: usuario.IdUsuario,
+                    accion: "LOGIN_FALLIDO",
+                    detalle: $"Contraseña inválida para el usuario {usuario.Email}"
+                );
+
                 throw new Exception("Credenciales inválidas.");
+            }
 
             var fechaAcceso = DateTime.Now;
             await _usuarioDAO.ActualizarUltimoAccesoAsync(usuario.IdUsuario, fechaAcceso);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "LOGIN_EXITOSO",
+                detalle: $"Inicio de sesión exitoso para {usuario.Email}"
+            );
 
             return new RespuestaInicioSesionDTO
             {

--- a/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
+++ b/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
@@ -9,15 +9,18 @@ namespace PSA.AppCore.Managers
         private readonly UsuarioDAO _usuarioDAO;
         private readonly TokenRecuperacionDAO _tokenRecuperacionDAO;
         private readonly IServicioHashContrasena _servicioHash;
+        private readonly AuditoriaLogDAO _auditoriaLogDAO;
 
         public RecuperacionContrasenaManager(
             UsuarioDAO usuarioDAO,
             TokenRecuperacionDAO tokenRecuperacionDAO,
-            IServicioHashContrasena servicioHash)
+            IServicioHashContrasena servicioHash,
+            AuditoriaLogDAO auditoriaLogDAO)
         {
             _usuarioDAO = usuarioDAO;
             _tokenRecuperacionDAO = tokenRecuperacionDAO;
             _servicioHash = servicioHash;
+            _auditoriaLogDAO = auditoriaLogDAO;
         }
 
         public async Task<(string Token, string NombreUsuario)> GenerarTokenConNombreAsync(string email)
@@ -25,6 +28,14 @@ namespace PSA.AppCore.Managers
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(email);
             if (usuario == null)
             {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "TokensRecuperacion",
+                    accion: "TOKEN_RECUPERACION_FALLIDO",
+                    detalle: $"Solicitud de recuperación para correo inexistente: {email}"
+                );
+
                 throw new InvalidOperationException("No existe una cuenta asociada al correo indicado.");
             }
 
@@ -32,12 +43,34 @@ namespace PSA.AppCore.Managers
 
             var token = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
             await _tokenRecuperacionDAO.CrearTokenAsync(usuario.IdUsuario, token, DateTime.UtcNow.AddMinutes(3));
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "TokensRecuperacion",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "TOKEN_RECUPERACION_GENERADO",
+                detalle: "Se generó token de recuperación de contraseña."
+            );
+
             return (token, usuario.NombreCompleto);
         }
 
         public async Task<bool> TokenEsValidoAsync(string token)
         {
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: registro?.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "TokensRecuperacion",
+                idRegistroAfectado: registro?.IdToken,
+                accion: registro == null ? "TOKEN_RECUPERACION_INVALIDO" : "TOKEN_RECUPERACION_VALIDADO",
+                detalle: registro == null
+                    ? "Se intentó usar un token inválido o expirado."
+                    : "Se validó un token de recuperación."
+            );
+
             return registro != null;
         }
 
@@ -58,6 +91,14 @@ namespace PSA.AppCore.Managers
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
             if (registro == null)
             {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    accion: "CAMBIO_CONTRASENA_FALLIDO",
+                    detalle: "Se intentó restablecer contraseña con token inválido o expirado."
+                );
+
                 throw new InvalidOperationException("El token es inválido o expiró.");
             }
 
@@ -70,6 +111,15 @@ namespace PSA.AppCore.Managers
             var hash = _servicioHash.GenerarHash(nuevaContrasena);
             await _usuarioDAO.ActualizarPasswordHashPorEmailAsync(usuario.Email, hash);
             await _tokenRecuperacionDAO.MarcarTokenComoUsadoAsync(registro.IdToken);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "CAMBIO_CONTRASENA_EXITOSO",
+                detalle: "Se restableció la contraseña usando token de recuperación."
+            );
         }
     }
 }

--- a/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
+++ b/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
@@ -1,0 +1,68 @@
+using Microsoft.Data.SqlClient;
+
+namespace PSA.DataAccess.DAO
+{
+    public class AuditoriaLogDAO
+    {
+        private readonly string _connectionString;
+
+        public AuditoriaLogDAO(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public async Task RegistrarEventoAsync(
+            int? idUsuario,
+            string modulo,
+            string tablaAfectada,
+            string accion,
+            string? detalle = null,
+            int? idRegistroAfectado = null,
+            string? ipOrigen = null,
+            string? valorAnterior = null,
+            string? valorNuevo = null)
+        {
+            const string sql = @"
+INSERT INTO AuditoriaLog
+(
+    IdUsuario,
+    Modulo,
+    TablaAfectada,
+    IdRegistroAfectado,
+    Accion,
+    ValorAnterior,
+    ValorNuevo,
+    IpOrigen,
+    Detalle
+)
+VALUES
+(
+    @IdUsuario,
+    @Modulo,
+    @TablaAfectada,
+    @IdRegistroAfectado,
+    @Accion,
+    @ValorAnterior,
+    @ValorNuevo,
+    @IpOrigen,
+    @Detalle
+);";
+
+            using var connection = new SqlConnection(_connectionString);
+            using var command = new SqlCommand(sql, connection);
+
+            command.Parameters.AddWithValue("@IdUsuario", (object?)idUsuario ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Modulo", modulo);
+            command.Parameters.AddWithValue("@TablaAfectada", tablaAfectada);
+            command.Parameters.AddWithValue("@IdRegistroAfectado", (object?)idRegistroAfectado ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Accion", accion);
+            command.Parameters.AddWithValue("@ValorAnterior", (object?)valorAnterior ?? DBNull.Value);
+            command.Parameters.AddWithValue("@ValorNuevo", (object?)valorNuevo ?? DBNull.Value);
+            command.Parameters.AddWithValue("@IpOrigen", (object?)ipOrigen ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Detalle", (object?)detalle ?? DBNull.Value);
+
+            await connection.OpenAsync();
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -10,6 +10,7 @@
 
 	<ItemGroup>
 		<Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+		<Compile Include="DAO\AuditoriaLogDAO.cs" />
 		<Compile Include="DbContextHelper.cs" />
 		<Compile Include="DAO\FincaDAO.cs" />
 		<Compile Include="DAO\RecuperacionContrasenaDAO.cs" />

--- a/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
+++ b/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
@@ -1,10 +1,62 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<RootNamespace>PSA.EntidadesDTO</RootNamespace>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>PSA.EntidadesDTO</RootNamespace>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+    <Compile Include="Base\BaseEntity.cs" />
+    <Compile Include="Base\IAuditable.cs" />
+    <Compile Include="Base\IBaseEntity.cs" />
+    <Compile Include="DTOs\Auditoria\AuditoriaLogDTO.cs" />
+    <Compile Include="DTOs\Dashboard\ResumenDashboardAdministradorDTO.cs" />
+    <Compile Include="DTOs\Evaluaciones\EvaluacionEvidenciaDTO.cs" />
+    <Compile Include="DTOs\Evaluaciones\EvaluacionTecnicaDTO.cs" />
+    <Compile Include="DTOs\FincaDetalleDTO.cs" />
+    <Compile Include="DTOs\FincaResumenDTO.cs" />
+    <Compile Include="DTOs\Fincas\FincaDTO.cs" />
+    <Compile Include="DTOs\Fincas\FincaEvidenciaDTO.cs" />
+    <Compile Include="DTOs\InicioSesionDTO.cs" />
+    <Compile Include="DTOs\Notificaciones\NotificacionDTO.cs" />
+    <Compile Include="DTOs\Pagos\ConfiguracionPagoDTO.cs" />
+    <Compile Include="DTOs\Pagos\CuentaBancariaDTO.cs" />
+    <Compile Include="DTOs\Pagos\CuotaPagoDTO.cs" />
+    <Compile Include="DTOs\Pagos\DetalleConfiguracionPagoDTO.cs" />
+    <Compile Include="DTOs\Pagos\PlanPagoDTO.cs" />
+    <Compile Include="DTOs\RecuperacionContrasena\RespuestaRecuperacionDTO.cs" />
+    <Compile Include="DTOs\RecuperacionContrasena\SmtpSettingsDTO.cs" />
+    <Compile Include="DTOs\RecuperacionContrasena\ValidarTokenDTO.cs" />
+    <Compile Include="DTOs\RecuperarContrasenaDTO.cs" />
+    <Compile Include="DTOs\RegistrarFincaDTO.cs" />
+    <Compile Include="DTOs\RegistrarUsuarioDTO.cs" />
+    <Compile Include="DTOs\RespuestaInicioSesionDTO.cs" />
+    <Compile Include="DTOs\RestablecerContrasenaDTO.cs" />
+    <Compile Include="DTOs\Usuarios\RolDTO.cs" />
+    <Compile Include="DTOs\Usuarios\TokenRecuperacionDTO.cs" />
+    <Compile Include="DTOs\Usuarios\UsuarioDTO.cs" />
+    <Compile Include="DTOs\ValidarTokenRecuperacionDTO.cs" />
+    <Compile Include="Entidades\Auditoria\AuditoriaLog.cs" />
+    <Compile Include="Entidades\Evaluaciones\EvaluacionEvidencia.cs" />
+    <Compile Include="Entidades\Evaluaciones\EvaluacionTecnica.cs" />
+    <Compile Include="Entidades\Fincas\Finca.cs" />
+    <Compile Include="Entidades\Fincas\FincaEvidencia.cs" />
+    <Compile Include="Entidades\Notificaciones\Notificacion.cs" />
+    <Compile Include="Entidades\Pagos\ConfiguracionPago.cs" />
+    <Compile Include="Entidades\Pagos\CuentaBancaria.cs" />
+    <Compile Include="Entidades\Pagos\CuotaPago.cs" />
+    <Compile Include="Entidades\Pagos\DetalleConfiguracionPago.cs" />
+    <Compile Include="Entidades\Pagos\PlanPago.cs" />
+    <Compile Include="Entidades\Rol.cs" />
+    <Compile Include="Entidades\TokenRecuperacion.cs" />
+    <Compile Include="Entidades\Usuario.cs" />
+    <Compile Include="Entidades\Usuarios\Rol.cs" />
+    <Compile Include="Entidades\Usuarios\TokenRecuperacion.cs" />
+    <Compile Include="Entidades\Usuarios\Usuario.cs" />
+  </ItemGroup>
 
 </Project>

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -54,6 +54,32 @@ builder.Services.AddScoped<FincaDAO>(sp =>
     return new FincaDAO(connectionString);
 });
 
+builder.Services.AddScoped<AuditoriaLogDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection'.");
+    }
+
+    return new AuditoriaLogDAO(connectionString);
+});
+
+builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection'.");
+    }
+
+    return new TokenRecuperacionDAO(connectionString);
+});
+
 builder.Services.AddScoped<RecuperacionContrasenaDAO>(sp =>
 {
     var configuration = sp.GetRequiredService<IConfiguration>();

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -54,6 +54,19 @@ builder.Services.AddScoped<FincaDAO>(sp =>
     return new FincaDAO(connectionString);
 });
 
+builder.Services.AddScoped<AuditoriaLogDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection' en WebApp.");
+    }
+
+    return new AuditoriaLogDAO(connectionString);
+});
+
 builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>
 {
     var configuration = sp.GetRequiredService<IConfiguration>();


### PR DESCRIPTION
### Motivation
- Add structured auditing for authentication and password recovery flows to record login successes/failures, token events, and password resets.
- Persist audit events to the database through a dedicated DAO and expose it via dependency injection so managers can log actions.

### Description
- Introduced `AuditoriaLogDAO` with `RegistrarEventoAsync(...)` to insert audit records into the `AuditoriaLog` table. 
- Injected `AuditoriaLogDAO` into `AutenticacionManager` and `RecuperacionContrasenaManager` and added audit calls for login failures, invalid password attempts, successful logins, token generation, token validation/invalid attempts, and successful/failed password resets using `RegistrarEventoAsync`.
- Registered `AuditoriaLogDAO` in DI for both `PSA.WebAPI` and `PSA.WebApp` `Program.cs` and added the new DAO to `PSA.DataAccess.csproj` compile items.
- Updated `PSA.EntidadesDTO.csproj` to explicitly include DTOs and entities (including audit DTO/entity files) and to disable default compile items for deterministic project contents.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc718de658832dbb2b19816285c3ae)