### PR TITLE
Add auditing for authentication and recovery; improve finca map UX and consolidate project files

### DIFF
--- a/PSA.AppCore/Managers/AutenticacionManager.cs
+++ b/PSA.AppCore/Managers/AutenticacionManager.cs
@@ -9,13 +9,16 @@ namespace PSA.AppCore.Managers
     {
         private readonly IServicioHashContrasena _servicioHashContrasena;
         private readonly UsuarioDAO _usuarioDAO;
+        private readonly AuditoriaLogDAO _auditoriaLogDAO;
 
         public AutenticacionManager(
             IServicioHashContrasena servicioHashContrasena,
-            UsuarioDAO usuarioDAO)
+            UsuarioDAO usuarioDAO,
+            AuditoriaLogDAO auditoriaLogDAO)
         {
             _servicioHashContrasena = servicioHashContrasena;
             _usuarioDAO = usuarioDAO;
+            _auditoriaLogDAO = auditoriaLogDAO;
         }
 
         public async Task<int> RegistrarUsuarioAsync(RegistrarUsuarioDTO dto)
@@ -68,7 +71,17 @@ namespace PSA.AppCore.Managers
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(dto.Email.Trim());
 
             if (usuario == null)
+            {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    accion: "LOGIN_FALLIDO",
+                    detalle: $"Intento fallido para correo no registrado: {dto.Email.Trim()}"
+                );
+
                 throw new Exception("Credenciales inválidas.");
+            }
 
             var contrasenaValida = _servicioHashContrasena.VerificarHash(
                 usuario.PasswordHash,
@@ -76,10 +89,30 @@ namespace PSA.AppCore.Managers
             );
 
             if (!contrasenaValida)
+            {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: usuario.IdUsuario,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    idRegistroAfectado: usuario.IdUsuario,
+                    accion: "LOGIN_FALLIDO",
+                    detalle: $"Contraseña inválida para el usuario {usuario.Email}"
+                );
+
                 throw new Exception("Credenciales inválidas.");
+            }
 
             var fechaAcceso = DateTime.Now;
             await _usuarioDAO.ActualizarUltimoAccesoAsync(usuario.IdUsuario, fechaAcceso);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "LOGIN_EXITOSO",
+                detalle: $"Inicio de sesión exitoso para {usuario.Email}"
+            );
 
             return new RespuestaInicioSesionDTO
             {

--- a/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
+++ b/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
@@ -9,15 +9,18 @@ namespace PSA.AppCore.Managers
         private readonly UsuarioDAO _usuarioDAO;
         private readonly TokenRecuperacionDAO _tokenRecuperacionDAO;
         private readonly IServicioHashContrasena _servicioHash;
+        private readonly AuditoriaLogDAO _auditoriaLogDAO;
 
         public RecuperacionContrasenaManager(
             UsuarioDAO usuarioDAO,
             TokenRecuperacionDAO tokenRecuperacionDAO,
-            IServicioHashContrasena servicioHash)
+            IServicioHashContrasena servicioHash,
+            AuditoriaLogDAO auditoriaLogDAO)
         {
             _usuarioDAO = usuarioDAO;
             _tokenRecuperacionDAO = tokenRecuperacionDAO;
             _servicioHash = servicioHash;
+            _auditoriaLogDAO = auditoriaLogDAO;
         }
 
         public async Task<(string Token, string NombreUsuario)> GenerarTokenConNombreAsync(string email)
@@ -25,6 +28,14 @@ namespace PSA.AppCore.Managers
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(email);
             if (usuario == null)
             {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "TokensRecuperacion",
+                    accion: "TOKEN_RECUPERACION_FALLIDO",
+                    detalle: $"Solicitud de recuperación para correo inexistente: {email}"
+                );
+
                 throw new InvalidOperationException("No existe una cuenta asociada al correo indicado.");
             }
 
@@ -32,12 +43,34 @@ namespace PSA.AppCore.Managers
 
             var token = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
             await _tokenRecuperacionDAO.CrearTokenAsync(usuario.IdUsuario, token, DateTime.UtcNow.AddMinutes(3));
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "TokensRecuperacion",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "TOKEN_RECUPERACION_GENERADO",
+                detalle: "Se generó token de recuperación de contraseña."
+            );
+
             return (token, usuario.NombreCompleto);
         }
 
         public async Task<bool> TokenEsValidoAsync(string token)
         {
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: registro?.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "TokensRecuperacion",
+                idRegistroAfectado: registro?.IdToken,
+                accion: registro == null ? "TOKEN_RECUPERACION_INVALIDO" : "TOKEN_RECUPERACION_VALIDADO",
+                detalle: registro == null
+                    ? "Se intentó usar un token inválido o expirado."
+                    : "Se validó un token de recuperación."
+            );
+
             return registro != null;
         }
 
@@ -58,6 +91,14 @@ namespace PSA.AppCore.Managers
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
             if (registro == null)
             {
+                await _auditoriaLogDAO.RegistrarEventoAsync(
+                    idUsuario: null,
+                    modulo: "Autenticacion",
+                    tablaAfectada: "Usuarios",
+                    accion: "CAMBIO_CONTRASENA_FALLIDO",
+                    detalle: "Se intentó restablecer contraseña con token inválido o expirado."
+                );
+
                 throw new InvalidOperationException("El token es inválido o expiró.");
             }
 
@@ -70,6 +111,15 @@ namespace PSA.AppCore.Managers
             var hash = _servicioHash.GenerarHash(nuevaContrasena);
             await _usuarioDAO.ActualizarPasswordHashPorEmailAsync(usuario.Email, hash);
             await _tokenRecuperacionDAO.MarcarTokenComoUsadoAsync(registro.IdToken);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: usuario.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: usuario.IdUsuario,
+                accion: "CAMBIO_CONTRASENA_EXITOSO",
+                detalle: "Se restableció la contraseña usando token de recuperación."
+            );
         }
     }
 }

