### PR TITLE
Add Dashboard feature, tighten validations and use UTC timestamps

### DIFF
--- a/PSA.AppCore/FincaService.cs
+++ b/PSA.AppCore/FincaService.cs
@@ -9,7 +9,7 @@ namespace PSA.AppCore
 
         public FincaService(FincaDAO fincaDAO)
         {
-            _fincaDAO = fincaDAO;
+            _fincaDAO = fincaDAO ?? throw new ArgumentNullException(nameof(fincaDAO));
         }
 
         public List<FincaDTO> RetrieveAll()
@@ -28,8 +28,9 @@ namespace PSA.AppCore
         public void Create(FincaDTO finca)
         {
             ValidarFinca(finca);
-            finca.FechaRegistro = DateTime.Now;
-            finca.FechaActualizacion = DateTime.Now;
+            var now = DateTime.UtcNow;
+            finca.FechaRegistro = now;
+            finca.FechaActualizacion = now;
             _fincaDAO.Create(finca);
         }
 
@@ -39,7 +40,7 @@ namespace PSA.AppCore
                 throw new Exception("El id de la finca es obligatorio para actualizar.");
 
             ValidarFinca(finca);
-            finca.FechaActualizacion = DateTime.Now;
+            finca.FechaActualizacion = DateTime.UtcNow;
             _fincaDAO.Update(finca);
         }
 
@@ -55,6 +56,15 @@ namespace PSA.AppCore
         {
             if (finca == null)
                 throw new Exception("La finca es requerida.");
+
+            finca.NombreFinca = finca.NombreFinca?.Trim() ?? string.Empty;
+            finca.Provincia = finca.Provincia?.Trim() ?? string.Empty;
+            finca.Canton = finca.Canton?.Trim() ?? string.Empty;
+            finca.Distrito = finca.Distrito?.Trim() ?? string.Empty;
+            finca.Vegetacion = finca.Vegetacion?.Trim() ?? string.Empty;
+            finca.UsoSuelo = finca.UsoSuelo?.Trim() ?? string.Empty;
+            finca.Pendiente = finca.Pendiente?.Trim() ?? string.Empty;
+            finca.EstadoFinca = finca.EstadoFinca?.Trim() ?? string.Empty;
 
             if (finca.IdPropietario <= 0)
                 throw new Exception("El propietario es obligatorio.");
@@ -91,6 +101,12 @@ namespace PSA.AppCore
 
             if (finca.Longitud < -180 || finca.Longitud > 180)
                 throw new Exception("La longitud debe estar entre -180 y 180.");
+
+            if (finca.FechaActualizacion != default && finca.FechaRegistro != default &&
+                finca.FechaActualizacion < finca.FechaRegistro)
+            {
+                throw new Exception("La fecha de actualización no puede ser menor a la fecha de registro.");
+            }
         }
     }
 }

--- a/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
+++ b/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
@@ -15,13 +15,19 @@ namespace PSA.AppCore.Managers
             TokenRecuperacionDAO tokenRecuperacionDAO,
             IServicioHashContrasena servicioHash)
         {
-            _usuarioDAO = usuarioDAO;
-            _tokenRecuperacionDAO = tokenRecuperacionDAO;
-            _servicioHash = servicioHash;
+            _usuarioDAO = usuarioDAO ?? throw new ArgumentNullException(nameof(usuarioDAO));
+            _tokenRecuperacionDAO = tokenRecuperacionDAO ?? throw new ArgumentNullException(nameof(tokenRecuperacionDAO));
+            _servicioHash = servicioHash ?? throw new ArgumentNullException(nameof(servicioHash));
         }
 
         public async Task<(string Token, string NombreUsuario)> GenerarTokenConNombreAsync(string email)
         {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                throw new InvalidOperationException("El correo es obligatorio.");
+            }
+
+            email = email.Trim();
             var usuario = await _usuarioDAO.ObtenerPorEmailAsync(email);
             if (usuario == null)
             {
@@ -37,6 +43,11 @@ namespace PSA.AppCore.Managers
 
         public async Task<bool> TokenEsValidoAsync(string token)
         {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return false;
+            }
+
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
             return registro != null;
         }
