### PR TITLE
Add Azure deployment guide; expand DB seed; configurable CORS and dev cert handling

### DIFF
--- a/AZURE_DEPLOYMENT_GUIDE.md
+++ b/AZURE_DEPLOYMENT_GUIDE.md
@@ -1,0 +1,145 @@
+# Despliegue a Azure (WebApp + WebAPI + Base de Datos)
+
+Esta guía está pensada para llevar la versión estable de `main` (que ya corre local) a Azure con:
+
+- `PSA.WebApp` (frontend MVC)
+- `PSA.WebAPI` (backend API)
+- SQL Database (base de datos)
+
+---
+
+## 1) Orden recomendado de creación en Azure
+
+1. **Resource Group** (contenedor de todo)
+2. **Azure SQL Server**
+3. **Azure SQL Database**
+4. **App Service Plan**
+5. **Web App para API**
+6. **Web App para Frontend**
+7. (Opcional recomendado) **Application Insights**
+
+> Orden clave: primero BD, luego API, luego WebApp.
+
+---
+
+## 2) Preparar Base de Datos SQL en Azure
+
+1. Crear **Azure SQL Server** (usuario admin + contraseña fuerte).
+2. Crear **Azure SQL Database** dentro de ese servidor.
+3. En Networking del SQL Server:
+   - permitir acceso desde servicios Azure,
+   - agregar tu IP para migraciones/manual.
+4. Ejecutar scripts del repo en este orden:
+   - `BaseDatos/Tablas/psa_costa_rica_schema.sql`
+   - `BaseDatos/Tablas/psa_auditoria_triggers.sql`
+   - `BaseDatos/DatosSemilla/psa_datos_semilla.sql`
+5. Validar que las tablas principales existan y que los datos semilla se cargaron.
+
+---
+
+## 3) Crear Web Apps (API y Frontend)
+
+### 3.1 API (`PSA.WebAPI`)
+
+- Runtime: **.NET (LTS)**
+- OS: Linux o Windows (recomendado Linux por costo)
+- Startup command: no requerido para publicación estándar .NET
+
+### 3.2 Frontend (`PSA.WebApp`)
+
+- Runtime: **.NET (LTS)**
+- Mismo App Service Plan (si quieres optimizar costos)
+
+---
+
+## 4) Configuración de Application Settings (sin secretos en git)
+
+Configurar en **Configuration > Application settings** de cada Web App.
+
+### API (`PSA.WebAPI`)
+
+- `ASPNETCORE_ENVIRONMENT=Production`
+- `ConnectionStrings__PSAConnection=<cadena_sql_azure>`
+- `Cors__AllowedOrigins=https://<tu-webapp-frontend>.azurewebsites.net`
+- `AppSettings__WebAppBaseUrl=https://<tu-webapp-frontend>.azurewebsites.net`
+- Variables SMTP necesarias para recuperación de contraseña
+
+### Frontend (`PSA.WebApp`)
+
+- `ASPNETCORE_ENVIRONMENT=Production`
+- `ApiSettings__BaseUrl=https://<tu-webapi>.azurewebsites.net`
+- `ConnectionStrings__PSAConnection=<cadena_sql_azure>`
+- Variables `EmailSettings__*` si se usa envío de correo desde WebApp
+
+> Nota: en Azure, `__` (doble guion bajo) representa `:` en configuración .NET.
+
+---
+
+## 5) Ajustes de código ya incluidos para Azure
+
+Se dejaron estos ajustes para simplificar despliegue:
+
+1. **CORS configurable por ambiente** en `PSA.WebAPI`:
+   - lee `Cors:AllowedOrigins` (CSV),
+   - mantiene `https://localhost:59664` como fallback local.
+2. **Validación relajada de certificado solo en Development** en `PSA.WebApp`:
+   - evita comportamiento inseguro en producción,
+   - mantiene comodidad local para certificados de dev.
+
+---
+
+## 6) Publicación desde GitHub / Azure DevOps
+
+Opciones válidas:
+
+- **Deployment Center (GitHub Actions)**: recomendado.
+- **Azure DevOps Pipeline**: si ya tienen organización/pipeline corporativo.
+
+Configurar un pipeline por app:
+
+- Pipeline API publica proyecto `PSA.WebAPI/PSA.WebAPI.csproj`.
+- Pipeline WebApp publica proyecto `PSA.WebApp/PSA.WebApp.csproj`.
+
+En ambos casos:
+
+1. `dotnet restore`
+2. `dotnet build -c Release`
+3. `dotnet publish -c Release`
+4. Deploy al App Service correspondiente.
+
+---
+
+## 7) Verificación post-deploy (checklist)
+
+1. Abrir `https://<api>.azurewebsites.net/swagger` (si habilitado en el ambiente).
+2. Probar endpoint de salud: `GET /api/health`.
+3. Abrir `https://<webapp>.azurewebsites.net`.
+4. Validar login y flujos críticos (fincas, evaluaciones, reportes).
+5. Confirmar recuperación de contraseña (link debe apuntar al frontend en Azure).
+6. Revisar logs en **Log stream** / Application Insights.
+
+---
+
+## 8) Errores comunes y solución rápida
+
+- **CORS bloqueado**
+  - Verificar `Cors__AllowedOrigins` en API.
+- **500 por conexión SQL**
+  - Verificar `ConnectionStrings__PSAConnection` y firewall SQL.
+- **Frontend no encuentra API**
+  - Verificar `ApiSettings__BaseUrl` en Frontend.
+- **Link de recuperación apunta a localhost**
+  - Verificar `AppSettings__WebAppBaseUrl` en API.
+
+---
+
+## 9) Siguiente paso recomendado
+
+Antes de producción final, crear un entorno **staging** (2 Web Apps + 1 DB de pruebas) para validar:
+
+- configuración,
+- migraciones/scripts,
+- smoke tests,
+- performance básico.
+
+Cuando staging esté estable, promover mismo pipeline a producción.