--- a/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
+++ b/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
@@ -1,0 +1,68 @@
+using Microsoft.Data.SqlClient;
+
+namespace PSA.DataAccess.DAO
+{
+    public class AuditoriaLogDAO
+    {
+        private readonly string _connectionString;
+
+        public AuditoriaLogDAO(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public async Task RegistrarEventoAsync(
+            int? idUsuario,
+            string modulo,
+            string tablaAfectada,
+            string accion,
+            string? detalle = null,
+            int? idRegistroAfectado = null,
+            string? ipOrigen = null,
+            string? valorAnterior = null,
+            string? valorNuevo = null)
+        {
+            const string sql = @"
+INSERT INTO AuditoriaLog
+(
+    IdUsuario,
+    Modulo,
+    TablaAfectada,
+    IdRegistroAfectado,
+    Accion,
+    ValorAnterior,
+    ValorNuevo,
+    IpOrigen,
+    Detalle
+)
+VALUES
+(
+    @IdUsuario,
+    @Modulo,
+    @TablaAfectada,
+    @IdRegistroAfectado,
+    @Accion,
+    @ValorAnterior,
+    @ValorNuevo,
+    @IpOrigen,
+    @Detalle
+);";
+
+            using var connection = new SqlConnection(_connectionString);
+            using var command = new SqlCommand(sql, connection);
+
+            command.Parameters.AddWithValue("@IdUsuario", (object?)idUsuario ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Modulo", modulo);
+            command.Parameters.AddWithValue("@TablaAfectada", tablaAfectada);
+            command.Parameters.AddWithValue("@IdRegistroAfectado", (object?)idRegistroAfectado ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Accion", accion);
+            command.Parameters.AddWithValue("@ValorAnterior", (object?)valorAnterior ?? DBNull.Value);
+            command.Parameters.AddWithValue("@ValorNuevo", (object?)valorNuevo ?? DBNull.Value);
+            command.Parameters.AddWithValue("@IpOrigen", (object?)ipOrigen ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Detalle", (object?)detalle ?? DBNull.Value);
+
+            await connection.OpenAsync();
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -10,6 +10,7 @@
 
 	<ItemGroup>
 		<Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+		<Compile Include="DAO\AuditoriaLogDAO.cs" />
 		<Compile Include="DbContextHelper.cs" />
 		<Compile Include="DAO\FincaDAO.cs" />
 		<Compile Include="DAO\RecuperacionContrasenaDAO.cs" />

--- a/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
+++ b/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
@@ -1,10 +1,62 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<RootNamespace>PSA.EntidadesDTO</RootNamespace>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>PSA.EntidadesDTO</RootNamespace>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+    <Compile Include="Base\BaseEntity.cs" />
+    <Compile Include="Base\IAuditable.cs" />
+    <Compile Include="Base\IBaseEntity.cs" />
+    <Compile Include="DTOs\Auditoria\AuditoriaLogDTO.cs" />
+    <Compile Include="DTOs\Dashboard\ResumenDashboardAdministradorDTO.cs" />
+    <Compile Include="DTOs\Evaluaciones\EvaluacionEvidenciaDTO.cs" />
+    <Compile Include="DTOs\Evaluaciones\EvaluacionTecnicaDTO.cs" />
+    <Compile Include="DTOs\FincaDetalleDTO.cs" />
+    <Compile Include="DTOs\FincaResumenDTO.cs" />
+    <Compile Include="DTOs\Fincas\FincaDTO.cs" />
+    <Compile Include="DTOs\Fincas\FincaEvidenciaDTO.cs" />
+    <Compile Include="DTOs\InicioSesionDTO.cs" />
+    <Compile Include="DTOs\Notificaciones\NotificacionDTO.cs" />
+    <Compile Include="DTOs\Pagos\ConfiguracionPagoDTO.cs" />
+    <Compile Include="DTOs\Pagos\CuentaBancariaDTO.cs" />
+    <Compile Include="DTOs\Pagos\CuotaPagoDTO.cs" />
+    <Compile Include="DTOs\Pagos\DetalleConfiguracionPagoDTO.cs" />
+    <Compile Include="DTOs\Pagos\PlanPagoDTO.cs" />
+    <Compile Include="DTOs\RecuperacionContrasena\RespuestaRecuperacionDTO.cs" />
+    <Compile Include="DTOs\RecuperacionContrasena\SmtpSettingsDTO.cs" />
+    <Compile Include="DTOs\RecuperacionContrasena\ValidarTokenDTO.cs" />
+    <Compile Include="DTOs\RecuperarContrasenaDTO.cs" />
+    <Compile Include="DTOs\RegistrarFincaDTO.cs" />
+    <Compile Include="DTOs\RegistrarUsuarioDTO.cs" />
+    <Compile Include="DTOs\RespuestaInicioSesionDTO.cs" />
+    <Compile Include="DTOs\RestablecerContrasenaDTO.cs" />
+    <Compile Include="DTOs\Usuarios\RolDTO.cs" />
+    <Compile Include="DTOs\Usuarios\TokenRecuperacionDTO.cs" />
+    <Compile Include="DTOs\Usuarios\UsuarioDTO.cs" />
+    <Compile Include="DTOs\ValidarTokenRecuperacionDTO.cs" />
+    <Compile Include="Entidades\Auditoria\AuditoriaLog.cs" />
+    <Compile Include="Entidades\Evaluaciones\EvaluacionEvidencia.cs" />
+    <Compile Include="Entidades\Evaluaciones\EvaluacionTecnica.cs" />
+    <Compile Include="Entidades\Fincas\Finca.cs" />
+    <Compile Include="Entidades\Fincas\FincaEvidencia.cs" />
+    <Compile Include="Entidades\Notificaciones\Notificacion.cs" />
+    <Compile Include="Entidades\Pagos\ConfiguracionPago.cs" />
+    <Compile Include="Entidades\Pagos\CuentaBancaria.cs" />
+    <Compile Include="Entidades\Pagos\CuotaPago.cs" />
+    <Compile Include="Entidades\Pagos\DetalleConfiguracionPago.cs" />
+    <Compile Include="Entidades\Pagos\PlanPago.cs" />
+    <Compile Include="Entidades\Rol.cs" />
+    <Compile Include="Entidades\TokenRecuperacion.cs" />
+    <Compile Include="Entidades\Usuario.cs" />
+    <Compile Include="Entidades\Usuarios\Rol.cs" />
+    <Compile Include="Entidades\Usuarios\TokenRecuperacion.cs" />
+    <Compile Include="Entidades\Usuarios\Usuario.cs" />
+  </ItemGroup>
 
 </Project>

--- a/PSA.WebAPI/Controllers/AutenticacionController.cs
+++ b/PSA.WebAPI/Controllers/AutenticacionController.cs
@@ -92,34 +92,13 @@ namespace PSA.WebAPI.Controllers
                 }
 
                 var urlLogin = $"{Request.Scheme}://{Request.Host}/Autenticacion/IniciarSesion";
-                var correoSoporte = _configuration["SmtpSettings:SupportEmail"] ?? "soporte@psacostarica.cr";
-                var fechaRegistro = DateTime.Now.ToString("dd/MM/yyyy HH:mm");
                 var nombreUsuario = string.IsNullOrWhiteSpace(dto.NombreCompleto) ? "usuario" : dto.NombreCompleto.Trim();
 
-                var cuerpo = $@"Hola {nombreUsuario},
-
-Tu registro en PSA Costa Rica se completó de manera exitosa el {fechaRegistro}.
-
-Ya puedes ingresar al sistema mediante el siguiente enlace:
-{urlLogin}
-
-Te recomendamos conservar este correo como comprobante de tu registro.
-
-Si no reconoces esta acción o consideras que el registro fue realizado por error, por favor contacta al equipo de soporte:
-{correoSoporte}
-
-Gracias por formar parte de PSA Costa Rica.
-
-Saludos,
-Equipo PSA Costa Rica
-
-Este es un correo automático. Por favor, no respondas a este mensaje.";
-
                 var correoService = new CorreoService(smtp);
-                correoService.EnviarCorreoTextoPlano(
+                correoService.EnviarCorreoRecuperacion(
                     dto.Email.Trim(),
-                    "Bienvenido(a) a PSA Costa Rica",
-                    cuerpo
+                    nombreUsuario,
+                    urlLogin
                 );
             }
             catch

--- a/PSA.WebAPI/Controllers/FincaController.cs
+++ b/PSA.WebAPI/Controllers/FincaController.cs
@@ -15,6 +15,7 @@ namespace PSA.WebAPI.Controllers
             _fincaService = fincaService;
         }
 
+        [HttpGet("ObtenerTodos")]
         [HttpGet("RetrieveAll")]
         public IActionResult RetrieveAll()
         {
@@ -33,6 +34,7 @@ namespace PSA.WebAPI.Controllers
             }
         }
 
+        [HttpGet("ObtenerPorId/{id}")]
         [HttpGet("RetrieveById/{id}")]
         public IActionResult RetrieveById(int id)
         {
@@ -68,6 +70,7 @@ namespace PSA.WebAPI.Controllers
             }
         }
 
+        [HttpPost("Crear")]
         [HttpPost("Create")]
         public IActionResult Create([FromBody] FincaDTO finca)
         {
@@ -114,6 +117,7 @@ namespace PSA.WebAPI.Controllers
             }
         }
 
+        [HttpPut("Actualizar")]
         [HttpPut("Update")]
         public IActionResult Update([FromBody] FincaDTO finca)
         {
@@ -168,6 +172,7 @@ namespace PSA.WebAPI.Controllers
             }
         }
 
+        [HttpDelete("Eliminar/{id}")]
         [HttpDelete("Delete/{id}")]
         public IActionResult Delete(int id)
         {

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -1,17 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<RootNamespace>PSA.WebAPI</RootNamespace>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>PSA.WebAPI</RootNamespace>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\PSA.AppCore\PSA.AppCore.csproj" />
-		<ProjectReference Include="..\PSA.DataAccess\PSA.DataAccess.csproj" />
-		<ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+    <Compile Include="Controllers\AutenticacionController.cs" />
+    <Compile Include="Controllers\BaseApiController.cs" />
+    <Compile Include="Controllers\DashboardController.cs" />
+    <Compile Include="Controllers\FincaController.cs" />
+    <Compile Include="Controllers\FincasController.cs" />
+    <Compile Include="Controllers\HealthController.cs" />
+    <Compile Include="Controllers\Middleware\ExceptionMiddleware.cs" />
+    <Compile Include="Controllers\Models\ApiResponse.cs" />
+    <Compile Include="Controllers\RecuperacionContrasenaController.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Services\CorreoService.cs" />
+    <ProjectReference Include="..\PSA.AppCore\PSA.AppCore.csproj" />
+    <ProjectReference Include="..\PSA.DataAccess\PSA.DataAccess.csproj" />
+    <ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -54,6 +54,32 @@ builder.Services.AddScoped<FincaDAO>(sp =>
     return new FincaDAO(connectionString);
 });
 
+builder.Services.AddScoped<AuditoriaLogDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection'.");
+    }
+
+    return new AuditoriaLogDAO(connectionString);
+});
+
+builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection'.");
+    }
+
+    return new TokenRecuperacionDAO(connectionString);
+});
+
 builder.Services.AddScoped<RecuperacionContrasenaDAO>(sp =>
 {
     var configuration = sp.GetRequiredService<IConfiguration>();

--- a/PSA.WebApp/EMAIL_SETUP.md
+++ b/PSA.WebApp/EMAIL_SETUP.md
@@ -5,12 +5,12 @@ Para que el correo de recuperación funcione en local, configure credenciales po
 - `PSA_EMAIL_SMTP_HOST` (ej. `smtp.us1.unione.io`)
 - `PSA_EMAIL_SMTP_PORT` (ej. `587`)
 - `PSA_EMAIL_SMTP_USERNAME` (ej. `7133848`)
-- `PSA_EMAIL_SMTP_PASSWORD` (password SMTP) **o** `PSA_EMAIL_API_KEY`
+- `PSA_EMAIL_SMTP_PASSWORD` (contraseña SMTP) **o** `PSA_EMAIL_API_KEY`
 - `PSA_EMAIL_FROM` (ej. `do-not-reply@sandbox-7133848-7db346.unionemailer.com`)
-- `PSA_EMAIL_FROM_NAME` (ej. `PSA Costa Rica - Do Not Reply`)
+- `PSA_EMAIL_FROM_NAME` (ej. `PSA Costa Rica - No responder`)
 - `PSA_EMAIL_ENABLE_SSL` (`true`)
 
 Opcional:
 - `PSA_EMAIL_SENDER_DOMAIN` para construir remitente `do-not-reply@<dominio>` si no define `PSA_EMAIL_FROM`.
 
-> No suba secretos reales al repositorio. Use `appsettings.Development.json`, User Secrets o variables de entorno.
+> No suba secretos reales al repositorio. Use `appsettings.Development.json`, Secretos de usuario o variables de entorno.

--- a/PSA.WebApp/PSA.WebApp.csproj
+++ b/PSA.WebApp/PSA.WebApp.csproj
@@ -5,12 +5,38 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>PSA.WebApp</RootNamespace>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+    <Compile Include="Controllers\AdministracionController.cs" />
+    <Compile Include="Controllers\AutenticacionController.cs" />
+    <Compile Include="Controllers\AuthController.cs" />
+    <Compile Include="Controllers\DashboardController.cs" />
+    <Compile Include="Controllers\EvaluacionesController.cs" />
+    <Compile Include="Controllers\FincasController.cs" />
+    <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Controllers\NotificacionesController.cs" />
+    <Compile Include="Controllers\PagosController.cs" />
+    <Compile Include="Controllers\ReportesController.cs" />
+    <Compile Include="Models\RecuperarContrasenaViewModel.cs" />
+    <Compile Include="Models\RestablecerContrasenaViewModel.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Servicios\IServicioCorreo.cs" />
+    <Compile Include="Servicios\ServicioCorreoSmtp.cs" />
     <ProjectReference Include="..\PSA.AppCore\PSA.AppCore.csproj" />
     <ProjectReference Include="..\PSA.DataAccess\PSA.DataAccess.csproj" />
     <ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Remove="Pages\**\*.cshtml" />
+    <Content Remove="Pages\**\*.cshtml.css" />
+    <None Remove="Pages\**\*.cshtml" />
+    <None Remove="Pages\**\*.cshtml.css" />
+    <RazorGenerate Remove="Pages\**\*.cshtml" />
+    <ScopedCssInput Remove="Pages\**\*.cshtml.css" />
   </ItemGroup>
 
 </Project>

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -6,7 +6,11 @@ using PSA.WebApp.Servicios;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllersWithViews();
+builder.Services.AddControllersWithViews(options =>
+{
+    options.ModelBindingMessageProvider.SetValueMustNotBeNullAccessor(_ => "Este campo es obligatorio.");
+    options.ModelBindingMessageProvider.SetMissingBindRequiredValueAccessor(_ => "Este campo es obligatorio.");
+});
 builder.Services.AddHttpClient();
 
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
@@ -52,6 +56,19 @@ builder.Services.AddScoped<FincaDAO>(sp =>
     }
 
     return new FincaDAO(connectionString);
+});
+
+builder.Services.AddScoped<AuditoriaLogDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection' en WebApp.");
+    }
+
+    return new AuditoriaLogDAO(connectionString);
 });
 
 builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>