@@ -55,6 +66,16 @@ namespace PSA.AppCore.Managers
 
         public async Task RestablecerContrasenaAsync(string token, string nuevaContrasena)
         {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw new InvalidOperationException("El token es obligatorio.");
+            }
+
+            if (string.IsNullOrWhiteSpace(nuevaContrasena) || nuevaContrasena.Trim().Length < 8)
+            {
+                throw new InvalidOperationException("La nueva contraseña debe contener al menos 8 caracteres.");
+            }
+
             var registro = await _tokenRecuperacionDAO.ObtenerTokenVigenteAsync(token);
             if (registro == null)
             {
@@ -67,7 +88,7 @@ namespace PSA.AppCore.Managers
                 throw new InvalidOperationException("No se encontró el usuario asociado al token.");
             }
 
-            var hash = _servicioHash.GenerarHash(nuevaContrasena);
+            var hash = _servicioHash.GenerarHash(nuevaContrasena.Trim());
             await _usuarioDAO.ActualizarPasswordHashPorEmailAsync(usuario.Email, hash);
             await _tokenRecuperacionDAO.MarcarTokenComoUsadoAsync(registro.IdToken);
         }

--- a/PSA.DataAccess/DAO/DashboardDAO.cs
+++ b/PSA.DataAccess/DAO/DashboardDAO.cs
@@ -1,0 +1,180 @@
+using Microsoft.Data.SqlClient;
+
+namespace PSA.DataAccess.DAO
+{
+    public class DashboardDAO
+    {
+        private readonly string _connectionString;
+
+        public DashboardDAO(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public async Task<(int FincasRegistradas, int EvaluacionesPendientes, int CuotasPorConfirmar, List<(string Mensaje, int? IdEntidad)> Actividad)> ObtenerResumenDuenoAsync(int idPropietario)
+        {
+            const string sql = @"
+SELECT
+    (SELECT COUNT(1) FROM Fincas WHERE IdPropietario = @IdPropietario) AS FincasRegistradas,
+    (SELECT COUNT(1)
+     FROM EvaluacionesTecnicas e
+     INNER JOIN Fincas f ON f.IdFinca = e.IdFinca
+     WHERE f.IdPropietario = @IdPropietario
+       AND e.EstadoEvaluacion IN ('Pendiente', 'En Proceso')) AS EvaluacionesPendientes,
+    (SELECT COUNT(1)
+     FROM CuotasPago c
+     INNER JOIN PlanesPago p ON p.IdPlanPago = c.IdPlanPago
+     INNER JOIN Fincas f ON f.IdFinca = p.IdFinca
+     WHERE f.IdPropietario = @IdPropietario
+       AND c.EstadoCuota IN ('Programada', 'Atrasada', 'Acumulada')) AS CuotasPorConfirmar;";
+
+            const string sqlActividad = @"
+SELECT TOP 3 Mensaje, IdEntidadReferencia
+FROM Notificaciones
+WHERE IdUsuario = @IdPropietario
+ORDER BY FechaCreacion DESC;";
+
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            int fincas = 0;
+            int evaluaciones = 0;
+            int cuotas = 0;
+
+            using (var command = new SqlCommand(sql, connection))
+            {
+                command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+                using var reader = await command.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    fincas = reader.GetInt32(reader.GetOrdinal("FincasRegistradas"));
+                    evaluaciones = reader.GetInt32(reader.GetOrdinal("EvaluacionesPendientes"));
+                    cuotas = reader.GetInt32(reader.GetOrdinal("CuotasPorConfirmar"));
+                }
+            }
+
+            var actividad = new List<(string Mensaje, int? IdEntidad)>();
+            using (var commandActividad = new SqlCommand(sqlActividad, connection))
+            {
+                commandActividad.Parameters.AddWithValue("@IdPropietario", idPropietario);
+                using var readerActividad = await commandActividad.ExecuteReaderAsync();
+                while (await readerActividad.ReadAsync())
+                {
+                    var mensaje = readerActividad["Mensaje"]?.ToString() ?? string.Empty;
+                    var idEntidad = readerActividad["IdEntidadReferencia"] == DBNull.Value
+                        ? (int?)null
+                        : Convert.ToInt32(readerActividad["IdEntidadReferencia"]);
+                    actividad.Add((mensaje, idEntidad));
+                }
+            }
+
+            return (fincas, evaluaciones, cuotas, actividad);
+        }
+
+        public async Task<(int FincasPendientes, int EvaluacionesAbiertas, int DecisionesMesActual, List<(int IdFinca, string NombreFinca)> ProximasAcciones)> ObtenerResumenIngenieroAsync(int idIngeniero)
+        {
+            const string sql = @"
+SELECT
+    (SELECT COUNT(1) FROM EvaluacionesTecnicas WHERE EstadoEvaluacion = 'Pendiente') AS FincasPendientes,
+    (SELECT COUNT(1) FROM EvaluacionesTecnicas WHERE IdIngeniero = @IdIngeniero AND EstadoEvaluacion IN ('Pendiente', 'En Proceso')) AS EvaluacionesAbiertas,
+    (SELECT COUNT(1)
+     FROM EvaluacionesTecnicas
+     WHERE IdIngeniero = @IdIngeniero
+       AND DecisionTecnica IS NOT NULL
+       AND YEAR(FechaDecision) = YEAR(SYSDATETIME())
+       AND MONTH(FechaDecision) = MONTH(SYSDATETIME())) AS DecisionesMesActual;";
+
+            const string sqlAcciones = @"
+SELECT TOP 3 f.IdFinca, f.NombreFinca
+FROM EvaluacionesTecnicas e
+INNER JOIN Fincas f ON f.IdFinca = e.IdFinca
+WHERE e.IdIngeniero = @IdIngeniero
+  AND e.EstadoEvaluacion IN ('Pendiente', 'En Proceso')
+ORDER BY ISNULL(e.FechaVisita, CAST(GETDATE() AS date)) ASC, e.IdEvaluacion DESC;";
+
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            int pendientes = 0;
+            int abiertas = 0;
+            int decisiones = 0;
+
+            using (var command = new SqlCommand(sql, connection))
+            {
+                command.Parameters.AddWithValue("@IdIngeniero", idIngeniero);
+                using var reader = await command.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    pendientes = reader.GetInt32(reader.GetOrdinal("FincasPendientes"));
+                    abiertas = reader.GetInt32(reader.GetOrdinal("EvaluacionesAbiertas"));
+                    decisiones = reader.GetInt32(reader.GetOrdinal("DecisionesMesActual"));
+                }
+            }
+
+            var acciones = new List<(int IdFinca, string NombreFinca)>();
+            using (var commandAcciones = new SqlCommand(sqlAcciones, connection))
+            {
+                commandAcciones.Parameters.AddWithValue("@IdIngeniero", idIngeniero);
+                using var readerAcciones = await commandAcciones.ExecuteReaderAsync();
+                while (await readerAcciones.ReadAsync())
+                {
+                    acciones.Add((
+                        readerAcciones.GetInt32(readerAcciones.GetOrdinal("IdFinca")),
+                        readerAcciones["NombreFinca"]?.ToString() ?? string.Empty
+                    ));
+                }
+            }
+
+            return (pendientes, abiertas, decisiones, acciones);
+        }
+
+        public async Task<(int UsuariosActivos, int CuentasPorValidar, int EventosAuditoria24h, List<string> Alertas)> ObtenerResumenAdministradorAsync()
+        {
+            const string sql = @"
+SELECT
+    (SELECT COUNT(1) FROM Usuarios WHERE Estado = 'Activo') AS UsuariosActivos,
+    (SELECT COUNT(1) FROM CuentasBancarias WHERE EstadoValidacion = 'Pendiente') AS CuentasPorValidar,
+    (SELECT COUNT(1) FROM AuditoriaLog WHERE FechaAccion >= DATEADD(HOUR, -24, SYSDATETIME())) AS EventosAuditoria24h;";
+
+            const string sqlAlertas = @"
+SELECT TOP 3 Detalle
+FROM AuditoriaLog
+WHERE Detalle IS NOT NULL AND LTRIM(RTRIM(Detalle)) <> ''
+ORDER BY FechaAccion DESC;";
+
+            using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync();
+
+            int usuarios = 0;
+            int cuentas = 0;
+            int auditoria = 0;
+
+            using (var command = new SqlCommand(sql, connection))
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    usuarios = reader.GetInt32(reader.GetOrdinal("UsuariosActivos"));
+                    cuentas = reader.GetInt32(reader.GetOrdinal("CuentasPorValidar"));
+                    auditoria = reader.GetInt32(reader.GetOrdinal("EventosAuditoria24h"));
+                }
+            }
+
+            var alertas = new List<string>();
+            using (var commandAlertas = new SqlCommand(sqlAlertas, connection))
+            {
+                using var readerAlertas = await commandAlertas.ExecuteReaderAsync();
+                while (await readerAlertas.ReadAsync())
+                {
+                    var detalle = readerAlertas["Detalle"]?.ToString();
+                    if (!string.IsNullOrWhiteSpace(detalle))
+                    {
+                        alertas.Add(detalle.Trim());
+                    }
+                }
+            }
+
+            return (usuarios, cuentas, auditoria, alertas);
+        }
+    }
+}

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -12,6 +12,7 @@
 		<Compile Remove="bin\**\*.cs;obj\**\*.cs" />
 		<Compile Include="DbContextHelper.cs" />
 		<Compile Include="DAO\FincaDAO.cs" />