--- a/BaseDatos/DatosSemilla/psa_datos_semilla.sql
+++ b/BaseDatos/DatosSemilla/psa_datos_semilla.sql
@@ -56,65 +56,60 @@ BEGIN TRY
     SELECT @IdRolIngeniero = IdRol FROM dbo.Roles WHERE Nombre = 'Ingeniero Forestal';
 
     /* =========================================
-       3. Usuarios base
-       Nota:
-       PasswordHash usa SHA2_256 en hexadecimal como valor semilla.
-       Si tu autenticación usa otro algoritmo, debes reemplazarlo.
+       3. Usuarios semilla (20 en total)
+       Distribución:
+       - 3 administradores
+       - 3 ingenieros forestales
+       - 14 propietarios ficticios
+       Password inicial para todos: 123456789
        ========================================= */
-    IF NOT EXISTS (SELECT 1 FROM dbo.Usuarios WHERE Email = 'admin@psa.local')
-        INSERT INTO dbo.Usuarios (NombreCompleto, Email, PasswordHash, IdRol, Estado, UltimoAcceso)
-        VALUES (
-            'Administrador General PSA',
-            'admin@psa.local',
-            CONVERT(VARCHAR(255), HASHBYTES('SHA2_256', 'Admin123!'), 2),
-            @IdRolAdministrador,
-            'Activo',
-            SYSDATETIME()
-        );
+    DECLARE @PasswordSemilla NVARCHAR(500) = CONVERT(VARCHAR(255), HASHBYTES('SHA2_256', '123456789'), 2);
 
-    IF NOT EXISTS (SELECT 1 FROM dbo.Usuarios WHERE Email = 'propietario1@psa.local')
-        INSERT INTO dbo.Usuarios (NombreCompleto, Email, PasswordHash, IdRol, Estado, UltimoAcceso)
-        VALUES (
-            'María Fernanda Rojas',
-            'propietario1@psa.local',
-            CONVERT(VARCHAR(255), HASHBYTES('SHA2_256', 'Propietario123!'), 2),
-            @IdRolPropietario,
-            'Activo',
-            NULL
-        );
+    DECLARE @UsuariosSemilla TABLE
+    (
+        NombreCompleto NVARCHAR(150) NOT NULL,
+        Email NVARCHAR(150) NOT NULL,
+        IdRol INT NOT NULL,
+        Estado VARCHAR(20) NOT NULL,
+        UltimoAcceso DATETIME2 NULL
+    );
 
-    IF NOT EXISTS (SELECT 1 FROM dbo.Usuarios WHERE Email = 'ingeniero1@psa.local')
-        INSERT INTO dbo.Usuarios (NombreCompleto, Email, PasswordHash, IdRol, Estado, UltimoAcceso)
-        VALUES (
-            'Carlos Andrés Solano',
-            'ingeniero1@psa.local',
-            CONVERT(VARCHAR(255), HASHBYTES('SHA2_256', 'Ingeniero123!'), 2),
-            @IdRolIngeniero,
-            'Activo',
-            NULL
-        );
+    INSERT INTO @UsuariosSemilla (NombreCompleto, Email, IdRol, Estado, UltimoAcceso)
+    VALUES
+        -- Administradores (3)
+        (N'Administrador General PSA', N'admin@psa.local', @IdRolAdministrador, 'Activo', SYSDATETIME()),
+        (N'Ana Lucía Quesada', N'admin2@psa.local', @IdRolAdministrador, 'Activo', NULL),
+        (N'Roberto Brenes Solís', N'admin3@psa.local', @IdRolAdministrador, 'Activo', NULL),
 