--- a/PSA.WebApp/Views/Auth/Login.cshtml
+++ b/PSA.WebApp/Views/Auth/Login.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    ViewData["Title"] = "Login";
+    ViewData["Title"] = "Iniciar sesión";
 }
 
 <h2>Iniciar Sesión</h2>

--- a/PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml
+++ b/PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml
@@ -28,9 +28,7 @@
                 </div>
                 <div class="campo-formulario">
                     <label asp-for="Provincia"></label>
-                    <select asp-for="Provincia" id="provinciaSelect" required data-valor-actual="@Model.Provincia">
-                        <option value="">Seleccione una provincia</option>
-                    </select>
+                    <input asp-for="Provincia" id="provinciaInput" required readonly placeholder="Se completa al elegir un punto en el mapa" />
                     <span asp-validation-for="Provincia" class="text-danger"></span>
                 </div>
             </div>
@@ -38,16 +36,12 @@
             <div class="grid-dos-columnas">
                 <div class="campo-formulario">
                     <label asp-for="Canton"></label>
-                    <select asp-for="Canton" id="cantonSelect" required disabled data-valor-actual="@Model.Canton">
-                        <option value="">Seleccione primero una provincia</option>
-                    </select>
+                    <input asp-for="Canton" id="cantonInput" required readonly placeholder="Se completa al elegir un punto en el mapa" />
                     <span asp-validation-for="Canton" class="text-danger"></span>
                 </div>
                 <div class="campo-formulario">
                     <label asp-for="Distrito"></label>