+		<Compile Include="DAO\DashboardDAO.cs" />
 		<Compile Include="DAO\RecuperacionContrasenaDAO.cs" />
 		<Compile Include="DAO\TokenRecuperacionDAO.cs" />
 		<Compile Include="DAO\UsuarioDAO.cs" />

--- a/PSA.WebApp/Controllers/DashboardController.cs
+++ b/PSA.WebApp/Controllers/DashboardController.cs
@@ -1,45 +1,119 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using PSA.DataAccess.DAO;
+using PSA.WebApp.Models;
+using System.Security.Claims;
 
 namespace PSA.WebApp.Controllers
 {
     [Authorize]
     public class DashboardController : Controller
     {
+        private readonly DashboardDAO _dashboardDAO;
+
+        public DashboardController(DashboardDAO dashboardDAO)
+        {
+            _dashboardDAO = dashboardDAO;
+        }
+
         [HttpGet]
         [Authorize(Roles = "2")]
-        public IActionResult Dueno()
+        public async Task<IActionResult> Dueno()
         {
             ViewBag.ModuloActivo = "dashboard";
             ViewBag.RolActivo = "Dueno";
             ViewBag.TituloPagina = "Dashboard del dueño de finca";
             ViewBag.SubtituloPagina = "Resumen general de fincas, evaluaciones, notificaciones y pagos.";
             ViewBag.BreadcrumbActual = "Dashboard";
-            return View();
+
+            var idUsuario = ObtenerIdUsuarioSesion();
+            if (idUsuario <= 0)
+            {
+                return RedirectToAction("IniciarSesion", "Autenticacion");
+            }
+
+            var resumen = await _dashboardDAO.ObtenerResumenDuenoAsync(idUsuario);
+            var modelo = new DashboardDuenoViewModel
+            {
+                FincasRegistradas = resumen.FincasRegistradas,
+                EvaluacionesPendientes = resumen.EvaluacionesPendientes,
+                CuotasPorConfirmar = resumen.CuotasPorConfirmar,
+                ActividadReciente = resumen.Actividad
+                    .Select(x => new ActividadDashboardViewModel
+                    {
+                        Titulo = x.Mensaje,
+                        Url = x.IdEntidad.HasValue ? Url.Action("DetalleFinca", "Fincas", new { id = x.IdEntidad.Value }) : Url.Action("Index", "Notificaciones")
+                    })
+                    .ToList()
+            };
+
+            return View(modelo);
         }
 
         [HttpGet]
         [Authorize(Roles = "3")]
-        public IActionResult Ingeniero()
+        public async Task<IActionResult> Ingeniero()
         {
             ViewBag.ModuloActivo = "dashboard";
             ViewBag.RolActivo = "Ingeniero";
             ViewBag.TituloPagina = "Dashboard del ingeniero forestal";
             ViewBag.SubtituloPagina = "Accesos rápidos a evaluaciones, visitas y fincas pendientes.";
             ViewBag.BreadcrumbActual = "Dashboard";
-            return View();
+
+            var idUsuario = ObtenerIdUsuarioSesion();
+            if (idUsuario <= 0)
+            {
+                return RedirectToAction("IniciarSesion", "Autenticacion");
+            }
+
+            var resumen = await _dashboardDAO.ObtenerResumenIngenieroAsync(idUsuario);
+            var modelo = new DashboardIngenieroViewModel
+            {
+                FincasPendientes = resumen.FincasPendientes,
+                EvaluacionesAbiertas = resumen.EvaluacionesAbiertas,
+                DecisionesMesActual = resumen.DecisionesMesActual,
+                ProximasAcciones = resumen.ProximasAcciones
+                    .Select(x => new ActividadDashboardViewModel
+                    {
+                        Titulo = $"Registrar o completar evaluación para \"{x.NombreFinca}\".",
+                        Url = Url.Action("NuevaEvaluacion", "Evaluaciones", new { fincaId = x.IdFinca })
+                    })
+                    .ToList()
+            };
+
+            return View(modelo);
         }
 
         [HttpGet]
         [Authorize(Roles = "1")]
-        public IActionResult Administrador()
+        public async Task<IActionResult> Administrador()
         {
             ViewBag.ModuloActivo = "dashboard";
             ViewBag.RolActivo = "Administrador";
             ViewBag.TituloPagina = "Dashboard del administrador";
             ViewBag.SubtituloPagina = "Monitoreo operativo del sistema, usuarios, pagos y auditoría.";
             ViewBag.BreadcrumbActual = "Dashboard";
-            return View();
+
+            var resumen = await _dashboardDAO.ObtenerResumenAdministradorAsync();
+            var modelo = new DashboardAdministradorViewModel
+            {
+                UsuariosActivos = resumen.UsuariosActivos,
+                CuentasPorValidar = resumen.CuentasPorValidar,
+                EventosAuditoria24h = resumen.EventosAuditoria24h,
+                Alertas = resumen.Alertas.Select(x => new ActividadDashboardViewModel
+                {
+                    Titulo = x,
+                    Url = Url.Action("AuditoriaLogs", "Administracion")
+                }).ToList()
+            };
+
+            return View(modelo);
+        }
+
+        private int ObtenerIdUsuarioSesion()
+        {
+            var idClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return int.TryParse(idClaim, out var idUsuario) ? idUsuario : 0;
         }
     }
 }

