### PR TITLE
feat: integrar issues 24, 60 y 61 — bandeja Ingeniero, menú por rol y reportes base

### DIFF
--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -30,12 +30,22 @@ namespace PSA.WebApp.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> FincasPendientes()
+        public async Task<IActionResult> FincasPendientes(string estado = "Todos")
         {
             CargarContextoBase("Fincas pendientes", "Revise y tome evaluaciones técnicas pendientes o en proceso.");
+            var pendientes = await ObtenerBandejaDesdeApiConFallbackAsync();
+
+            if (!string.Equals(estado, "Todos", StringComparison.OrdinalIgnoreCase))
+            {
+                pendientes = pendientes
+                    .Where(x => string.Equals(x.EstadoEvaluacion, estado, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+
             var model = new BandejaEvaluacionesViewModel
             {
-                Pendientes = await ObtenerBandejaDesdeApiConFallbackAsync()
+                Pendientes = pendientes,
+                EstadoFiltro = estado
             };
 
             return View(model);

--- a/PSA.WebApp/Controllers/ReportesController.cs
+++ b/PSA.WebApp/Controllers/ReportesController.cs
@@ -1,20 +1,32 @@
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace PSA.WebApp.Controllers
 {
-    [Authorize(Roles = "1,3")]
+    [Authorize(Roles = "1,2,3")]
     public class ReportesController : Controller
     {
         [HttpGet]
         public IActionResult Index()
         {
             ViewBag.ModuloActivo = "reportes";
-            ViewBag.RolActivo = "Administrador";
+            ViewBag.RolActivo = ObtenerNombreRol();
             ViewBag.TituloPagina = "Reportes";
-            ViewBag.SubtituloPagina = "Consulte reportes operativos, técnicos y administrativos del sistema.";
+            ViewBag.SubtituloPagina = "Consulte reportes base según su rol dentro del sistema.";
             ViewBag.BreadcrumbActual = "Reportes";
             return View();
+        }
+
+        private string ObtenerNombreRol()
+        {
+            var rolId = User.FindFirstValue(ClaimTypes.Role);
+            return rolId switch
+            {
+                "2" => "Administrador",
+                "3" => "Ingeniero",
+                _ => "Dueno"
+            };
         }
     }
 }

--- a/PSA.WebApp/Models/EvaluacionesViewModels.cs
+++ b/PSA.WebApp/Models/EvaluacionesViewModels.cs
@@ -5,6 +5,7 @@ namespace PSA.WebApp.Models
     public class BandejaEvaluacionesViewModel
     {
         public List<BandejaEvaluacionPendienteDTO> Pendientes { get; set; } = new();
+        public string EstadoFiltro { get; set; } = "Todos";
     }
 
     public class NuevaEvaluacionViewModel

--- a/PSA.WebApp/Views/Evaluaciones/FincasPendientes.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/FincasPendientes.cshtml
@@ -12,6 +12,20 @@
         <a class="boton-secundario" asp-controller="Evaluaciones" asp-action="EvaluacionesEnProceso">Evaluaciones en proceso</a>
     </div>
 
+    <section class="tarjeta-panel mb-3">
+        <form method="get" asp-action="FincasPendientes" class="d-flex gap-2 align-items-end flex-wrap">
+            <div>
+                <label for="estado" class="form-label">Filtrar por estado</label>
+                <select id="estado" name="estado" class="form-select">
+                    <option value="Todos" selected="@(Model.EstadoFiltro == "Todos")">Todos</option>
+                    <option value="Pendiente" selected="@(Model.EstadoFiltro == "Pendiente")">Pendiente</option>
+                    <option value="En proceso" selected="@(Model.EstadoFiltro == "En proceso")">En proceso</option>
+                </select>
+            </div>
+            <button type="submit" class="boton-primario">Aplicar filtro</button>
+        </form>
+    </section>
+
     <section class="tarjeta-panel">
         <div class="tabla-responsive">
             <table class="tabla-base">
@@ -22,7 +36,7 @@
                         <th>Ubicación</th>
                         <th>Hectáreas</th>
                         <th>Estado</th>
-                        <th>Acción</th>
+                        <th>Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -37,8 +51,11 @@
                             <td>@item.Hectareas.ToString("N2")</td>
                             <td><span class="badge-estado @(item.EstadoEvaluacion == "En proceso" ? "badge-info" : "badge-pendiente")">@item.EstadoEvaluacion</span></td>
                             <td>
-                                <a class="boton-link" asp-controller="Evaluaciones" asp-action="NuevaEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">
+                                <a class="boton-link me-2" asp-controller="Evaluaciones" asp-action="NuevaEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">
                                     @(item.EstadoEvaluacion == "En proceso" ? "Continuar" : "Evaluar")
+                                </a>
+                                <a class="boton-link" asp-controller="Evaluaciones" asp-action="DetalleEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">
+                                    Ver detalle
                                 </a>
                             </td>
                         </tr>
@@ -63,68 +80,3 @@
         </div>
     </section>
 </section>
-
-
-<script>
-    document.addEventListener("DOMContentLoaded", async () => {
-
-    const response = await fetch(`https://localhost:59665/api/Finca/RetrieveAll`);
-
-        try {
-            const response = await fetch(`https://localhost:59665/api/Finca/RetrieveAll`);
-
-            if (!response.ok) {
-                console.error("Error al cargar fincas");
-                return;
-            }
-
-            const fincas = await response.json();
-
-            const tabla = document.getElementById("tablaFincas");
-            tabla.innerHTML = "";
-
-            fincas.forEach(f => {
-
-                const estadoClase = f.estadoFinca === "Registrada"
-                    ? "badge-pendiente"
-                    : "badge-info";
-
-                tabla.innerHTML += `
-                    <tr>
-                        <td>${f.nombreFinca}</td>
-                        <td>${f.idPropietario}</td>
-                        <td>
-                            <span class="badge-estado ${estadoClase}">
-                                ${f.estadoFinca}
-                            </span>
-                        </td>
-                        <td>Sin iniciar</td>
-                        <td>
-                            <a class="boton-link"
-                               href="/Evaluaciones/NuevaEvaluacion?fincaId=${f.idFinca}">
-                               Evaluar
-                            </a>
-                        </td>
-                    </tr>
-                `;
-            });
-
-            if (fincas.length === 0) {
-                tabla.innerHTML = `
-                    <tr>
-                        <td colspan="5">No hay fincas registradas</td>
-                    </tr>
-                `;
-            }
-
-        } catch (error) {
-            console.error(error);
-
-            document.getElementById("tablaFincas").innerHTML = `
-                <tr>
-                    <td colspan="5">Error al cargar datos</td>
-                </tr>
-            `;
-        }
-    });
-</script>

--- a/PSA.WebApp/Views/Reportes/Index.cshtml
+++ b/PSA.WebApp/Views/Reportes/Index.cshtml
@@ -1,30 +1,67 @@
+@using System.Security.Claims
 @{
     ViewData["Title"] = "Reportes";
+    var rolId = User.FindFirstValue(ClaimTypes.Role);
+    var esDueno = rolId == "1";
+    var esAdmin = rolId == "2";
+    var esIngeniero = rolId == "3";
 }
 <section class="seccion-pagina">
     <div class="cabecera-pagina">
         <div>
             <span class="eyebrow">Consulta analítica</span>
             <h2>Reportes del sistema</h2>
-            <p>Punto de entrada para reportes operativos, técnicos y administrativos.</p>
+            <p>Pantallas base de reportes visibles según su rol.</p>
         </div>
     </div>
 
     <div class="grid-tarjetas-kpi">
-        <a class="tarjeta-kpi" asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">
-            <span class="etiqueta-kpi">Reporte técnico</span>
-            <strong>Disponible</strong>
-            <small>Evaluaciones por período</small>
-        </a>
-        <a class="tarjeta-kpi" asp-controller="Pagos" asp-action="PlanesPago">
-            <span class="etiqueta-kpi">Reporte financiero</span>
-            <strong>Disponible</strong>
-            <small>Cuotas por estado</small>
-        </a>
-        <a class="tarjeta-kpi" asp-controller="Administracion" asp-action="AuditoriaLogs">
-            <span class="etiqueta-kpi">Reporte auditoría</span>
-            <strong>Disponible</strong>
-            <small>Eventos críticos</small>
-        </a>
+        @if (esDueno)
+        {
+            <a class="tarjeta-kpi" asp-controller="Pagos" asp-action="HistorialPagos">
+                <span class="etiqueta-kpi">Reporte de dueño</span>
+                <strong>Pagos e historial</strong>
+                <small>Revise sus pagos registrados y estado.</small>
+            </a>
+            <a class="tarjeta-kpi" asp-controller="Fincas" asp-action="MisFincas">
+                <span class="etiqueta-kpi">Reporte de fincas</span>
+                <strong>Estado de fincas</strong>
+                <small>Consulte el estado general de sus fincas.</small>
+            </a>
+        }
+
+        @if (esIngeniero)
+        {
+            <a class="tarjeta-kpi" asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">
+                <span class="etiqueta-kpi">Reporte técnico</span>
+                <strong>Evaluaciones por período</strong>
+                <small>Consulte evaluaciones por filtros técnicos.</small>
+            </a>
+            <a class="tarjeta-kpi" asp-controller="Evaluaciones" asp-action="FincasIngeniero">
+                <span class="etiqueta-kpi">Reporte operativo</span>
+                <strong>Fincas del ingeniero</strong>
+                <small>Resumen de fincas evaluadas y en proceso.</small>
+            </a>
+        }
+
+        @if (esAdmin)
+        {
+            <a class="tarjeta-kpi" asp-controller="Pagos" asp-action="PlanesPago">
+                <span class="etiqueta-kpi">Reporte financiero</span>
+                <strong>Planes de pago</strong>
+                <small>Estado general de planes y cuotas.</small>
+            </a>
+            <a class="tarjeta-kpi" asp-controller="Administracion" asp-action="AuditoriaLogs">
+                <span class="etiqueta-kpi">Reporte administrativo</span>
+                <strong>Auditoría y trazabilidad</strong>
+                <small>Eventos clave y acciones administrativas.</small>
+            </a>
+        }
     </div>
+
+    <section class="tarjeta-panel mt-3">
+        <div class="lista-accesos">
+            <a class="acceso-rapido" asp-controller="Dashboard" asp-action="@(esAdmin ? "Administrador" : esIngeniero ? "Ingeniero" : "Dueno")">Volver al dashboard</a>
+        </div>
+    </section>
 </section>

--- a/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
+++ b/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
@@ -43,6 +43,7 @@
             <a class="item-menu @(moduloActivo == "dashboard" ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Dueno">Dashboard</a>
             <a class="item-menu @(moduloActivo == "fincas" ? "activo" : string.Empty)" asp-controller="Fincas" asp-action="MisFincas">Mis fincas</a>
             <a class="item-menu @(moduloActivo == "pagos" ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="HistorialPagos">Pagos</a>
+            <a class="item-menu @(moduloActivo == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
             <a class="item-menu @(moduloActivo == "notificaciones" ? "activo" : string.Empty)" asp-controller="Notificaciones" asp-action="Index">Notificaciones</a>
 
             <p class="menu-lateral__seccion">Próximamente</p>


### PR DESCRIPTION
### Motivation
- Habilitar al Ingeniero la visualización y filtrado de fincas/evaluaciones pendientes y acceso al detalle (ISSUE-24). 
- Mostrar un menú adaptado y coherente según rol (Dueño/Ingeniero/Administrador) para facilitar navegación (ISSUE-60).
- Proveer pantallas base de reportes visibles y navegables por rol (ISSUE-61).

### Description
- Se añadió el parámetro `estado` a `FincasPendientes` en `PSA.WebApp/Controllers/EvaluacionesController.cs` y se aplica filtrado sobre la bandeja obtenida desde API/DAO.  
- Se extendió `BandejaEvaluacionesViewModel` (`PSA.WebApp/Models/EvaluacionesViewModels.cs`) con `EstadoFiltro` para preservar el estado seleccionado.  
- Se actualizó la vista `PSA.WebApp/Views/Evaluaciones/FincasPendientes.cshtml` para incluir un selector de estado (`Todos`, `Pendiente`, `En proceso`), botones de acción `Evaluar`/`Continuar` y enlace `Ver detalle`, y se eliminó el script embebido obsoleto.  
- `ReportesController` (`PSA.WebApp/Controllers/ReportesController.cs`) ahora permite `Authorize(Roles = "1,2,3")`, determina el rol activo con `ObtenerNombreRol()` y ajusta el contexto visual.  
- La vista `PSA.WebApp/Views/Reportes/Index.cshtml` renderiza tarjetas de reportes adaptadas a `Dueño`, `Ingeniero` y `Administrador` y añade el acceso rápido para volver al dashboard correspondiente.  
- Se agregó enlace a `Reportes` en la barra lateral del Dueño en `PSA.WebApp/Views/Shared/_BarraLateral.cshtml` para mantener coherencia de navegación por rol.  
- Cambios registrados con un commit que integra los archivos modificados: controladores, vistas y modelos relacionados.

### Testing
- Intenté compilar con `dotnet build PSA.WebApp/PSA.WebApp.csproj`, pero el entorno devolvió `dotnet: command not found`, por lo que la compilación no pudo ejecutarse.  
- No se ejecutaron otras pruebas automatizadas en este entorno por la ausencia de SDK/runner; los cambios quedaron validados por revisión de diffs y ejecución de comandos de git local (`git commit`) exitoso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef031bbc0832dac4dc7c22554934c)