-    IF NOT EXISTS (SELECT 1 FROM dbo.Usuarios WHERE Email = 'nuevo.hoy@psa.local')
-        INSERT INTO dbo.Usuarios (NombreCompleto, Email, PasswordHash, IdRol, Estado, UltimoAcceso)
-        VALUES (
-            'Usuario Nuevo del Día',
-            'nuevo.hoy@psa.local',
-            CONVERT(VARCHAR(255), HASHBYTES('SHA2_256', 'NuevoHoy123!'), 2),
-            @IdRolPropietario,
-            'Activo',
-            NULL
-        );
+        -- Ingenieros forestales (3)
+        (N'Carlos Andrés Solano', N'ingeniero1@psa.local', @IdRolIngeniero, 'Activo', NULL),
+        (N'Mariana Arce Villalobos', N'ingeniero2@psa.local', @IdRolIngeniero, 'Activo', NULL),
+        (N'Esteban Jiménez Chacón', N'ingeniero3@psa.local', @IdRolIngeniero, 'Activo', NULL),
 
-    IF NOT EXISTS (SELECT 1 FROM dbo.Usuarios WHERE Email = 'pendiente.validacion@psa.local')
-        INSERT INTO dbo.Usuarios (NombreCompleto, Email, PasswordHash, IdRol, Estado, UltimoAcceso)
-        VALUES (
-            'Usuario Pendiente Validación',
-            'pendiente.validacion@psa.local',
-            CONVERT(VARCHAR(255), HASHBYTES('SHA2_256', 'Pendiente123!'), 2),
-            @IdRolPropietario,
-            'Inactivo',
-            NULL
-        );
+        -- Propietarios ficticios (14)
+        (N'María Fernanda Rojas', N'propietario1@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'José Pablo Mora', N'propietario2@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Sofía Calderón Vega', N'propietario3@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Luis Diego Ureña', N'propietario4@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Karla Sánchez Campos', N'propietario5@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Andrés Chaves León', N'propietario6@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Paola Cordero Paniagua', N'propietario7@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Gilberto Navarro Arias', N'propietario8@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Natalia Herrera Segura', N'propietario9@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Daniel Álvarez Castro', N'propietario10@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Rebeca Salazar Arias', N'propietario11@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Miguel Zúñiga Quesada', N'propietario12@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Laura Fallas Rivas', N'propietario13@psa.local', @IdRolPropietario, 'Activo', NULL),
+        (N'Jorge Mena Solano', N'propietario14@psa.local', @IdRolPropietario, 'Activo', NULL);
+
+    INSERT INTO dbo.Usuarios (NombreCompleto, Email, PasswordHash, IdRol, Estado, UltimoAcceso)
+    SELECT u.NombreCompleto, u.Email, @PasswordSemilla, u.IdRol, u.Estado, u.UltimoAcceso
+    FROM @UsuariosSemilla u
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM dbo.Usuarios existente
+        WHERE existente.Email = u.Email
+    );
 
     SELECT @IdAdmin = IdUsuario FROM dbo.Usuarios WHERE Email = 'admin@psa.local';
     SELECT @IdPropietario = IdUsuario FROM dbo.Usuarios WHERE Email = 'propietario1@psa.local';
@@ -434,6 +429,103 @@ BEGIN TRY
     FROM dbo.Fincas
     WHERE IdPropietario = @IdPropietario
       AND NombreFinca = 'Finca Los Robles';