--- a/PSA.WebApp/Models/DashboardViewModels.cs
+++ b/PSA.WebApp/Models/DashboardViewModels.cs
@@ -1,0 +1,32 @@
+namespace PSA.WebApp.Models
+{
+    public class ActividadDashboardViewModel
+    {
+        public string Titulo { get; set; } = string.Empty;
+        public string? Url { get; set; }
+    }
+
+    public class DashboardDuenoViewModel
+    {
+        public int FincasRegistradas { get; set; }
+        public int EvaluacionesPendientes { get; set; }
+        public int CuotasPorConfirmar { get; set; }
+        public List<ActividadDashboardViewModel> ActividadReciente { get; set; } = new();
+    }
+
+    public class DashboardIngenieroViewModel
+    {
+        public int FincasPendientes { get; set; }
+        public int EvaluacionesAbiertas { get; set; }
+        public int DecisionesMesActual { get; set; }
+        public List<ActividadDashboardViewModel> ProximasAcciones { get; set; } = new();
+    }
+
+    public class DashboardAdministradorViewModel
+    {
+        public int UsuariosActivos { get; set; }
+        public int CuentasPorValidar { get; set; }
+        public int EventosAuditoria24h { get; set; }
+        public List<ActividadDashboardViewModel> Alertas { get; set; } = new();
+    }
+}

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -67,6 +67,19 @@ builder.Services.AddScoped<TokenRecuperacionDAO>(sp =>
     return new TokenRecuperacionDAO(connectionString);
 });
 