-                    <select asp-for="Distrito" id="distritoSelect" required disabled data-valor-actual="@Model.Distrito">
-                        <option value="">Seleccione primero un cantón</option>
-                    </select>
+                    <input asp-for="Distrito" id="distritoInput" required readonly placeholder="Se completa al elegir un punto en el mapa" />
                     <span asp-validation-for="Distrito" class="text-danger"></span>
                 </div>
             </div>
@@ -81,7 +75,7 @@
 
             <div class="campo-formulario">
                 <label for="mapaUbicacionFinca">Ubicación en mapa</label>
-                <p class="texto-ayuda">Seleccione provincia, cantón y distrito. Luego haga clic en el mapa para colocar el pin y completar latitud/longitud automáticamente.</p>
+                <p class="texto-ayuda">Haga clic en el mapa para colocar el pin. El sistema completará automáticamente provincia, cantón, distrito, latitud y longitud.</p>
                 <div id="mapaUbicacionFinca" class="mapa-ubicacion-finca" aria-label="Mapa de ubicación de finca"></div>
             </div>
 

--- a/PSA.WebApp/Views/Home/Index.cshtml
+++ b/PSA.WebApp/Views/Home/Index.cshtml
@@ -29,7 +29,7 @@
             funcionales mediante arquitectura clara, documentación sólida y ejecución organizada.
         </p>
         <div class="hb-actions">
-            <a class="btn btn-primary" asp-controller="Home" asp-action="Producto">Ver landing de PSA Costa Rica</a>
+            <a class="btn btn-primary" asp-controller="Home" asp-action="Producto">Ver página principal de PSA Costa Rica</a>
             <a class="btn btn-outline" href="#equipo">Conocer al equipo</a>
         </div>
     </section>
@@ -102,8 +102,8 @@
         <h2 class="section-title">Nuestro equipo</h2>
         <p class="section-subtitle">Personas, roles y enfoque de trabajo en el proyecto.</p>
         <div class="hb-grid-4">
-            <article class="card card-hover"><h4>Dennis Cruz Montiel</h4><p><span class="badge badge-green">Product Owner</span></p><p>Define la visión del producto y prioriza el alcance.</p></article>
-            <article class="card card-hover"><h4>Yoel Rojas Arguedas</h4><p><span class="badge badge-blue">Scrum Master</span></p><p>Facilita la ejecución del equipo y da seguimiento al avance.</p></article>
+            <article class="card card-hover"><h4>Dennis Cruz Montiel</h4><p><span class="badge badge-green">Propietario del Producto</span></p><p>Define la visión del producto y prioriza el alcance.</p></article>
+            <article class="card card-hover"><h4>Yoel Rojas Arguedas</h4><p><span class="badge badge-blue">Líder Scrum</span></p><p>Facilita la ejecución del equipo y da seguimiento al avance.</p></article>
             <article class="card card-hover"><h4>Kimberly Cascante Mora</h4><p><span class="badge badge-blue">Calidad</span></p><p>Asegura consistencia funcional y calidad de entregables.</p></article>
             <article class="card card-hover"><h4>Jared Mendez Jimenez</h4><p><span class="badge badge-red">Equipo</span></p><p>Apoya la construcción técnica y la implementación de componentes clave.</p></article>
         </div>
@@ -117,7 +117,7 @@
                 a pagos por servicios ambientales.
             </p>
             <div class="hb-actions">
-                <a class="btn btn-primary" asp-controller="Autenticacion" asp-action="IniciarSesion">Entrar al login</a>
+                <a class="btn btn-primary" asp-controller="Autenticacion" asp-action="IniciarSesion">Entrar al inicio de sesión</a>
                 <a class="btn btn-secondary" asp-controller="Autenticacion" asp-action="RegistroUsuario">Crear cuenta</a>
             </div>
         </article>
@@ -126,10 +126,10 @@
     <section class="section section--with-image" id="contacto">
         <img class="section-watermark" src="https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&w=2400&q=85" alt="Pantallas con análisis de software" />
         <h2 class="section-title">Contacto</h2>