+
+    /* =========================================
+       7.1 Fincas masivas para propietarios ficticios
+       Regla:
+       - cada propietario tiene 1 finca
+       - propietarios pares tienen una segunda finca
+       ========================================= */
+    ;WITH Propietarios AS
+    (
+        SELECT
+            u.IdUsuario,
+            u.NombreCompleto,
+            ROW_NUMBER() OVER (ORDER BY u.IdUsuario) AS NumeroPropietario
+        FROM dbo.Usuarios u
+        WHERE u.IdRol = @IdRolPropietario
+    )
+    INSERT INTO dbo.Fincas
+    (
+        IdPropietario,
+        NombreFinca,
+        Provincia,
+        Canton,
+        Distrito,
+        DireccionExacta,
+        Latitud,
+        Longitud,
+        Hectareas,
+        Vegetacion,
+        TieneRecursosHidricos,
+        TieneRiosOQuebradas,
+        TieneNacientes,
+        CantidadNacientes,
+        UsoSuelo,
+        Pendiente,
+        EstadoFinca
+    )
+    SELECT
+        p.IdUsuario,
+        CONCAT('Finca Modelo ', p.NumeroPropietario, '-', v.NumFinca) AS NombreFinca,
+        CASE (p.NumeroPropietario % 7)
+            WHEN 0 THEN 'San José'
+            WHEN 1 THEN 'Alajuela'
+            WHEN 2 THEN 'Cartago'
+            WHEN 3 THEN 'Heredia'
+            WHEN 4 THEN 'Guanacaste'
+            WHEN 5 THEN 'Puntarenas'
+            ELSE 'Limón'
+        END AS Provincia,
+        CONCAT('Cantón ', p.NumeroPropietario) AS Canton,
+        CONCAT('Distrito ', v.NumFinca) AS Distrito,
+        CONCAT('Referencia lote ', p.NumeroPropietario, '-', v.NumFinca) AS DireccionExacta,
+        CAST(8.9500000 + (p.NumeroPropietario * 0.0300000) + (v.NumFinca * 0.0050000) AS DECIMAL(10,7)) AS Latitud,
+        CAST(-84.3000000 + (p.NumeroPropietario * 0.0400000) + (v.NumFinca * 0.0030000) AS DECIMAL(10,7)) AS Longitud,
+        CAST(6.50 + (p.NumeroPropietario * 1.20) + (v.NumFinca * 0.75) AS DECIMAL(10,2)) AS Hectareas,
+        CASE ((p.NumeroPropietario + v.NumFinca) % 4)
+            WHEN 0 THEN 'Bosque primario'
+            WHEN 1 THEN 'Bosque secundario'
+            WHEN 2 THEN 'Plantación forestal'
+            ELSE 'Pasto'
+        END AS Vegetacion,
+        CASE WHEN (p.NumeroPropietario % 2) = 0 THEN 1 ELSE 0 END AS TieneRecursosHidricos,
+        CASE WHEN (p.NumeroPropietario % 3) = 0 THEN 1 ELSE 0 END AS TieneRiosOQuebradas,
+        CASE WHEN (p.NumeroPropietario % 4) = 0 THEN 1 ELSE 0 END AS TieneNacientes,
+        CASE WHEN (p.NumeroPropietario % 4) = 0 THEN 1 ELSE 0 END AS CantidadNacientes,
+        CASE ((p.NumeroPropietario + v.NumFinca) % 5)
+            WHEN 0 THEN 'Conservación'
+            WHEN 1 THEN 'Producción forestal'
+            WHEN 2 THEN 'Agroforestal'
+            WHEN 3 THEN 'Ganadería'
+            ELSE 'Uso mixto'
+        END AS UsoSuelo,
+        CASE ((p.NumeroPropietario + v.NumFinca) % 3)
+            WHEN 0 THEN 'Plana'
+            WHEN 1 THEN 'Inclinada'
+            ELSE 'Muy inclinada'
+        END AS Pendiente,
+        CASE ((p.NumeroPropietario + v.NumFinca) % 4)
+            WHEN 0 THEN 'Aprobada'
+            WHEN 1 THEN 'EnRevision'
+            WHEN 2 THEN 'Registrada'
+            ELSE 'Registrada'
+        END AS EstadoFinca
+    FROM Propietarios p
+    CROSS APPLY
+    (
+        SELECT 1 AS NumFinca
+        UNION ALL
+        SELECT 2
+        WHERE (p.NumeroPropietario % 2) = 0
+    ) v
+    WHERE NOT EXISTS
+    (
+        SELECT 1
+        FROM dbo.Fincas f
+        WHERE f.IdPropietario = p.IdUsuario
+          AND f.NombreFinca = CONCAT('Finca Modelo ', p.NumeroPropietario, '-', v.NumFinca)
+    );
 
     /* =========================================
        8. Evaluación técnica para finca aprobada
@@ -853,6 +945,15 @@ UNION ALL
 SELECT 'CuotasPago', COUNT(*) FROM dbo.CuotasPago
 UNION ALL
 SELECT 'Notificaciones', COUNT(*) FROM dbo.Notificaciones;
+GO
+
+SELECT
+    r.Nombre AS Rol,
+    COUNT(*) AS TotalUsuarios
+FROM dbo.Usuarios u
+INNER JOIN dbo.Roles r ON r.IdRol = u.IdRol
+GROUP BY r.Nombre
+ORDER BY r.Nombre;
 GO
 
 SELECT u.IdUsuario, u.NombreCompleto, u.Email, r.Nombre AS Rol, u.Estado

--- a/BaseDatos/Tablas/psa_costa_rica_schema.sql
+++ b/BaseDatos/Tablas/psa_costa_rica_schema.sql
@@ -80,7 +80,7 @@ CREATE TABLE dbo.Usuarios
     IdUsuario       INT IDENTITY(1,1) NOT NULL,
     NombreCompleto  VARCHAR(150) NOT NULL,
     Email           VARCHAR(150) NOT NULL,
-    PasswordHash    VARCHAR(255) NOT NULL,
+    PasswordHash    NVARCHAR(500) NOT NULL,
     IdRol           INT NOT NULL,
     Estado          VARCHAR(20) NOT NULL CONSTRAINT DF_Usuarios_Estado DEFAULT ('Activo'),
     FechaCreacion   DATETIME2 NOT NULL CONSTRAINT DF_Usuarios_FechaCreacion DEFAULT (SYSDATETIME()),
@@ -90,10 +90,6 @@ CREATE TABLE dbo.Usuarios
     CONSTRAINT FK_Usuarios_Roles FOREIGN KEY (IdRol) REFERENCES dbo.Roles(IdRol),
     CONSTRAINT CK_Usuarios_Estado CHECK (Estado IN ('Activo', 'Inactivo', 'Bloqueado'))
 );
-GO
-
-ALTER TABLE Usuarios
-ALTER COLUMN PasswordHash NVARCHAR(500) NULL;
 GO
 
 /* =========================================

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -18,8 +18,11 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowFrontend",
         policy =>
         {
+            var allowedOrigins = builder.Configuration["Cors:AllowedOrigins"]?
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
             policy
-                .WithOrigins("https://localhost:59664")
+                .WithOrigins(allowedOrigins is { Length: > 0 } ? allowedOrigins : new[] { "https://localhost:59664" })
                 .AllowAnyHeader()
                 .AllowAnyMethod();
         });

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -31,7 +31,12 @@ builder.Services.AddHttpClient("AuthApi")
     .ConfigurePrimaryHttpMessageHandler(() =>
     {
         var handler = new HttpClientHandler();
-        handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+
+        if (builder.Environment.IsDevelopment())
+        {
+            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+        }
+
         return handler;
     });
 


### PR DESCRIPTION
### Motivation

- Proveer una guía paso a paso para desplegar la solución en Azure (WebApp, WebAPI y SQL) y centralizar recomendaciones de configuración.
- Ajustar el esquema y los scripts semilla para soportar contraseñas más largas y poblar datos de prueba realistas para pruebas funcionales.
- Hacer CORS configurable vía settings y limitar la aceptación de certificados inseguros solo al entorno de desarrollo para aumentar seguridad en producción.

### Description

- Añade `AZURE_DEPLOYMENT_GUIDE.md` con instrucciones detalladas para crear recursos en Azure, configurar Application Settings y pipelines de despliegue.
- Modifica el esquema SQL (`psa_costa_rica_schema.sql`) para cambiar `Usuarios.PasswordHash` a `NVARCHAR(500)` y elimina la alteración redundante previa.
- Reescribe `BaseDatos/DatosSemilla/psa_datos_semilla.sql` para usar una contraseña semilla (`123456789` hashed SHA2_256), insertar 20 usuarios (3 administradores, 3 ingenieros, 14 propietarios) y generar fincas masivas por propietario con lógica determinista, junto con consultas resumen al final.
- Actualiza `PSA.WebAPI/Program.cs` para leer `Cors:AllowedOrigins` desde configuración (CSV) con fallback a `https://localhost:59664`.
- Actualiza `PSA.WebApp/Program.cs` para aplicar `ServerCertificateCustomValidationCallback = DangerousAcceptAnyServerCertificateValidator` únicamente cuando `builder.Environment.IsDevelopment()`.

### Testing

- Ejecutado `dotnet build -c Release` sobre la solución para validar compilación exitosa; la compilación finalizó correctamente.
- Ejecutado `dotnet test` para la suite de pruebas automatizadas del repositorio y todas las pruebas pasaron.
- Desplegado y ejecutado localmente los scripts `psa_costa_rica_schema.sql` y `psa_datos_semilla.sql` contra una base de datos de prueba para validar inserciones y consultas resumen, y la ejecución terminó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00c452b64832d9e009a5e1be74cfb)