+builder.Services.AddScoped<DashboardDAO>(sp =>
+{
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var connectionString = configuration.GetConnectionString("PSAConnection");
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("No se encontró la cadena de conexión 'PSAConnection' en WebApp.");
+    }
+
+    return new DashboardDAO(connectionString);
+});
+
 builder.Services.AddScoped<AutenticacionManager>();
 builder.Services.AddScoped<RecuperacionContrasenaManager>();
 builder.Services.AddScoped<IServicioCorreo, ServicioCorreoSmtp>();

--- a/PSA.WebApp/Views/Dashboard/Administrador.cshtml
+++ b/PSA.WebApp/Views/Dashboard/Administrador.cshtml
@@ -1,3 +1,4 @@
+@model PSA.WebApp.Models.DashboardAdministradorViewModel
 @{
     ViewData["Title"] = "Dashboard del administrador";
 }
@@ -14,17 +15,17 @@
     <div class="grid-tarjetas-kpi">
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Usuarios activos</span>
-            <strong>28</strong>
-            <small>3 pendientes de aprobación</small>
+            <strong>@Model.UsuariosActivos</strong>
+            <small>Registros en estado Activo</small>
         </article>
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Cuentas por validar</span>
-            <strong>5</strong>
+            <strong>@Model.CuentasPorValidar</strong>
             <small>Revisión administrativa requerida</small>
         </article>
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Eventos de auditoría</span>
-            <strong>148</strong>
+            <strong>@Model.EventosAuditoria24h</strong>
             <small>Últimas 24 horas</small>
         </article>
     </div>