-        <p class="section-subtitle">Listo para convertir esta base en la landing final institucional del equipo.</p>
+        <p class="section-subtitle">Listo para convertir esta base en la página principal institucional del equipo.</p>
         <div class="hb-actions">
             <a class="btn btn-outline" href="https://github.com/dcruzm-ops/HummingBird_Solutions" target="_blank" rel="noopener noreferrer">Ver repositorio</a>
-            <a class="btn btn-accent" asp-controller="Home" asp-action="Producto">Ir al landing del producto</a>
+            <a class="btn btn-accent" asp-controller="Home" asp-action="Producto">Ir a la página del producto</a>
         </div>
     </section>
 </div>

--- a/PSA.WebApp/wwwroot/js/registro-finca.js
+++ b/PSA.WebApp/wwwroot/js/registro-finca.js
@@ -8,9 +8,9 @@ document.addEventListener("DOMContentLoaded", function () {
     var textoBoton = formulario.querySelector("[data-loading-texto]");
     var spinnerBoton = formulario.querySelector("[data-loading-spinner]");
 
-    var provinciaSelect = document.getElementById("provinciaSelect");
-    var cantonSelect = document.getElementById("cantonSelect");
-    var distritoSelect = document.getElementById("distritoSelect");
+    var provinciaInput = document.getElementById("provinciaInput");
+    var cantonInput = document.getElementById("cantonInput");
+    var distritoInput = document.getElementById("distritoInput");
     var latitudInput = document.getElementById("Latitud");
     var longitudInput = document.getElementById("Longitud");
     var tieneRiosOQuebradasCheck = document.getElementById("tieneRiosOQuebradas");
@@ -79,184 +79,94 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     }
 
-    var ubicacionesCR = {
-        "San José": {
-            "San José": ["Carmen", "Merced", "Hospital", "Catedral", "Zapote", "San Francisco de Dos Ríos", "Uruca", "Mata Redonda", "Pavas", "Hatillo", "San Sebastián"],
-            "Escazú": ["Escazú", "San Antonio", "San Rafael"],
-            "Desamparados": ["Desamparados", "San Miguel", "San Juan de Dios", "San Rafael Arriba", "San Antonio", "Frailes", "Patarrá", "San Cristóbal", "Rosario", "Damas", "San Rafael Abajo", "Gravilias", "Los Guido"],
-            "Puriscal": ["Santiago", "Mercedes Sur", "Barbacoas", "Grifo Alto", "San Rafael", "Candelarita", "Desamparaditos", "San Antonio", "Chires"],
-            "Tarrazú": ["San Marcos", "San Lorenzo", "San Carlos"],
-            "Aserrí": ["Aserrí", "Tarbaca", "Vuelta de Jorco", "San Gabriel", "Legua", "Monterrey", "Salitrillos"],
-            "Mora": ["Colón", "Guayabo", "Tabarcia", "Piedras Negras", "Picagres", "Jaris", "Quitirrisí"],
-            "Goicoechea": ["Guadalupe", "San Francisco", "Calle Blancos", "Mata de Plátano", "Ipís", "Rancho Redondo", "Purral"],
-            "Santa Ana": ["Santa Ana", "Salitral", "Pozos", "Uruca", "Piedades", "Brasil"],
-            "Alajuelita": ["Alajuelita", "San Josecito", "San Antonio", "Concepción", "San Felipe"],
-            "Vázquez de Coronado": ["San Isidro", "San Rafael", "Dulce Nombre de Jesús", "Patalillo", "Cascajal"],
-            "Acosta": ["San Ignacio", "Guaitil", "Palmichal", "Cangrejal", "Sabanillas"],
-            "Tibás": ["San Juan", "Cinco Esquinas", "Anselmo Llorente", "León XIII", "Colima"],
-            "Moravia": ["San Vicente", "San Jerónimo", "La Trinidad"],
-            "Montes de Oca": ["San Pedro", "Sabanilla", "Mercedes", "San Rafael"],
-            "Turrubares": ["San Pablo", "San Pedro", "San Juan de Mata", "San Luis", "Carara"],
-            "Dota": ["Santa María", "Jardín", "Copey"],
-            "Curridabat": ["Curridabat", "Granadilla", "Sánchez", "Tirrases"],
-            "Pérez Zeledón": ["San Isidro de El General", "El General", "Daniel Flores", "Rivas", "San Pedro", "Platanar", "Pejibaye", "Cajón", "Barú", "Río Nuevo", "Páramo", "La Amistad"],
-            "León Cortés Castro": ["San Pablo", "San Andrés", "Llano Bonito", "San Isidro", "Santa Cruz", "San Antonio"]
-        },
-        "Alajuela": {
-            "Alajuela": ["Alajuela", "San José", "Carrizal", "San Antonio", "Guácima", "San Isidro", "Sabanilla", "San Rafael", "Río Segundo", "Desamparados", "Turrúcares", "Tambor", "Garita", "Sarapiquí"],
-            "San Ramón": ["San Ramón", "Santiago", "San Juan", "Piedades Norte", "Piedades Sur", "San Rafael", "San Isidro", "Ángeles", "Alfaro", "Volio", "Concepción", "Zapotal", "Peñas Blancas", "San Lorenzo"],
-            "Grecia": ["Grecia", "San Isidro", "San José", "San Roque", "Tacares", "Puente de Piedra", "Bolívar"],
-            "San Mateo": ["San Mateo", "Desmonte", "Jesús María", "Labrador"],
-            "Atenas": ["Atenas", "Jesús", "Mercedes", "San Isidro", "Concepción", "San José", "Santa Eulalia", "Escobal"],
-            "Naranjo": ["Naranjo", "San Miguel", "San José", "Cirrí Sur", "San Jerónimo", "San Juan", "El Rosario", "Palmitos"],
-            "Palmares": ["Palmares", "Zaragoza", "Buenos Aires", "Santiago", "Candelaria", "Esquipulas", "La Granja"],
-            "Poás": ["San Pedro", "San Juan", "San Rafael", "Carrillos", "Sabana Redonda"],
-            "Orotina": ["Orotina", "El Mastate", "Hacienda Vieja", "Coyolar", "La Ceiba"],
-            "San Carlos": ["Quesada", "Florencia", "Buenavista", "Aguas Zarcas", "Venecia", "Pital", "La Fortuna", "La Tigra", "La Palmera", "Venado", "Cutris", "Monterrey", "Pocosol"],
-            "Zarcero": ["Zarcero", "Laguna", "Tapezco", "Guadalupe", "Palmira", "Zapote", "Brisas"],
-            "Sarchí": ["Sarchí Norte", "Sarchí Sur", "Toro Amarillo", "San Pedro", "Rodríguez"],
-            "Upala": ["Upala", "Aguas Claras", "San José o Pizote", "Bijagua", "Delicias", "Dos Ríos", "Yolillal", "Canalete"],
-            "Los Chiles": ["Los Chiles", "Caño Negro", "El Amparo", "San Jorge"],
-            "Guatuso": ["San Rafael", "Buenavista", "Cote", "Katira"],
-            "Río Cuarto": ["Río Cuarto", "Santa Rita", "Santa Isabel"]
-        },
-        "Cartago": {
-            "Cartago": ["Oriental", "Occidental", "Carmen", "San Nicolás", "Aguacaliente o San Francisco", "Guadalupe o Arenilla", "Corralillo", "Tierra Blanca", "Dulce Nombre", "Llano Grande", "Quebradilla"],
-            "Paraíso": ["Paraíso", "Santiago", "Orosi", "Cachí", "Llanos de Santa Lucía", "Birrisito"],
-            "La Unión": ["Tres Ríos", "San Diego", "San Juan", "San Rafael", "Concepción", "Dulce Nombre", "San Ramón", "Río Azul"],
-            "Jiménez": ["Juan Viñas", "Tucurrique", "Pejibaye", "La Victoria"],
-            "Turrialba": ["Turrialba", "La Suiza", "Peralta", "Santa Cruz", "Santa Teresita", "Pavones", "Tuis", "Tayutic", "Santa Rosa", "Tres Equis"],
-            "Alvarado": ["Pacayas", "Cervantes", "Capellades"],
-            "Oreamuno": ["San Rafael", "Cot", "Potrero Cerrado", "Cipreses", "Santa Rosa"],
-            "El Guarco": ["El Tejar", "San Isidro", "Tobosí", "Patio de Agua"]
-        },
-        "Heredia": {
-            "Heredia": ["Heredia", "Mercedes", "San Francisco", "Ulloa", "Varablanca"],
-            "Barva": ["Barva", "San Pedro", "San Pablo", "San Roque", "Santa Lucía", "San José de la Montaña", "Puente Salas"],
-            "Santo Domingo": ["Santo Domingo", "San Vicente", "San Miguel", "Paracito", "Santo Tomás", "Santa Rosa", "Tures", "Pará"],
-            "Santa Bárbara": ["Santa Bárbara", "San Pedro", "San Juan", "Jesús", "Santo Domingo", "Purabá"],
-            "San Rafael": ["San Rafael", "San Josecito", "Santiago", "Los Ángeles", "Concepción"],
-            "San Isidro": ["San Isidro", "San José", "Concepción", "San Francisco"],
-            "Belén": ["San Antonio", "La Ribera", "La Asunción"],
-            "Flores": ["San Joaquín", "Barrantes", "Llorente"],
-            "San Pablo": ["San Pablo", "Rincón de Sabanilla"],
-            "Sarapiquí": ["Puerto Viejo", "La Virgen", "Las Horquetas", "Llanuras del Gaspar", "Cureña"]
-        },
-        "Guanacaste": {
-            "Liberia": ["Liberia", "Cañas Dulces", "Mayorga", "Nacascolo", "Curubandé"],
-            "Nicoya": ["Nicoya", "Mansión", "San Antonio", "Quebrada Honda", "Sámara", "Nosara", "Belén de Nosarita"],
-            "Santa Cruz": ["Santa Cruz", "Bolsón", "Veintisiete de Abril", "Tempate", "Cartagena", "Cuajiniquil", "Diriá", "Cabo Velas", "Tamarindo"],
-            "Bagaces": ["Bagaces", "La Fortuna", "Mogote", "Río Naranjo"],
-            "Carrillo": ["Filadelfia", "Palmira", "Sardinal", "Belén"],
-            "Cañas": ["Cañas", "Palmira", "San Miguel", "Bebedero", "Porozal"],
-            "Abangares": ["Las Juntas", "Sierra", "San Juan", "Colorado"],
-            "Tilarán": ["Tilarán", "Quebrada Grande", "Tronadora", "Santa Rosa", "Líbano", "Tierras Morenas", "Arenal", "Cabeceras"],
-            "Nandayure": ["Carmona", "Santa Rita", "Zapotal", "San Pablo", "Porvenir", "Bejuco"],
-            "La Cruz": ["La Cruz", "Santa Cecilia", "La Garita", "Santa Elena"],
-            "Hojancha": ["Hojancha", "Monte Romo", "Puerto Carrillo", "Huacas", "Matambú"]
-        },
-        "Puntarenas": {
-            "Puntarenas": ["Puntarenas", "Pitahaya", "Chomes", "Lepanto", "Paquera", "Manzanillo", "Guacimal", "Barranca", "Isla del Coco", "Cóbano", "Chacarita", "Chira", "Acapulco", "El Roble", "Arancibia"],
-            "Esparza": ["Espíritu Santo", "San Juan Grande", "Macacona", "San Rafael", "San Jerónimo", "Caldera"],
-            "Buenos Aires": ["Buenos Aires", "Volcán", "Potrero Grande", "Boruca", "Pilas", "Colinas", "Chánguena", "Biolley", "Brunka"],
-            "Montes de Oro": ["Miramar", "La Unión", "San Isidro"],
-            "Osa": ["Puerto Cortés", "Palmar", "Sierpe", "Bahía Ballena", "Piedras Blancas", "Bahía Drake"],
-            "Quepos": ["Quepos", "Savegre", "Naranjito"],
-            "Golfito": ["Golfito", "Guaycará", "Pavón"],
-            "Coto Brus": ["San Vito", "Sabalito", "Aguabuena", "Limoncito", "Pittier", "Gutiérrez Braun"],
-            "Parrita": ["Parrita"],
-            "Corredores": ["Corredor", "La Cuesta", "Canoas", "Laurel"],
-            "Garabito": ["Jacó", "Tárcoles", "Lagunillas"],
-            "Monteverde": ["Monteverde"],
-            "Puerto Jiménez": ["Puerto Jiménez"]
-        },
-        "Limón": {
-            "Limón": ["Limón", "Valle La Estrella", "Río Blanco", "Matama"],
-            "Pococí": ["Guápiles", "Jiménez", "Rita", "Roxana", "Cariari", "Colorado", "La Colonia"],
-            "Siquirres": ["Siquirres", "Pacuarito", "Florida", "Germania", "El Cairo", "Alegría", "Reventazón"],
-            "Talamanca": ["Bratsi", "Sixaola", "Cahuita", "Telire"],
-            "Matina": ["Matina", "Batán", "Carrandi"],
-            "Guácimo": ["Guácimo", "Mercedes", "Pocora", "Río Jiménez", "Duacarí"]
-        }
-    };
-
-    var centrosProvincia = {
-        "San José": [9.9281, -84.0907],
-        "Alajuela": [10.0162, -84.2116],
-        "Cartago": [9.8644, -83.9194],
-        "Heredia": [9.9980, -84.1165],
-        "Guanacaste": [10.6350, -85.4377],
-        "Puntarenas": [9.9762, -84.8384],
-        "Limón": [9.9907, -83.0359]
-    };
-
-    function llenarOpciones(select, opciones, placeholder) {
-        if (!select) {
-            return;
-        }
-
-        select.innerHTML = "";
-
-        var opcionInicial = document.createElement("option");
-        opcionInicial.value = "";
-        opcionInicial.textContent = placeholder;
-        select.appendChild(opcionInicial);
-
-        opciones.forEach(function (opcion) {
-            var item = document.createElement("option");
-            item.value = opcion;
-            item.textContent = opcion;
-            select.appendChild(item);
-        });
-    }
-
-    function inicializarUbicaciones() {
-        var provincias = Object.keys(ubicacionesCR);
-        llenarOpciones(provinciaSelect, provincias, "Seleccione una provincia");
-
-        var provinciaActual = provinciaSelect.dataset.valorActual || provinciaSelect.value;
-        var cantonActual = cantonSelect.dataset.valorActual || cantonSelect.value;
-        var distritoActual = distritoSelect.dataset.valorActual || distritoSelect.value;
-
-        if (provinciaActual && ubicacionesCR[provinciaActual]) {
-            provinciaSelect.value = provinciaActual;
-            cargarCantones(provinciaActual, cantonActual, distritoActual);
-        } else {
-            cantonSelect.disabled = true;
-            distritoSelect.disabled = true;
-            llenarOpciones(cantonSelect, [], "Seleccione primero una provincia");
-            llenarOpciones(distritoSelect, [], "Seleccione primero un cantón");
-        }
-    }
-
-    function cargarCantones(provincia, cantonSeleccionado, distritoSeleccionado) {
-        var cantones = Object.keys(ubicacionesCR[provincia] || {});
-        llenarOpciones(cantonSelect, cantones, "Seleccione un cantón");
-        cantonSelect.disabled = cantones.length === 0;
-
-        if (cantonSeleccionado && cantones.indexOf(cantonSeleccionado) >= 0) {
-            cantonSelect.value = cantonSeleccionado;
-            cargarDistritos(provincia, cantonSeleccionado, distritoSeleccionado);
-            return;
-        }
-
-        llenarOpciones(distritoSelect, [], "Seleccione primero un cantón");
-        distritoSelect.disabled = true;
-    }
-
-    function cargarDistritos(provincia, canton, distritoSeleccionado) {
-        var distritos = ((ubicacionesCR[provincia] || {})[canton]) || [];
-        llenarOpciones(distritoSelect, distritos, "Seleccione un distrito");
-        distritoSelect.disabled = distritos.length === 0;
-
-        if (distritoSeleccionado && distritos.indexOf(distritoSeleccionado) >= 0) {
-            distritoSelect.value = distritoSeleccionado;
-        }
-    }
-
     var mapaContenedor = document.getElementById("mapaUbicacionFinca");
     var mapa = null;
     var marcador = null;
+
+    function setCoordenadas(latitud, longitud) {
+        if (latitudInput) {
+            latitudInput.value = Number(latitud).toFixed(7);
+        }
+        if (longitudInput) {
+            longitudInput.value = Number(longitud).toFixed(7);
+        }
+    }
+
+    function setUbicacionAdministrativa(provincia, canton, distrito) {
+        if (provinciaInput) {
+            provinciaInput.value = provincia || "";
+        }
+        if (cantonInput) {
+            cantonInput.value = canton || "";
+        }
+        if (distritoInput) {
+            distritoInput.value = distrito || "";
+        }
+    }
+
+    function extraerPrimerValorValido() {
+        for (var i = 0; i < arguments.length; i++) {
+            if (arguments[i] && String(arguments[i]).trim()) {
+                return String(arguments[i]).trim();
+            }
+        }
+        return "";
+    }
+
+    function resolverUbicacionAdministrativa(latitud, longitud) {
+        var url = "https://nominatim.openstreetmap.org/reverse?format=jsonv2&accept-language=es&zoom=18&lat="
+            + encodeURIComponent(latitud)
+            + "&lon="
+            + encodeURIComponent(longitud);
+
+        fetch(url, {
+            headers: {
+                "Accept": "application/json"
+            }
+        })
+            .then(function (respuesta) {
+                if (!respuesta.ok) {
+                    throw new Error("No se pudo resolver la ubicación administrativa");
+                }
+                return respuesta.json();
+            })
+            .then(function (resultado) {
+                var address = resultado && resultado.address ? resultado.address : {};
+
+                var provincia = extraerPrimerValorValido(address.state, address.region, address.province);
+                var canton = extraerPrimerValorValido(address.county, address.city, address.town, address.municipality);
+                var distrito = extraerPrimerValorValido(address.city_district, address.suburb, address.village, address.hamlet, address.neighbourhood);
+
+                setUbicacionAdministrativa(provincia, canton, distrito);
+            })
+            .catch(function () {
+                setUbicacionAdministrativa("", "", "");
+            });
+    }
+
+    function colocarPin(latitud, longitud, centrar) {
+        if (!mapa) {
+            return;
+        }
+
+        if (!marcador) {
+            marcador = window.L.marker([latitud, longitud], { draggable: true }).addTo(mapa);
+            marcador.on("dragend", function (evento) {
+                var pos = evento.target.getLatLng();
+                setCoordenadas(pos.lat, pos.lng);
+                resolverUbicacionAdministrativa(pos.lat, pos.lng);
+            });
+        } else {
+            marcador.setLatLng([latitud, longitud]);
+        }
+
+        if (centrar) {
+            mapa.setView([latitud, longitud], Math.max(mapa.getZoom(), 13));
+        }
+
+        setCoordenadas(latitud, longitud);
+        resolverUbicacionAdministrativa(latitud, longitud);
+    }
 
     function inicializarMapa() {
         if (!mapaContenedor || typeof window.L === "undefined") {
@@ -285,130 +195,6 @@ document.addEventListener("DOMContentLoaded", function () {
         }, 120);
     }
 
-    function colocarPin(latitud, longitud, centrar) {
-        if (!mapa) {
-            return;
-        }
-
-        if (!marcador) {
-            marcador = window.L.marker([latitud, longitud], { draggable: true }).addTo(mapa);
-            marcador.on("dragend", function (evento) {
-                var pos = evento.target.getLatLng();
-                setCoordenadas(pos.lat, pos.lng);
-            });
-        } else {
-            marcador.setLatLng([latitud, longitud]);
-        }
-
-        if (centrar) {
-            mapa.setView([latitud, longitud], Math.max(mapa.getZoom(), 13));
-        }
-
-        setCoordenadas(latitud, longitud);
-    }
-
-    function setCoordenadas(latitud, longitud) {
-        if (latitudInput) {
-            latitudInput.value = Number(latitud).toFixed(7);
-        }
-        if (longitudInput) {
-            longitudInput.value = Number(longitud).toFixed(7);
-        }
-    }
-
-    function limpiarCoordenadas() {
-        if (latitudInput) {
-            latitudInput.value = "";
-        }
-        if (longitudInput) {
-            longitudInput.value = "";
-        }
-        if (mapa && marcador) {
-            mapa.removeLayer(marcador);
-            marcador = null;
-        }
-    }
-
-    function enfocarZonaSeleccionada() {
-        var provincia = provinciaSelect.value;
-        var canton = cantonSelect.value;
-        var distrito = distritoSelect.value;
-
-        if (!mapa || !provincia || !canton || !distrito) {
-            return;
-        }
-
-        var consulta = encodeURIComponent(distrito + ", " + canton + ", " + provincia + ", Costa Rica");
-        var url = "https://nominatim.openstreetmap.org/search?format=json&countrycodes=cr&limit=1&q=" + consulta;
-
-        fetch(url, {
-            headers: {
-                "Accept": "application/json"
-            }
-        })
-            .then(function (respuesta) {
-                if (!respuesta.ok) {
-                    throw new Error("No se pudo consultar la ubicación");
-                }
-                return respuesta.json();
-            })
-            .then(function (resultados) {
-                if (resultados && resultados.length > 0) {
-                    var lat = Number(resultados[0].lat);
-                    var lon = Number(resultados[0].lon);
-                    mapa.setView([lat, lon], 12);
-                    return;
-                }
-
-                var centro = centrosProvincia[provincia];
-                if (centro) {
-                    mapa.setView(centro, 10);
-                }
-            })
-            .catch(function () {
-                var centro = centrosProvincia[provincia];
-                if (centro) {
-                    mapa.setView(centro, 10);
-                }
-            });
-    }
-
-    provinciaSelect.addEventListener("change", function () {
-        limpiarCoordenadas();
-
-        if (!provinciaSelect.value) {
-            llenarOpciones(cantonSelect, [], "Seleccione primero una provincia");
-            llenarOpciones(distritoSelect, [], "Seleccione primero un cantón");
-            cantonSelect.disabled = true;
-            distritoSelect.disabled = true;
-            return;
-        }
-
-        cargarCantones(provinciaSelect.value);
-
-        var centro = centrosProvincia[provinciaSelect.value];
-        if (mapa && centro) {
-            mapa.setView(centro, 10);
-        }
-    });
-
-    cantonSelect.addEventListener("change", function () {
-        limpiarCoordenadas();
-
-        if (!provinciaSelect.value || !cantonSelect.value) {
-            llenarOpciones(distritoSelect, [], "Seleccione primero un cantón");
-            distritoSelect.disabled = true;
-            return;
-        }
-
-        cargarDistritos(provinciaSelect.value, cantonSelect.value);
-    });
-
-    distritoSelect.addEventListener("change", function () {
-        limpiarCoordenadas();
-        enfocarZonaSeleccionada();
-    });
-
     if (tieneRiosOQuebradasCheck) {
         tieneRiosOQuebradasCheck.addEventListener("change", sincronizarRecursosHidricos);
     }
@@ -418,13 +204,8 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     configurarMensajesValidacionEspanol();
-    inicializarUbicaciones();
     inicializarMapa();
     sincronizarRecursosHidricos();
-
-    if (provinciaSelect.value && cantonSelect.value && distritoSelect.value) {
-        enfocarZonaSeleccionada();
-    }
 
     if (latitudInput && longitudInput && latitudInput.value && longitudInput.value && mapa) {
         colocarPin(Number(latitudInput.value), Number(longitudInput.value), true);
@@ -445,10 +226,21 @@ document.addEventListener("DOMContentLoaded", function () {
             && latitud >= -90 && latitud <= 90
             && longitud >= -180 && longitud <= 180;
 
+        var ubicacionAdministrativaCompleta = provinciaInput && cantonInput && distritoInput
+            && provinciaInput.value.trim()
+            && cantonInput.value.trim()
+            && distritoInput.value.trim();
+
         if (hectareasInput) {
             hectareasInput.setCustomValidity("");
             if (!Number.isFinite(hectareas) || hectareas <= 0) {
                 hectareasInput.setCustomValidity("El valor de hectáreas debe ser mayor a 0.");
+            }
+        }
+
+        if (!ubicacionAdministrativaCompleta) {
+            if (provinciaInput) {
+                provinciaInput.setCustomValidity("Seleccione un punto válido en el mapa para derivar la ubicación.");
             }
         }
 


### PR DESCRIPTION
### Motivation
- Add persistent audit logging for authentication and password recovery flows to increase traceability and security.
- Improve the finca registration UX by auto-resolving administrative location from a map point and simplifying form fields.
- Make project builds deterministic by disabling default compile items and declaring source files explicitly across projects.
- Minor UI/text and email sending adjustments to align messaging and reuse the recovery email helper.

### Description
- Introduced `AuditoriaLogDAO` (`PSA.DataAccess/DAO/AuditoriaLogDAO.cs`) to persist audit records and added it to DI in `Program.cs` for both `PSA.WebAPI` and `PSA.WebApp` via `builder.Services.AddScoped<AuditoriaLogDAO>(...)`.
- Injected `AuditoriaLogDAO` into `AutenticacionManager` and `RecuperacionContrasenaManager` and added calls to `RegistrarEventoAsync(...)` for events such as `LOGIN_FALLIDO`, `LOGIN_EXITOSO`, `TOKEN_RECUPERACION_GENERADO`, `TOKEN_RECUPERACION_VALIDADO`, `TOKEN_RECUPERACION_INVALIDO`, `CAMBIO_CONTRASENA_EXITOSO`, and `CAMBIO_CONTRASENA_FALLIDO`.
- Added the new audit DTO/entity files to `PSA.EntidadesDTO` project and updated several `.csproj` files to set `EnableDefaultCompileItems=false` and include source files explicitly (projects: `PSA.DataAccess`, `PSA.EntidadesDTO`, `PSA.WebAPI`, `PSA.WebApp`).
- Changed welcome/recovery email sending in `AutenticacionController` to call `CorreoService.EnviarCorreoRecuperacion(...)` with `nombreUsuario` and `urlLogin` parameters and removed the verbose inline welcome body.
- Enhanced `FincaController` with Spanish route names (`ObtenerTodos`, `ObtenerPorId`, `Crear`, `Actualizar`, `Eliminar`) while keeping existing English routes.
- Redesigned finca registration form and client script: replaced province/canton/district `<select>`s with readonly inputs filled by reverse geocoding, simplified map interactions, updated `registro-finca.js` to resolve administrative place names from coordinates, and adjusted client-side validation messages and behavior.
- Minor content and localization edits across views and docs, including `EMAIL_SETUP.md` wording and several UI label/text updates in `Views` and `Home` pages.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc718de658832dbb2b19816285c3ae)