### PR TITLE
Remove Swagger usage and Swashbuckle package from PSA.WebAPI

### DIFF
--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -24,7 +24,6 @@
     <ProjectReference Include="..\PSA.AppCore\PSA.AppCore.csproj" />
     <ProjectReference Include="..\PSA.DataAccess\PSA.DataAccess.csproj" />
     <ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -11,7 +11,6 @@ Console.WriteLine("PSAConnection: " + builder.Configuration["ConnectionStrings:P
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 
 builder.Services.AddScoped<IServicioHashContrasena, ServicioHashContrasena>();
 
@@ -98,17 +97,6 @@ builder.Services.AddScoped<AutenticacionManager>();
 builder.Services.AddScoped<RecuperacionContrasenaManager>();
 
 var app = builder.Build();
-
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-
-    app.UseSwaggerUI(options =>
-    {
-        options.SwaggerEndpoint("./v1/swagger.json", "PSA.WebAPI v1");
-        options.RoutePrefix = "swagger";
-    });
-}
 
 app.UseHttpsRedirection();
 app.UseAuthorization();


### PR DESCRIPTION
### Motivation
- The WebAPI startup was failing with missing extension methods (`AddSwaggerGen`, `UseSwagger`, `UseSwaggerUI`) and a NuGet package resolution error for `Microsoft.AspNetCore.OpenApi`, so the Swagger/OpenAPI path was removed to allow the API to start without that unavailable dependency.

### Description
- Removed the call to `builder.Services.AddSwaggerGen()` from `PSA.WebAPI/Program.cs`.
- Removed the development-only `app.UseSwagger()` and `app.UseSwaggerUI(...)` block from `PSA.WebAPI/Program.cs`.
- Removed the `Swashbuckle.AspNetCore` package reference from `PSA.WebAPI/PSA.WebAPI.csproj`.
- Preserved all other service registrations and the application pipeline behavior.

### Testing
- Attempted `dotnet build PSA.WebAPI/PSA.WebAPI.csproj -v minimal` and the command could not run because `dotnet` is not installed in this environment, so no build verification completed.
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced661ef94832dbe1e76ff2b45d0dd)