@@ -34,9 +35,17 @@
             <h3>Alertas administrativas</h3>
         </div>
         <ul class="lista-timeline">
-            <li><a asp-controller="Administracion" asp-action="ParametrosPago">Se detectaron 2 cambios en parámetros de pago.</a></li>
-            <li><a asp-controller="Pagos" asp-action="PlanesPago">Existe 1 plan de pago sin cuenta bancaria asociada.</a></li>
-            <li><a asp-controller="Administracion" asp-action="GestionUsuarios">Hay 3 usuarios sin rol asignado definitivo.</a></li>
+            @if (Model.Alertas.Any())
+            {
+                @foreach (var alerta in Model.Alertas)
+                {
+                    <li><a href="@(alerta.Url ?? "#")">@alerta.Titulo</a></li>
+                }
+            }
+            else
+            {
+                <li><a asp-controller="Administracion" asp-action="AuditoriaLogs">No hay alertas administrativas recientes.</a></li>
+            }
         </ul>
     </section>
 </section>

--- a/PSA.WebApp/Views/Dashboard/Dueno.cshtml
+++ b/PSA.WebApp/Views/Dashboard/Dueno.cshtml
@@ -1,3 +1,4 @@
+@model PSA.WebApp.Models.DashboardDuenoViewModel
 @{
     ViewData["Title"] = "Dashboard del dueño";
 }
@@ -14,18 +15,18 @@
     <div class="grid-tarjetas-kpi">
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Fincas registradas</span>
-            <strong>3</strong>
-            <small>2 activas y 1 en revisión</small>
+            <strong>@Model.FincasRegistradas</strong>
+            <small>Datos en tiempo real desde base de datos</small>
         </article>
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Evaluaciones pendientes</span>
-            <strong>1</strong>
-            <small>Última actualización hace 2 días</small>
+            <strong>@Model.EvaluacionesPendientes</strong>
+            <small>Estados Pendiente y En Proceso</small>
         </article>
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Cuotas por confirmar</span>
-            <strong>2</strong>
-            <small>Plan anual 2026</small>
+            <strong>@Model.CuotasPorConfirmar</strong>
+            <small>Cuotas programadas, atrasadas o acumuladas</small>
         </article>
     </div>
 
@@ -46,9 +47,17 @@
                 <h3>Actividad reciente</h3>
             </div>
             <ul class="lista-timeline">
-                <li><a asp-controller="Fincas" asp-action="DetalleFinca" asp-route-id="1">Finca “Los Laureles” actualizada con nueva evidencia.</a></li>
-                <li><a asp-controller="Fincas" asp-action="DetalleFinca" asp-route-id="2">Evaluación técnica de “Finca El Bosque” marcada como en proceso.</a></li>
-                <li><a asp-controller="Notificaciones" asp-action="Index">Cuenta bancaria pendiente de validación administrativa.</a></li>
+                @if (Model.ActividadReciente.Any())
+                {
+                    @foreach (var actividad in Model.ActividadReciente)
+                    {
+                        <li><a href="@(actividad.Url ?? "#")">@actividad.Titulo</a></li>
+                    }
+                }
+                else
+                {
+                    <li><a asp-controller="Notificaciones" asp-action="Index">No hay actividad reciente para mostrar.</a></li>
+                }
             </ul>
         </section>
     </div>

--- a/PSA.WebApp/Views/Dashboard/Ingeniero.cshtml
+++ b/PSA.WebApp/Views/Dashboard/Ingeniero.cshtml
@@ -1,3 +1,4 @@
+@model PSA.WebApp.Models.DashboardIngenieroViewModel
 @{
     ViewData["Title"] = "Dashboard del ingeniero";
 }
@@ -14,17 +15,17 @@
     <div class="grid-tarjetas-kpi">
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Fincas pendientes</span>
-            <strong>6</strong>
-            <small>Por revisar esta semana</small>
+            <strong>@Model.FincasPendientes</strong>
+            <small>Con evaluación en estado Pendiente</small>
         </article>
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Evaluaciones abiertas</span>
-            <strong>4</strong>
-            <small>2 requieren visita</small>
+            <strong>@Model.EvaluacionesAbiertas</strong>
+            <small>Asignadas al ingeniero actual</small>
         </article>
         <article class="tarjeta-kpi">
             <span class="etiqueta-kpi">Decisiones emitidas</span>
-            <strong>12</strong>
+            <strong>@Model.DecisionesMesActual</strong>
             <small>Durante el mes actual</small>
         </article>
     </div>
@@ -34,9 +35,17 @@
             <h3>Próximas acciones</h3>
         </div>
         <ul class="lista-timeline">
-            <li><a asp-controller="Evaluaciones" asp-action="NuevaEvaluacion" asp-route-fincaId="12">Registrar visita técnica de la finca #12.</a></li>
-            <li><a asp-controller="Evaluaciones" asp-action="NuevaEvaluacion" asp-route-fincaId="2">Adjuntar evidencia técnica de la finca “Río Verde”.</a></li>
-            <li><a asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">Emitir decisión técnica para expediente PSA-2026-004.</a></li>
+            @if (Model.ProximasAcciones.Any())
+            {
+                @foreach (var accion in Model.ProximasAcciones)
+                {
+                    <li><a href="@(accion.Url ?? "#")">@accion.Titulo</a></li>
+                }
+            }
+            else
+            {
+                <li><a asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">No hay acciones pendientes para mostrar.</a></li>
+            }
         </ul>
     </section>
 </section>

--- a/PSA.WebApp/wwwroot/js/registro-finca.js
+++ b/PSA.WebApp/wwwroot/js/registro-finca.js
@@ -39,6 +39,18 @@ document.addEventListener("DOMContentLoaded", function () {
             return "El formato numérico de '" + nombreCampo + "' no es válido.";
         }
 
+        if (campo.validity.tooLong) {
+            return "El valor de '" + nombreCampo + "' supera la longitud permitida.";
+        }
+
+        if (campo.validity.tooShort) {
+            return "El valor de '" + nombreCampo + "' es demasiado corto.";
+        }
+
+        if (campo.validity.badInput) {
+            return "El valor ingresado en '" + nombreCampo + "' no tiene un formato válido.";
+        }
+
         return "";
     }
 
@@ -418,6 +430,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     configurarMensajesValidacionEspanol();
+    formulario.setAttribute("lang", "es");
     inicializarUbicaciones();
     inicializarMapa();
     sincronizarRecursosHidricos();


### PR DESCRIPTION
### Motivation
- Provide role-specific dashboard summaries for owners, engineers and admins backed by the database via a new DAO. 
- Harden services against null inputs and inconsistent data and unify timestamp semantics to UTC.

### Description
- Added `DashboardDAO` with methods `ObtenerResumenDuenoAsync`, `ObtenerResumenIngenieroAsync` and `ObtenerResumenAdministradorAsync` and registered it in `Program.cs`. 
- Implemented view models (`DashboardViewModels.cs`) and updated `DashboardController` and Razor views to render live KPIs and activity lists for each role. 
- Improved validation and safety in `FincaService` by checking constructor arguments, trimming string fields, enforcing coordinate/date constraints, and switching to `DateTime.UtcNow` for `FechaRegistro`/`FechaActualizacion`. 
- Hardened `RecuperacionContrasenaManager` with constructor null checks, input trimming/validation for `email`, `token` and `nuevaContrasena`, and trimmed password before hashing. 
- Enhanced client-side form validation in `wwwroot/js/registro-finca.js` by handling additional validity states and setting the form `lang` to `es`.

### Testing
- Built the solution with `dotnet build` to ensure projects compile after the changes and the build succeeded. 
- Executed existing automated tests with `dotnet test` where present and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce6fd9ee48832d951d7477f38eb345)