### PR TITLE
Add reporting views/API and make EvaluacionesTecnicas.IdIngeniero nullable; seed & UI fixes

### DIFF
--- a/BaseDatos/DatosSemilla/psa_datos_semilla.sql
+++ b/BaseDatos/DatosSemilla/psa_datos_semilla.sql
@@ -324,9 +324,9 @@ BEGIN TRY
         INSERT INTO dbo.CatalogoFincaValores (TipoCatalogo, Valor, Activo, OrdenVisual)
         VALUES ('UsoSuelo', 'Ganadería', 1, 4);
 
-    IF NOT EXISTS (SELECT 1 FROM dbo.CatalogoFincaValores WHERE TipoCatalogo = 'UsoSuelo' AND Valor = 'Uso mixto')
+    IF NOT EXISTS (SELECT 1 FROM dbo.CatalogoFincaValores WHERE TipoCatalogo = 'UsoSuelo' AND Valor = 'Mixto')
         INSERT INTO dbo.CatalogoFincaValores (TipoCatalogo, Valor, Activo, OrdenVisual)
-        VALUES ('UsoSuelo', 'Uso mixto', 1, 5);
+        VALUES ('UsoSuelo', 'Mixto', 1, 5);
 
     /* =========================================
        7. Fincas de ejemplo
@@ -436,13 +436,13 @@ BEGIN TRY
       AND NombreFinca = 'Finca Los Robles';
 
     /* =========================================
-       8. Evaluación técnica para finca aprobada
+       8. Evaluaciones técnicas para fincas semilla
        ========================================= */
     IF NOT EXISTS (
         SELECT 1
         FROM dbo.EvaluacionesTecnicas
         WHERE IdFinca = @IdFincaAprobada
-          AND IdIngeniero = @IdIngeniero
+          AND EstadoEvaluacion IN ('Evaluada – Califica', 'Finalizada')
     )
         INSERT INTO dbo.EvaluacionesTecnicas
         (
@@ -463,7 +463,7 @@ BEGIN TRY
         (
             @IdFincaAprobada,
             @IdIngeniero,
-            'Finalizada',
+            'Evaluada – Califica',
             DATEFROMPARTS(@AnioBase, 2, 10),
             N'La finca presenta cobertura boscosa continua y condiciones favorables para PSA.',
             'Califica',
@@ -478,8 +478,44 @@ BEGIN TRY
     SELECT TOP (1) @IdEvaluacion = IdEvaluacion
     FROM dbo.EvaluacionesTecnicas
     WHERE IdFinca = @IdFincaAprobada
-      AND IdIngeniero = @IdIngeniero
+      AND EstadoEvaluacion IN ('Evaluada – Califica', 'Finalizada')
     ORDER BY IdEvaluacion;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM dbo.EvaluacionesTecnicas
+        WHERE IdFinca = @IdFincaPendiente
+    )
+        INSERT INTO dbo.EvaluacionesTecnicas
+        (
+            IdFinca,
+            IdIngeniero,
+            EstadoEvaluacion,
+            FechaVisita,
+            Observaciones,
+            DecisionTecnica,
+            HectareasAjustadas,
+            VegetacionAjustada,
+            RecursosHidricosAjustado,
+            UsoSueloAjustado,
+            PendienteAjustada,
+            FechaDecision
+        )
+        VALUES
+        (
+            @IdFincaPendiente,
+            NULL,
+            'Pendiente',
+            NULL,
+            N'Evaluación generada automáticamente para nueva finca de semilla.',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL
+        );
 
     /* =========================================
        9. Plan de pago para finca aprobada

--- a/BaseDatos/Migraciones/2026-04-arreglo-arqui2-idingeniero-nullable.sql
+++ b/BaseDatos/Migraciones/2026-04-arreglo-arqui2-idingeniero-nullable.sql
@@ -1,0 +1,62 @@
+/*
+  Ajuste ArregloArqui2
+  Objetivo:
+  - Garantizar que IdIngeniero permita NULL en EvaluacionesTecnicas
+    para crear evaluaciones pendientes sin ingeniero asignado.
+*/
+
+USE PSA_CostaRica;
+GO
+
+BEGIN TRY
+    BEGIN TRANSACTION;
+
+    IF COL_LENGTH('dbo.EvaluacionesTecnicas', 'IdIngeniero') IS NOT NULL
+    BEGIN
+        DECLARE @isNullable BIT;
+
+        SELECT @isNullable = c.is_nullable
+        FROM sys.columns c
+        INNER JOIN sys.tables t ON t.object_id = c.object_id
+        WHERE t.name = 'EvaluacionesTecnicas'
+          AND c.name = 'IdIngeniero';
+
+        IF (@isNullable = 0)
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM sys.foreign_keys
+                WHERE name = 'FK_Evaluaciones_Usuarios_Ingeniero'
+                  AND parent_object_id = OBJECT_ID('dbo.EvaluacionesTecnicas')
+            )
+            BEGIN
+                ALTER TABLE dbo.EvaluacionesTecnicas
+                    DROP CONSTRAINT FK_Evaluaciones_Usuarios_Ingeniero;
+            END
+
+            ALTER TABLE dbo.EvaluacionesTecnicas
+                ALTER COLUMN IdIngeniero INT NULL;
+
+            IF NOT EXISTS (
+                SELECT 1
+                FROM sys.foreign_keys
+                WHERE name = 'FK_Evaluaciones_Usuarios_Ingeniero'
+                  AND parent_object_id = OBJECT_ID('dbo.EvaluacionesTecnicas')
+            )
+            BEGIN
+                ALTER TABLE dbo.EvaluacionesTecnicas
+                    ADD CONSTRAINT FK_Evaluaciones_Usuarios_Ingeniero
+                    FOREIGN KEY (IdIngeniero) REFERENCES dbo.Usuarios(IdUsuario);
+            END
+        END
+    END
+
+    COMMIT TRANSACTION;
+END TRY
+BEGIN CATCH
+    IF @@TRANCOUNT > 0
+        ROLLBACK TRANSACTION;
+
+    THROW;
+END CATCH;
+GO

--- a/BaseDatos/Tablas/psa_costa_rica_schema.sql
+++ b/BaseDatos/Tablas/psa_costa_rica_schema.sql
@@ -21,6 +21,16 @@ GO
    ========================================= */
 IF OBJECT_ID(N'dbo.vw_FincasMapa', N'V') IS NOT NULL
     DROP VIEW dbo.vw_FincasMapa;
+IF OBJECT_ID(N'dbo.vw_ReportePagosMensualesDueno', N'V') IS NOT NULL
+    DROP VIEW dbo.vw_ReportePagosMensualesDueno;
+IF OBJECT_ID(N'dbo.vw_ReporteTransaccionesPagosDueno', N'V') IS NOT NULL
+    DROP VIEW dbo.vw_ReporteTransaccionesPagosDueno;
+IF OBJECT_ID(N'dbo.vw_ReporteEvaluacionesIngeniero', N'V') IS NOT NULL
+    DROP VIEW dbo.vw_ReporteEvaluacionesIngeniero;
+IF OBJECT_ID(N'dbo.vw_ReportePagosPorUbicacion', N'V') IS NOT NULL
+    DROP VIEW dbo.vw_ReportePagosPorUbicacion;
+IF OBJECT_ID(N'dbo.vw_ResumenActividadSistema', N'V') IS NOT NULL
+    DROP VIEW dbo.vw_ResumenActividadSistema;
 GO
 
 IF OBJECT_ID(N'dbo.Notificaciones', N'U') IS NOT NULL DROP TABLE dbo.Notificaciones;
@@ -146,7 +156,7 @@ CREATE TABLE dbo.Fincas
     CONSTRAINT CK_Fincas_Longitud CHECK (Longitud BETWEEN -180 AND 180),
     CONSTRAINT CK_Fincas_Hectareas CHECK (Hectareas > 0),
     CONSTRAINT CK_Fincas_CantidadNacientes CHECK (CantidadNacientes >= 0 AND (TieneNacientes = 1 OR CantidadNacientes = 0)),
-    CONSTRAINT CK_Fincas_Estado CHECK (EstadoFinca IN ('Registrada', 'EnRevision', 'Aprobada', 'Rechazada', 'Inactiva'))
+    CONSTRAINT CK_Fincas_Estado CHECK (EstadoFinca IN ('Registrada', 'Pendiente', 'EnRevision', 'En proceso', 'Aprobada', 'Rechazada', 'Suspendida', 'Inactiva'))
 );
 GO
 
@@ -157,7 +167,7 @@ CREATE TABLE dbo.EvaluacionesTecnicas
 (
     IdEvaluacion                 INT IDENTITY(1,1) NOT NULL,
     IdFinca                      INT NOT NULL,
-    IdIngeniero                  INT NOT NULL,
+    IdIngeniero                  INT NULL,
     EstadoEvaluacion             VARCHAR(30) NOT NULL CONSTRAINT DF_Evaluaciones_Estado DEFAULT ('Pendiente'),
     FechaVisita                  DATE NULL,
     Observaciones                NVARCHAR(MAX) NULL,
@@ -171,7 +181,19 @@ CREATE TABLE dbo.EvaluacionesTecnicas
     CONSTRAINT PK_EvaluacionesTecnicas PRIMARY KEY (IdEvaluacion),
     CONSTRAINT FK_Evaluaciones_Fincas FOREIGN KEY (IdFinca) REFERENCES dbo.Fincas(IdFinca),
     CONSTRAINT FK_Evaluaciones_Usuarios_Ingeniero FOREIGN KEY (IdIngeniero) REFERENCES dbo.Usuarios(IdUsuario),
-    CONSTRAINT CK_Evaluaciones_Estado CHECK (EstadoEvaluacion IN ('Pendiente', 'En Proceso', 'Finalizada')),
+    CONSTRAINT CK_Evaluaciones_Estado CHECK (
+        EstadoEvaluacion IN (
+            'Pendiente',
+            'En Proceso',
+            'Finalizada',
+            'En proceso',
+            'Evaluada – No califica',
+            'Evaluada – Califica',
+            'Pendiente de cuenta bancaria',
+            'Pendiente de aprobación final de pago',
+            'Pagos activos'
+        )
+    ),
     CONSTRAINT CK_Evaluaciones_Decision CHECK (DecisionTecnica IS NULL OR DecisionTecnica IN ('Califica', 'No Califica')),
     CONSTRAINT CK_Evaluaciones_HectareasAjustadas CHECK (HectareasAjustadas IS NULL OR HectareasAjustadas > 0)
 );
@@ -433,6 +455,114 @@ SELECT
 FROM dbo.Fincas f
 INNER JOIN dbo.Usuarios u
     ON u.IdUsuario = f.IdPropietario;
+GO
+
+/* =========================================
+   Vistas para reportes y análisis de datos
+   ========================================= */
+CREATE VIEW dbo.vw_ReportePagosMensualesDueno
+AS
+SELECT
+    pp.IdPlanPago,
+    f.IdFinca,
+    f.IdPropietario,
+    f.NombreFinca,
+    pp.Anio,
+    cp.Mes,
+    cp.FechaProgramada,
+    pp.MontoBaseMensual,
+    pp.PorcentajeAjusteTotal,
+    cp.MontoProgramado AS MontoMensualCalculado,
+    cp.MontoPendiente,
+    cp.EstadoCuota
+FROM dbo.PlanesPago pp
+INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+INNER JOIN dbo.CuotasPago cp ON cp.IdPlanPago = pp.IdPlanPago;
+GO
+
+CREATE VIEW dbo.vw_ReporteTransaccionesPagosDueno
+AS
+SELECT
+    tp.IdTransaccionPago,
+    tp.FechaTransaccion,
+    tp.MontoTotal,
+    tp.EstadoTransaccion,
+    tp.ReferenciaExterna,
+    tp.Observaciones,
+    pp.IdPlanPago,
+    pp.Anio,
+    f.IdFinca,
+    f.IdPropietario,
+    f.NombreFinca,
+    f.Provincia,
+    f.Canton,
+    f.Distrito
+FROM dbo.TransaccionesPago tp
+INNER JOIN dbo.PlanesPago pp ON pp.IdPlanPago = tp.IdPlanPago
+INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca;
+GO
+
+CREATE VIEW dbo.vw_ReporteEvaluacionesIngeniero
+AS
+SELECT
+    e.IdEvaluacion,
+    e.IdIngeniero,
+    u.NombreCompleto AS Ingeniero,
+    e.EstadoEvaluacion,
+    e.DecisionTecnica,
+    e.FechaVisita,
+    e.FechaDecision,
+    f.IdFinca,
+    f.NombreFinca,
+    f.Provincia,
+    f.Canton,
+    f.Distrito
+FROM dbo.EvaluacionesTecnicas e
+LEFT JOIN dbo.Usuarios u ON u.IdUsuario = e.IdIngeniero
+INNER JOIN dbo.Fincas f ON f.IdFinca = e.IdFinca;
+GO
+
+CREATE VIEW dbo.vw_ReportePagosPorUbicacion
+AS
+SELECT
+    f.Provincia,
+    f.Canton,
+    f.Distrito,
+    pp.Anio,
+    cp.Mes,
+    SUM(cp.MontoProgramado - cp.MontoPendiente) AS MontoPagadoMes,
+    SUM(cp.MontoProgramado) AS MontoProgramadoMes
+FROM dbo.CuotasPago cp
+INNER JOIN dbo.PlanesPago pp ON pp.IdPlanPago = cp.IdPlanPago
+INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+GROUP BY
+    f.Provincia,
+    f.Canton,
+    f.Distrito,
+    pp.Anio,
+    cp.Mes;
+GO
+
+CREATE VIEW dbo.vw_ResumenActividadSistema
+AS
+SELECT 'Usuarios activos' AS Indicador, CAST(COUNT_BIG(1) AS BIGINT) AS Total
+FROM dbo.Usuarios
+WHERE Estado = 'Activo'
+UNION ALL
+SELECT 'Fincas registradas', CAST(COUNT_BIG(1) AS BIGINT)
+FROM dbo.Fincas
+UNION ALL
+SELECT 'Evaluaciones pendientes', CAST(COUNT_BIG(1) AS BIGINT)
+FROM dbo.EvaluacionesTecnicas
+WHERE EstadoEvaluacion IN ('Pendiente', 'En proceso', 'En Proceso')
+UNION ALL
+SELECT 'Planes de pago activos', CAST(COUNT_BIG(1) AS BIGINT)
+FROM dbo.PlanesPago
+WHERE EstadoPlan = 'Activo'
+UNION ALL
+SELECT 'Transacciones procesadas', CAST(COUNT_BIG(1) AS BIGINT)
+FROM dbo.TransaccionesPago
+WHERE EstadoTransaccion = 'Procesada';
 GO
 
 /* =========================================

--- a/PSA.AppCore/Managers/FincaManager.cs
+++ b/PSA.AppCore/Managers/FincaManager.cs
@@ -20,7 +20,16 @@ public class FincaManager
     public async Task<int> RegistrarFincaAsync(RegistrarFincaDTO dto)
     {
         var idFinca = await _fincaDao.CrearFincaAsync(dto);
-        await _evaluacionTecnicaManager.CrearPendientePorNuevaFincaAsync(idFinca);
+
+        try
+        {
+            await _evaluacionTecnicaManager.CrearPendientePorNuevaFincaAsync(idFinca);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"No se pudo crear la evaluación técnica pendiente para la finca {idFinca}: {ex.Message}");
+        }
+
         return idFinca;
     }
 

--- a/PSA.AppCore/Managers/ReportesManager.cs
+++ b/PSA.AppCore/Managers/ReportesManager.cs
@@ -1,0 +1,29 @@
+using PSA.DataAccess.DAO;
+using PSA.EntidadesDTO.DTOs.Reportes;
+
+namespace PSA.AppCore.Managers;
+
+public class ReportesManager
+{
+    private readonly ReportesDAO _reportesDao;
+
+    public ReportesManager(ReportesDAO reportesDao)
+    {
+        _reportesDao = reportesDao;
+    }
+
+    public Task<ReportePagosDuenoDTO> ObtenerPagosDuenoAsync(int idPropietario, FiltroReporteDTO filtro)
+        => _reportesDao.ObtenerPagosDuenoAsync(idPropietario, filtro ?? new FiltroReporteDTO());
+
+    public Task<List<ItemTransaccionDuenoDTO>> ObtenerTransaccionesDuenoAsync(int idPropietario, FiltroReporteDTO filtro)
+        => _reportesDao.ObtenerTransaccionesDuenoAsync(idPropietario, filtro ?? new FiltroReporteDTO());
+
+    public Task<ReporteEvaluacionesIngenieroDTO> ObtenerEvaluacionesIngenieroAsync(int idIngeniero, FiltroReporteDTO filtro)
+        => _reportesDao.ObtenerEvaluacionesIngenieroAsync(idIngeniero, filtro ?? new FiltroReporteDTO());
+
+    public Task<List<ItemPagoUbicacionDTO>> ObtenerPagosPorUbicacionAsync(FiltroReporteDTO filtro)
+        => _reportesDao.ObtenerPagosPorUbicacionAsync(filtro ?? new FiltroReporteDTO());
+
+    public Task<List<ItemResumenActividadDTO>> ObtenerResumenActividadAsync()
+        => _reportesDao.ObtenerResumenActividadAsync();
+}

--- a/PSA.DataAccess/DAO/EvaluacionTecnicaDAO.cs
+++ b/PSA.DataAccess/DAO/EvaluacionTecnicaDAO.cs
@@ -39,9 +39,22 @@ ORDER BY IdEvaluacion DESC;";
             command.Parameters.AddWithValue("@EstadoPendiente", EstadosEvaluacionTecnica.Pendiente);
             command.Parameters.AddWithValue("@EstadoEnProceso", EstadosEvaluacionTecnica.EnProceso);
 
-            await connection.OpenAsync();
-            var result = await command.ExecuteScalarAsync();
-            return result != null ? Convert.ToInt32(result) : 0;
+            try
+            {
+                await connection.OpenAsync();
+                var result = await command.ExecuteScalarAsync();
+                return result != null ? Convert.ToInt32(result) : 0;
+            }
+            catch (SqlException ex)
+            {
+                Console.Error.WriteLine($"Error SQL al crear evaluación pendiente para la finca {idFinca}: {ex.Message}");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error inesperado al crear evaluación pendiente para la finca {idFinca}: {ex.Message}");
+                return 0;
+            }
         }
 
         public async Task<List<BandejaEvaluacionPendienteDTO>> ObtenerBandejaPendientesAsync()

--- a/PSA.DataAccess/DAO/ReportesDAO.cs
+++ b/PSA.DataAccess/DAO/ReportesDAO.cs
@@ -1,0 +1,244 @@
+using Microsoft.Data.SqlClient;
+using PSA.EntidadesDTO.DTOs.Reportes;
+
+namespace PSA.DataAccess.DAO;
+
+public class ReportesDAO
+{
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public ReportesDAO(IDbConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+    }
+
+    public async Task<ReportePagosDuenoDTO> ObtenerPagosDuenoAsync(int idPropietario, FiltroReporteDTO filtro)
+    {
+        const string sqlPagos = @"
+SELECT IdPlanPago, IdFinca, NombreFinca, Anio, Mes, FechaProgramada,
+       MontoBaseMensual, PorcentajeAjusteTotal, MontoMensualCalculado,
+       MontoPendiente, EstadoCuota
+FROM dbo.vw_ReportePagosMensualesDueno
+WHERE IdPropietario = @IdPropietario
+  AND (@Anio IS NULL OR Anio = @Anio)
+  AND (@Mes IS NULL OR Mes = @Mes)
+ORDER BY Anio DESC, Mes DESC, IdPlanPago DESC;";
+
+        const string sqlAjustes = @"
+SELECT DISTINCT
+    pp.IdPlanPago,
+    d.TipoFactor,
+    d.ValorFactor,
+    d.PorcentajeAjuste
+FROM dbo.PlanesPago pp
+INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+INNER JOIN dbo.ConfiguracionPagoDetalle d ON d.IdConfiguracionPago = pp.IdConfiguracionPago
+WHERE f.IdPropietario = @IdPropietario
+  AND (@Anio IS NULL OR pp.Anio = @Anio)
+  AND (
+        (d.TipoFactor = 'Vegetacion' AND d.ValorFactor = f.Vegetacion)
+     OR (d.TipoFactor = 'Pendiente' AND d.ValorFactor = f.Pendiente)
+     OR (d.TipoFactor = 'UsoSuelo' AND d.ValorFactor = f.UsoSuelo)
+     OR (d.TipoFactor = 'RecursosHidricos' AND d.ValorFactor = CASE WHEN f.TieneRecursosHidricos = 1 THEN 'Si' ELSE 'No' END)
+  )
+ORDER BY pp.IdPlanPago DESC, d.TipoFactor;";
+
+        var resultado = new ReportePagosDuenoDTO();
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using (var command = new SqlCommand(sqlPagos, connection))
+        {
+            command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+            command.Parameters.AddWithValue("@Anio", (object?)filtro.Anio ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Mes", (object?)filtro.Mes ?? DBNull.Value);
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                resultado.PagosMensuales.Add(new ItemPagoMensualDuenoDTO
+                {
+                    IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+                    IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+                    NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+                    Anio = reader.GetInt32(reader.GetOrdinal("Anio")),
+                    Mes = reader.GetInt32(reader.GetOrdinal("Mes")),
+                    FechaProgramada = reader.GetDateTime(reader.GetOrdinal("FechaProgramada")),
+                    MontoBaseMensual = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")),
+                    PorcentajeAjusteTotal = reader.GetDecimal(reader.GetOrdinal("PorcentajeAjusteTotal")),
+                    MontoMensualCalculado = reader.GetDecimal(reader.GetOrdinal("MontoMensualCalculado")),
+                    MontoPendiente = reader.GetDecimal(reader.GetOrdinal("MontoPendiente")),
+                    EstadoCuota = reader["EstadoCuota"]?.ToString() ?? string.Empty
+                });
+            }
+        }
+
+        using (var command = new SqlCommand(sqlAjustes, connection))
+        {
+            command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+            command.Parameters.AddWithValue("@Anio", (object?)filtro.Anio ?? DBNull.Value);
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                resultado.AjustesAplicados.Add(new ItemAjustePagoDTO
+                {
+                    IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+                    TipoFactor = reader["TipoFactor"]?.ToString() ?? string.Empty,
+                    ValorFactor = reader["ValorFactor"]?.ToString() ?? string.Empty,
+                    PorcentajeAjuste = reader.GetDecimal(reader.GetOrdinal("PorcentajeAjuste"))
+                });
+            }
+        }
+
+        return resultado;
+    }
+
+    public async Task<List<ItemTransaccionDuenoDTO>> ObtenerTransaccionesDuenoAsync(int idPropietario, FiltroReporteDTO filtro)
+    {
+        const string sql = @"
+SELECT IdTransaccionPago, FechaTransaccion, MontoTotal, EstadoTransaccion,
+       ReferenciaExterna, Observaciones, IdPlanPago, IdFinca, NombreFinca
+FROM dbo.vw_ReporteTransaccionesPagosDueno
+WHERE IdPropietario = @IdPropietario
+  AND (@Anio IS NULL OR YEAR(FechaTransaccion) = @Anio)
+  AND (@Mes IS NULL OR MONTH(FechaTransaccion) = @Mes)
+ORDER BY FechaTransaccion DESC, IdTransaccionPago DESC;";
+
+        var resultado = new List<ItemTransaccionDuenoDTO>();
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+        command.Parameters.AddWithValue("@Anio", (object?)filtro.Anio ?? DBNull.Value);
+        command.Parameters.AddWithValue("@Mes", (object?)filtro.Mes ?? DBNull.Value);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            resultado.Add(new ItemTransaccionDuenoDTO
+            {
+                IdTransaccionPago = reader.GetInt32(reader.GetOrdinal("IdTransaccionPago")),
+                FechaTransaccion = reader.GetDateTime(reader.GetOrdinal("FechaTransaccion")),
+                MontoTotal = reader.GetDecimal(reader.GetOrdinal("MontoTotal")),
+                EstadoTransaccion = reader["EstadoTransaccion"]?.ToString() ?? string.Empty,
+                ReferenciaExterna = reader["ReferenciaExterna"] as string,
+                Observaciones = reader["Observaciones"] as string,
+                IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+                IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+                NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty
+            });
+        }
+
+        return resultado;
+    }
+
+    public async Task<ReporteEvaluacionesIngenieroDTO> ObtenerEvaluacionesIngenieroAsync(int idIngeniero, FiltroReporteDTO filtro)
+    {
+        const string sql = @"
+SELECT IdEvaluacion, IdIngeniero, Ingeniero, EstadoEvaluacion, DecisionTecnica,
+       FechaVisita, FechaDecision, IdFinca, NombreFinca, Provincia, Canton, Distrito
+FROM dbo.vw_ReporteEvaluacionesIngeniero
+WHERE IdIngeniero = @IdIngeniero
+  AND (@Anio IS NULL OR YEAR(COALESCE(FechaDecision, FechaVisita)) = @Anio)
+  AND (@Mes IS NULL OR MONTH(COALESCE(FechaDecision, FechaVisita)) = @Mes)
+ORDER BY COALESCE(FechaDecision, FechaVisita) DESC, IdEvaluacion DESC;";
+
+        var resultado = new ReporteEvaluacionesIngenieroDTO();
+
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdIngeniero", idIngeniero);
+        command.Parameters.AddWithValue("@Anio", (object?)filtro.Anio ?? DBNull.Value);
+        command.Parameters.AddWithValue("@Mes", (object?)filtro.Mes ?? DBNull.Value);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var item = new ItemEvaluacionIngenieroDTO
+            {
+                IdEvaluacion = reader.GetInt32(reader.GetOrdinal("IdEvaluacion")),
+                IdIngeniero = reader["IdIngeniero"] == DBNull.Value ? null : reader.GetInt32(reader.GetOrdinal("IdIngeniero")),
+                Ingeniero = reader["Ingeniero"]?.ToString() ?? string.Empty,
+                EstadoEvaluacion = reader["EstadoEvaluacion"]?.ToString() ?? string.Empty,
+                DecisionTecnica = reader["DecisionTecnica"] as string,
+                FechaVisita = reader["FechaVisita"] == DBNull.Value ? null : reader.GetDateTime(reader.GetOrdinal("FechaVisita")),
+                FechaDecision = reader["FechaDecision"] == DBNull.Value ? null : reader.GetDateTime(reader.GetOrdinal("FechaDecision")),
+                IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+                NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+                Provincia = reader["Provincia"]?.ToString() ?? string.Empty,
+                Canton = reader["Canton"]?.ToString() ?? string.Empty,
+                Distrito = reader["Distrito"]?.ToString() ?? string.Empty
+            };
+
+            resultado.Evaluaciones.Add(item);
+        }
+
+        resultado.Total = resultado.Evaluaciones.Count;
+        resultado.TotalCalifica = resultado.Evaluaciones.Count(x => string.Equals(x.DecisionTecnica, "Califica", StringComparison.OrdinalIgnoreCase));
+        resultado.TotalNoCalifica = resultado.Evaluaciones.Count(x => string.Equals(x.DecisionTecnica, "No Califica", StringComparison.OrdinalIgnoreCase));
+
+        return resultado;
+    }
+
+    public async Task<List<ItemPagoUbicacionDTO>> ObtenerPagosPorUbicacionAsync(FiltroReporteDTO filtro)
+    {
+        const string sql = @"
+SELECT Provincia, Canton, Distrito, Anio, Mes, MontoPagadoMes, MontoProgramadoMes
+FROM dbo.vw_ReportePagosPorUbicacion
+WHERE (@Anio IS NULL OR Anio = @Anio)
+  AND (@Mes IS NULL OR Mes = @Mes)
+ORDER BY Anio DESC, Mes DESC, Provincia, Canton, Distrito;";
+
+        var resultado = new List<ItemPagoUbicacionDTO>();
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@Anio", (object?)filtro.Anio ?? DBNull.Value);
+        command.Parameters.AddWithValue("@Mes", (object?)filtro.Mes ?? DBNull.Value);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            resultado.Add(new ItemPagoUbicacionDTO
+            {
+                Provincia = reader["Provincia"]?.ToString() ?? string.Empty,
+                Canton = reader["Canton"]?.ToString() ?? string.Empty,
+                Distrito = reader["Distrito"]?.ToString() ?? string.Empty,
+                Anio = reader.GetInt32(reader.GetOrdinal("Anio")),
+                Mes = reader.GetInt32(reader.GetOrdinal("Mes")),
+                MontoPagadoMes = reader.GetDecimal(reader.GetOrdinal("MontoPagadoMes")),
+                MontoProgramadoMes = reader.GetDecimal(reader.GetOrdinal("MontoProgramadoMes"))
+            });
+        }
+
+        return resultado;
+    }
+
+    public async Task<List<ItemResumenActividadDTO>> ObtenerResumenActividadAsync()
+    {
+        const string sql = @"
+SELECT Indicador, Total
+FROM dbo.vw_ResumenActividadSistema
+ORDER BY Indicador;";
+
+        var resultado = new List<ItemResumenActividadDTO>();
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            resultado.Add(new ItemResumenActividadDTO
+            {
+                Indicador = reader["Indicador"]?.ToString() ?? string.Empty,
+                Total = reader.GetInt64(reader.GetOrdinal("Total"))
+            });
+        }
+
+        return resultado;
+    }
+}

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -20,6 +20,7 @@
 		<Compile Include="DAO\AuditoriaLogDAO.cs" />
 		<Compile Include="DAO\EvaluacionTecnicaDAO.cs" />
 		<Compile Include="DAO\RecuperacionContrasenaDAO.cs" />
+		<Compile Include="DAO\ReportesDAO.cs" />
 		<Compile Include="DAO\TokenRecuperacionDAO.cs" />
 		<Compile Include="DAO\UsuarioDAO.cs" />
 		<ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />

--- a/PSA.EntidadesDTO/DTOs/RegistrarFincaDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/RegistrarFincaDTO.cs
@@ -8,21 +8,26 @@ namespace PSA.EntidadesDTO.DTOs
 
         [Required(ErrorMessage = "El nombre de la finca es obligatorio.")]
         [StringLength(150, ErrorMessage = "El nombre no puede superar 150 caracteres.")]
+        [Display(Name = "Nombre de la Finca")]
         public string NombreFinca { get; set; } = string.Empty;
 
         [Required(ErrorMessage = "La provincia es obligatoria.")]
         [StringLength(100, ErrorMessage = "La provincia no puede superar 100 caracteres.")]
+        [Display(Name = "Provincia")]
         public string Provincia { get; set; } = string.Empty;
 
         [Required(ErrorMessage = "El cantón es obligatorio.")]
         [StringLength(100, ErrorMessage = "El cantón no puede superar 100 caracteres.")]
+        [Display(Name = "Cantón")]
         public string Canton { get; set; } = string.Empty;
 
         [Required(ErrorMessage = "El distrito es obligatorio.")]
         [StringLength(100, ErrorMessage = "El distrito no puede superar 100 caracteres.")]
+        [Display(Name = "Distrito")]
         public string Distrito { get; set; } = string.Empty;
 
         [StringLength(250, ErrorMessage = "La dirección exacta no puede superar 250 caracteres.")]
+        [Display(Name = "Dirección Exacta")]
         public string? DireccionExacta { get; set; }
 
         [Required(ErrorMessage = "La latitud es obligatoria.")]
@@ -35,10 +40,12 @@ namespace PSA.EntidadesDTO.DTOs
 
         [Required(ErrorMessage = "Las hectáreas son obligatorias.")]
         [Range(0.01, 100000, ErrorMessage = "Hectáreas debe ser mayor a 0.")]
+        [Display(Name = "Tamaño en Hectáreas")]
         public decimal Hectareas { get; set; }
 
         [Required(ErrorMessage = "La vegetación es obligatoria.")]
         [StringLength(100, ErrorMessage = "La vegetación no puede superar 100 caracteres.")]
+        [Display(Name = "Tipo de Vegetación")]
         public string Vegetacion { get; set; } = "Bosque primario";
 
         public bool TieneRecursosHidricos { get; set; }
@@ -52,10 +59,12 @@ namespace PSA.EntidadesDTO.DTOs
 
         [Required(ErrorMessage = "El uso de suelo es obligatorio.")]
         [StringLength(100, ErrorMessage = "El uso de suelo no puede superar 100 caracteres.")]
+        [Display(Name = "Uso del Suelo")]
         public string UsoSuelo { get; set; } = "Conservación";
 
         [Required(ErrorMessage = "La pendiente es obligatoria.")]
         [StringLength(50, ErrorMessage = "La pendiente no puede superar 50 caracteres.")]
+        [Display(Name = "Tipo de Superficie")]
         public string Pendiente { get; set; } = "Plana";
     }
 }

--- a/PSA.EntidadesDTO/DTOs/Reportes/ReportesDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Reportes/ReportesDTO.cs
@@ -1,0 +1,90 @@
+namespace PSA.EntidadesDTO.DTOs.Reportes;
+
+public class FiltroReporteDTO
+{
+    public int? Anio { get; set; }
+    public int? Mes { get; set; }
+}
+
+public class ItemPagoMensualDuenoDTO
+{
+    public int IdPlanPago { get; set; }
+    public int IdFinca { get; set; }
+    public string NombreFinca { get; set; } = string.Empty;
+    public int Anio { get; set; }
+    public int Mes { get; set; }
+    public DateTime FechaProgramada { get; set; }
+    public decimal MontoBaseMensual { get; set; }
+    public decimal PorcentajeAjusteTotal { get; set; }
+    public decimal MontoMensualCalculado { get; set; }
+    public decimal MontoPendiente { get; set; }
+    public string EstadoCuota { get; set; } = string.Empty;
+}
+
+public class ItemAjustePagoDTO
+{
+    public int IdPlanPago { get; set; }
+    public string TipoFactor { get; set; } = string.Empty;
+    public string ValorFactor { get; set; } = string.Empty;
+    public decimal PorcentajeAjuste { get; set; }
+}
+
+public class ReportePagosDuenoDTO
+{
+    public List<ItemPagoMensualDuenoDTO> PagosMensuales { get; set; } = new();
+    public List<ItemAjustePagoDTO> AjustesAplicados { get; set; } = new();
+}
+
+public class ItemTransaccionDuenoDTO
+{
+    public int IdTransaccionPago { get; set; }
+    public DateTime FechaTransaccion { get; set; }
+    public decimal MontoTotal { get; set; }
+    public string EstadoTransaccion { get; set; } = string.Empty;
+    public string? ReferenciaExterna { get; set; }
+    public string? Observaciones { get; set; }
+    public int IdPlanPago { get; set; }
+    public int IdFinca { get; set; }
+    public string NombreFinca { get; set; } = string.Empty;
+}
+
+public class ItemEvaluacionIngenieroDTO
+{
+    public int IdEvaluacion { get; set; }
+    public int? IdIngeniero { get; set; }
+    public string Ingeniero { get; set; } = string.Empty;
+    public string EstadoEvaluacion { get; set; } = string.Empty;
+    public string? DecisionTecnica { get; set; }
+    public DateTime? FechaVisita { get; set; }
+    public DateTime? FechaDecision { get; set; }
+    public int IdFinca { get; set; }
+    public string NombreFinca { get; set; } = string.Empty;
+    public string Provincia { get; set; } = string.Empty;
+    public string Canton { get; set; } = string.Empty;
+    public string Distrito { get; set; } = string.Empty;
+}
+
+public class ReporteEvaluacionesIngenieroDTO
+{
+    public int Total { get; set; }
+    public int TotalCalifica { get; set; }
+    public int TotalNoCalifica { get; set; }
+    public List<ItemEvaluacionIngenieroDTO> Evaluaciones { get; set; } = new();
+}
+
+public class ItemPagoUbicacionDTO
+{
+    public string Provincia { get; set; } = string.Empty;
+    public string Canton { get; set; } = string.Empty;
+    public string Distrito { get; set; } = string.Empty;
+    public int Anio { get; set; }
+    public int Mes { get; set; }
+    public decimal MontoPagadoMes { get; set; }
+    public decimal MontoProgramadoMes { get; set; }
+}
+
+public class ItemResumenActividadDTO
+{
+    public string Indicador { get; set; } = string.Empty;
+    public long Total { get; set; }
+}

--- a/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
+++ b/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
@@ -35,6 +35,7 @@
     <Compile Include="DTOs\RecuperarContrasenaDTO.cs" />
     <Compile Include="DTOs\RegistrarFincaDTO.cs" />
     <Compile Include="DTOs\RegistrarUsuarioDTO.cs" />
+    <Compile Include="DTOs\Reportes\ReportesDTO.cs" />
     <Compile Include="DTOs\RespuestaInicioSesionDTO.cs" />
     <Compile Include="DTOs\RestablecerContrasenaDTO.cs" />
     <Compile Include="DTOs\Usuarios\RolDTO.cs" />

--- a/PSA.WebAPI/Controllers/ReportesController.cs
+++ b/PSA.WebAPI/Controllers/ReportesController.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Mvc;
+using PSA.AppCore.Managers;
+using PSA.EntidadesDTO.DTOs.Reportes;
+
+namespace PSA.WebAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ReportesController : ControllerBase
+{
+    private readonly ReportesManager _reportesManager;
+
+    public ReportesController(ReportesManager reportesManager)
+    {
+        _reportesManager = reportesManager;
+    }
+
+    [HttpGet("dueno/{idPropietario:int}/pagos")]
+    public async Task<IActionResult> ObtenerPagosDueno([FromRoute] int idPropietario, [FromQuery] int? anio = null, [FromQuery] int? mes = null)
+    {
+        var data = await _reportesManager.ObtenerPagosDuenoAsync(idPropietario, new FiltroReporteDTO { Anio = anio, Mes = mes });
+        return Ok(data);
+    }
+
+    [HttpGet("dueno/{idPropietario:int}/transacciones")]
+    public async Task<IActionResult> ObtenerTransaccionesDueno([FromRoute] int idPropietario, [FromQuery] int? anio = null, [FromQuery] int? mes = null)
+    {
+        var data = await _reportesManager.ObtenerTransaccionesDuenoAsync(idPropietario, new FiltroReporteDTO { Anio = anio, Mes = mes });
+        return Ok(data);
+    }
+
+    [HttpGet("ingeniero/{idIngeniero:int}/evaluaciones")]
+    public async Task<IActionResult> ObtenerEvaluacionesIngeniero([FromRoute] int idIngeniero, [FromQuery] int? anio = null, [FromQuery] int? mes = null)
+    {
+        var data = await _reportesManager.ObtenerEvaluacionesIngenieroAsync(idIngeniero, new FiltroReporteDTO { Anio = anio, Mes = mes });
+        return Ok(data);
+    }
+
+    [HttpGet("administrador/pagos-ubicacion")]
+    public async Task<IActionResult> ObtenerPagosPorUbicacion([FromQuery] int? anio = null, [FromQuery] int? mes = null)
+    {
+        var data = await _reportesManager.ObtenerPagosPorUbicacionAsync(new FiltroReporteDTO { Anio = anio, Mes = mes });
+        return Ok(data);
+    }
+
+    [HttpGet("administrador/resumen-actividad")]
+    public async Task<IActionResult> ObtenerResumenActividad()
+    {
+        var data = await _reportesManager.ObtenerResumenActividadAsync();
+        return Ok(data);
+    }
+}

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -16,6 +16,7 @@
     <Compile Include="Controllers\EvaluacionesTecnicasController.cs" />
     <Compile Include="Controllers\FincasController.cs" />
     <Compile Include="Controllers\HealthController.cs" />
+    <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Controllers\Middleware\ExceptionMiddleware.cs" />
     <Compile Include="Controllers\Models\ApiResponse.cs" />
     <Compile Include="Controllers\RecuperacionContrasenaController.cs" />

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -46,6 +46,7 @@ builder.Services.AddScoped<FincaEvidenciaDAO>();
 builder.Services.AddScoped<EvaluacionDAO>();
 builder.Services.AddScoped<AuditoriaLogDAO>();
 builder.Services.AddScoped<DashboardDAO>();
+builder.Services.AddScoped<ReportesDAO>();
 
 builder.Services.AddScoped<FincaService>();
 builder.Services.AddScoped<EvaluacionService>();
@@ -54,6 +55,7 @@ builder.Services.AddScoped<AutenticacionManager>();
 builder.Services.AddScoped<RecuperacionContrasenaManager>();
 builder.Services.AddScoped<EvaluacionTecnicaManager>();
 builder.Services.AddScoped<FincaManager>();
+builder.Services.AddScoped<ReportesManager>();
 
 var app = builder.Build();
 

--- a/PSA.WebApp/Controllers/ReportesController.cs
+++ b/PSA.WebApp/Controllers/ReportesController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PSA.WebApp.Models;
+using System.Net.Http.Json;
 using System.Security.Claims;
 
 namespace PSA.WebApp.Controllers
@@ -7,15 +9,51 @@ namespace PSA.WebApp.Controllers
     [Authorize(Roles = "1,2,3")]
     public class ReportesController : Controller
     {
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public ReportesController(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
         [HttpGet]
-        public IActionResult Index()
+        public async Task<IActionResult> Index(int? anio = null, int? mes = null)
         {
             ViewBag.ModuloActivo = "reportes";
             ViewBag.RolActivo = ObtenerNombreRol();
             ViewBag.TituloPagina = "Reportes";
-            ViewBag.SubtituloPagina = "Consulte reportes base según su rol dentro del sistema.";
+            ViewBag.SubtituloPagina = "Consulte reportes y análisis según su rol dentro del sistema.";
             ViewBag.BreadcrumbActual = "Reportes";
-            return View();
+
+            var modelo = new ReportesIndexViewModel
+            {
+                Anio = anio,
+                Mes = mes
+            };
+
+            var rolId = User.FindFirstValue(ClaimTypes.Role);
+            var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var idClaim) ? idClaim : 0;
+            var client = _httpClientFactory.CreateClient("AuthApi");
+
+            if (rolId == "2" && idUsuario > 0)
+            {
+                var query = $"?anio={anio}&mes={mes}";
+                modelo.PagosDueno = await client.GetFromJsonAsync<PSA.EntidadesDTO.DTOs.Reportes.ReportePagosDuenoDTO>($"api/Reportes/dueno/{idUsuario}/pagos{query}") ?? new();
+                modelo.TransaccionesDueno = await client.GetFromJsonAsync<List<PSA.EntidadesDTO.DTOs.Reportes.ItemTransaccionDuenoDTO>>($"api/Reportes/dueno/{idUsuario}/transacciones{query}") ?? new();
+            }
+            else if (rolId == "3" && idUsuario > 0)
+            {
+                var query = $"?anio={anio}&mes={mes}";
+                modelo.EvaluacionesIngeniero = await client.GetFromJsonAsync<PSA.EntidadesDTO.DTOs.Reportes.ReporteEvaluacionesIngenieroDTO>($"api/Reportes/ingeniero/{idUsuario}/evaluaciones{query}") ?? new();
+            }
+            else if (rolId == "1")
+            {
+                var query = $"?anio={anio}&mes={mes}";
+                modelo.PagosPorUbicacion = await client.GetFromJsonAsync<List<PSA.EntidadesDTO.DTOs.Reportes.ItemPagoUbicacionDTO>>($"api/Reportes/administrador/pagos-ubicacion{query}") ?? new();
+                modelo.ResumenActividad = await client.GetFromJsonAsync<List<PSA.EntidadesDTO.DTOs.Reportes.ItemResumenActividadDTO>>("api/Reportes/administrador/resumen-actividad") ?? new();
+            }
+
+            return View(modelo);
         }
 
         private string ObtenerNombreRol()

--- a/PSA.WebApp/Models/ReportesViewModels.cs
+++ b/PSA.WebApp/Models/ReportesViewModels.cs
@@ -1,0 +1,17 @@
+using PSA.EntidadesDTO.DTOs.Reportes;
+
+namespace PSA.WebApp.Models;
+
+public class ReportesIndexViewModel
+{
+    public int? Anio { get; set; }
+    public int? Mes { get; set; }
+
+    public ReportePagosDuenoDTO PagosDueno { get; set; } = new();
+    public List<ItemTransaccionDuenoDTO> TransaccionesDueno { get; set; } = new();
+
+    public ReporteEvaluacionesIngenieroDTO EvaluacionesIngeniero { get; set; } = new();
+
+    public List<ItemPagoUbicacionDTO> PagosPorUbicacion { get; set; } = new();
+    public List<ItemResumenActividadDTO> ResumenActividad { get; set; } = new();
+}

--- a/PSA.WebApp/PSA.WebApp.csproj
+++ b/PSA.WebApp/PSA.WebApp.csproj
@@ -21,6 +21,7 @@
     <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Models\DashboardViewModels.cs" />
     <Compile Include="Models\EvaluacionesViewModels.cs" />
+    <Compile Include="Models\ReportesViewModels.cs" />
     <Compile Include="Models\RecuperarContrasenaViewModel.cs" />
     <Compile Include="Models\RestablecerContrasenaViewModel.cs" />
     <Compile Include="Program.cs" />

--- a/PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml
+++ b/PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml
@@ -40,16 +40,11 @@
                     <label for="paisInput">País</label>
                     <input id="paisInput" value="Costa Rica" readonly />
                 </div>
-                <div class="campo-formulario"></div>
-            </div>
-
-            <div class="grid-dos-columnas">
                 <div class="campo-formulario">
                     <label asp-for="Provincia"></label>
                     <input asp-for="Provincia" id="provinciaInput" required readonly placeholder="Se completa al elegir un punto en el mapa" />
                     <span asp-validation-for="Provincia" class="text-danger"></span>
                 </div>
-                <div class="campo-formulario"></div>
             </div>
 
             <div class="grid-dos-columnas">
@@ -136,14 +131,14 @@
             <div class="grid-tres-columnas">
                 <div class="control-check">
                     <input asp-for="TieneRiosOQuebradas" type="checkbox" id="tieneRiosOQuebradas" />
-                    <label asp-for="TieneRiosOQuebradas">Sí tiene ríos o quebradas</label>
+                    <label asp-for="TieneRiosOQuebradas">¿Contiene ríos o quebradas?</label>
                 </div>
                 <div class="control-check">
                     <input asp-for="TieneNacientes" type="checkbox" id="tieneNacientes" />
-                    <label asp-for="TieneNacientes">Sí tiene nacientes</label>
+                    <label asp-for="TieneNacientes">¿Posee nacientes?</label>
                 </div>
                 <div class="campo-formulario">
-                    <label asp-for="CantidadNacientes">Cuántas nacientes tiene</label>
+                    <label asp-for="CantidadNacientes">Cantidad de nacientes</label>
                     <input asp-for="CantidadNacientes" type="number" min="0" step="1" id="cantidadNacientes" />
                     <span asp-validation-for="CantidadNacientes" class="text-danger"></span>
                 </div>

--- a/PSA.WebApp/Views/Reportes/Index.cshtml
+++ b/PSA.WebApp/Views/Reportes/Index.cshtml
@@ -1,67 +1,174 @@
+@model PSA.WebApp.Models.ReportesIndexViewModel
 @using System.Security.Claims
 @{
     ViewData["Title"] = "Reportes";
-    var rolId = User.FindFirstValue(ClaimTypes.Role);
-    var esDueno = rolId == "1";
-    var esAdmin = rolId == "2";
+    var rolId = User?.FindFirstValue(ClaimTypes.Role);
+    var esDueno = rolId == "2";
+    var esAdmin = rolId == "1";
     var esIngeniero = rolId == "3";
 }
 <section class="seccion-pagina">
     <div class="cabecera-pagina">
         <div>
             <span class="eyebrow">Consulta analítica</span>
-            <h2>Reportes del sistema</h2>
-            <p>Pantallas base de reportes visibles según su rol.</p>
+            <h2>Reportes y análisis de datos</h2>
+            <p>Filtre por período y visualice reportes según su rol.</p>
         </div>
     </div>
 
-    <div class="grid-tarjetas-kpi">
-        @if (esDueno)
-        {
-            <a class="tarjeta-kpi" asp-controller="Pagos" asp-action="HistorialPagos">
-                <span class="etiqueta-kpi">Reporte de dueño</span>
-                <strong>Pagos e historial</strong>
-                <small>Revise sus pagos registrados y estado.</small>
-            </a>
-            <a class="tarjeta-kpi" asp-controller="Fincas" asp-action="MisFincas">
-                <span class="etiqueta-kpi">Reporte de fincas</span>
-                <strong>Estado de fincas</strong>
-                <small>Consulte el estado general de sus fincas.</small>
-            </a>
-        }
-
-        @if (esIngeniero)
-        {
-            <a class="tarjeta-kpi" asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">
-                <span class="etiqueta-kpi">Reporte técnico</span>
-                <strong>Evaluaciones por período</strong>
-                <small>Consulte evaluaciones por filtros técnicos.</small>
-            </a>
-            <a class="tarjeta-kpi" asp-controller="Evaluaciones" asp-action="FincasIngeniero">
-                <span class="etiqueta-kpi">Reporte operativo</span>
-                <strong>Fincas del ingeniero</strong>
-                <small>Resumen de fincas evaluadas y en proceso.</small>
-            </a>
-        }
-
-        @if (esAdmin)
-        {
-            <a class="tarjeta-kpi" asp-controller="Pagos" asp-action="PlanesPago">
-                <span class="etiqueta-kpi">Reporte financiero</span>
-                <strong>Planes de pago</strong>
-                <small>Estado general de planes y cuotas.</small>
-            </a>
-            <a class="tarjeta-kpi" asp-controller="Administracion" asp-action="AuditoriaLogs">
-                <span class="etiqueta-kpi">Reporte administrativo</span>
-                <strong>Auditoría y trazabilidad</strong>
-                <small>Eventos clave y acciones administrativas.</small>
-            </a>
-        }
-    </div>
-
-    <section class="tarjeta-panel mt-3">
-        <div class="lista-accesos">
-            <a class="acceso-rapido" asp-controller="Dashboard" asp-action="@(esAdmin ? "Administrador" : esIngeniero ? "Ingeniero" : "Dueno")">Volver al dashboard</a>
+    <form method="get" class="seccion-formulario mb-3">
+        <div class="grid-tres-columnas">
+            <div class="campo-formulario">
+                <label for="anio">Año</label>
+                <input id="anio" name="anio" type="number" min="2000" max="2100" value="@Model.Anio" />
+            </div>
+            <div class="campo-formulario">
+                <label for="mes">Mes</label>
+                <input id="mes" name="mes" type="number" min="1" max="12" value="@Model.Mes" />
+            </div>
+            <div class="campo-formulario d-flex align-items-end">
+                <button type="submit" class="boton-primario">Aplicar filtros</button>
+            </div>
         </div>
-    </section>
+    </form>
+
+    @if (esDueno)
+    {
+        <section class="tarjeta-panel mb-3">
+            <h3>Reporte de pagos mensuales y cálculo</h3>
+            <div class="table-responsive">
+                <table class="tabla-base">
+                    <thead>
+                        <tr>
+                            <th>Finca</th><th>Año/Mes</th><th>Base</th><th>% Ajuste</th><th>Monto calculado</th><th>Pendiente</th><th>Estado</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var item in Model.PagosDueno.PagosMensuales)
+                    {
+                        <tr>
+                            <td>@item.NombreFinca</td>
+                            <td>@item.Anio/@item.Mes</td>
+                            <td>@item.MontoBaseMensual.ToString("N2")</td>
+                            <td>@item.PorcentajeAjusteTotal.ToString("N2")%</td>
+                            <td>@item.MontoMensualCalculado.ToString("N2")</td>
+                            <td>@item.MontoPendiente.ToString("N2")</td>
+                            <td>@item.EstadoCuota</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="tarjeta-panel mb-3">
+            <h3>Ajustes por criterios</h3>
+            <div class="table-responsive">
+                <table class="tabla-base">
+                    <thead><tr><th>Plan</th><th>Factor</th><th>Valor</th><th>%</th></tr></thead>
+                    <tbody>
+                    @foreach (var item in Model.PagosDueno.AjustesAplicados)
+                    {
+                        <tr>
+                            <td>@item.IdPlanPago</td>
+                            <td>@item.TipoFactor</td>
+                            <td>@item.ValorFactor</td>
+                            <td>@item.PorcentajeAjuste.ToString("N2")%</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="tarjeta-panel">
+            <h3>Histórico de transacciones</h3>
+            <div class="table-responsive">
+                <table class="tabla-base">
+                    <thead><tr><th>Fecha</th><th>Finca</th><th>Monto</th><th>Estado</th><th>Referencia</th></tr></thead>
+                    <tbody>
+                    @foreach (var item in Model.TransaccionesDueno)
+                    {
+                        <tr>
+                            <td>@item.FechaTransaccion.ToString("yyyy-MM-dd")</td>
+                            <td>@item.NombreFinca</td>
+                            <td>@item.MontoTotal.ToString("N2")</td>
+                            <td>@item.EstadoTransaccion</td>
+                            <td>@item.ReferenciaExterna</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    }
+
+    @if (esIngeniero)
+    {
+        <section class="grid-tarjetas-kpi mb-3">
+            <div class="tarjeta-kpi"><span class="etiqueta-kpi">Total</span><strong>@Model.EvaluacionesIngeniero.Total</strong></div>
+            <div class="tarjeta-kpi"><span class="etiqueta-kpi">Califica</span><strong>@Model.EvaluacionesIngeniero.TotalCalifica</strong></div>
+            <div class="tarjeta-kpi"><span class="etiqueta-kpi">No califica</span><strong>@Model.EvaluacionesIngeniero.TotalNoCalifica</strong></div>
+        </section>
+
+        <section class="tarjeta-panel">
+            <h3>Fincas evaluadas (mensual/anual)</h3>
+            <div class="table-responsive">
+                <table class="tabla-base">
+                    <thead><tr><th>Evaluación</th><th>Finca</th><th>Estado</th><th>Decisión</th><th>Fecha</th><th>Ubicación</th></tr></thead>
+                    <tbody>
+                    @foreach (var item in Model.EvaluacionesIngeniero.Evaluaciones)
+                    {
+                        <tr>
+                            <td>@item.IdEvaluacion</td>
+                            <td>@item.NombreFinca</td>
+                            <td>@item.EstadoEvaluacion</td>
+                            <td>@item.DecisionTecnica</td>
+                            <td>@((item.FechaDecision ?? item.FechaVisita)?.ToString("yyyy-MM-dd"))</td>
+                            <td>@item.Provincia, @item.Canton, @item.Distrito</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    }
+
+    @if (esAdmin)
+    {
+        <section class="tarjeta-panel mb-3">
+            <h3>Montos pagados por provincia, cantón y distrito</h3>
+            <div class="table-responsive">
+                <table class="tabla-base">
+                    <thead><tr><th>Año/Mes</th><th>Provincia</th><th>Cantón</th><th>Distrito</th><th>Pagado</th><th>Programado</th></tr></thead>
+                    <tbody>
+                    @foreach (var item in Model.PagosPorUbicacion)
+                    {
+                        <tr>
+                            <td>@item.Anio/@item.Mes</td>
+                            <td>@item.Provincia</td>
+                            <td>@item.Canton</td>
+                            <td>@item.Distrito</td>
+                            <td>@item.MontoPagadoMes.ToString("N2")</td>
+                            <td>@item.MontoProgramadoMes.ToString("N2")</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="tarjeta-panel">
+            <h3>Resumen de actividad del sistema</h3>
+            <div class="grid-tarjetas-kpi">
+                @foreach (var item in Model.ResumenActividad)
+                {
+                    <div class="tarjeta-kpi">
+                        <span class="etiqueta-kpi">@item.Indicador</span>
+                        <strong>@item.Total</strong>
+                    </div>
+                }
+            </div>
+        </section>
+    }
 </section>

--- a/PSA.WebApp/Views/Shared/_Encabezado.cshtml
+++ b/PSA.WebApp/Views/Shared/_Encabezado.cshtml
@@ -2,7 +2,7 @@
 @{
     var nombreUsuario = User?.Identity?.Name;
     var nombreMostrar = string.IsNullOrWhiteSpace(nombreUsuario) ? "Usuario" : nombreUsuario;
-    var rolClaim = User.FindFirstValue(ClaimTypes.Role);
+    var rolClaim = User?.FindFirstValue(ClaimTypes.Role);
     var rolActivo = rolClaim switch
     {
         "1" => "Administrador",

--- a/PSA.WebApp/wwwroot/js/registro-finca.js
+++ b/PSA.WebApp/wwwroot/js/registro-finca.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
         return document.getElementById(id) || null;
     }
 
-    var paisInput = obtenerCampo("paisSeleccionado");
+    var paisInput = obtenerCampo("paisInput");
     var provinciaInput = obtenerCampo("provinciaInput");
     var cantonInput = obtenerCampo("cantonInput");
     var distritoInput = obtenerCampo("distritoInput");
@@ -81,10 +81,6 @@ document.addEventListener("DOMContentLoaded", function () {
             }
         }
     }
-
-    var mapaContenedor = document.getElementById("mapaUbicacionFinca");
-    var mapa = null;
-    var marcador = null;
 
     function setCoordenadas(latitud, longitud) {
         var lat = Number(latitud);


### PR DESCRIPTION
### Motivation
- Allow creating pending technical evaluations without an assigned engineer by permitting `IdIngeniero` to be NULL and enabling automatic pending evaluation creation for new farms. 
- Provide server-side reporting capabilities (owner payments, transactions, engineer evaluations, payments by location and system summary) through DB views and new data access / API layers. 
- Improve robustness when creating pending evaluations from the application and give basic reporting UIs for different roles. 
- Harmonize some seed data, labels and client-side form behavior to match the new flows. 

### Description
- Database schema and seed updates: made `EvaluacionesTecnicas.IdIngeniero` nullable, expanded allowed `EstadoEvaluacion` values, added several reporting views (`vw_Reporte*` and `vw_ResumenActividadSistema`), adjusted `CatalogoFincaValores` seed (rename 'Uso mixto' -> 'Mixto') and inserted a pending evaluation seed for pending farm, and added a migration script `2026-04-arreglo-arqui2-idingeniero-nullable.sql`. 
- Data access and backend: added `ReportesDAO` with queries against the new views and reporting DTOs, added `ReportesManager` and `ReportesController`, registered `ReportesDAO` and `ReportesManager` in DI, and added `ReportesDTO` types to the DTO project. 
- Resilience and behavior changes: `EvaluacionTecnicaDAO.CrearEvaluacionPendienteAsync` now catches SQL and general exceptions and returns `0` on failure, and `FincaManager.RegistrarFincaAsync` wraps pending-evaluation creation in a `try/catch` to avoid failing the finca registration if evaluation creation fails. 
- Web UI and client fixes: introduced report pages, view models and controller for the web app, updated `RegistrarFinca` view labels and validation texts, fixed JS to reference the correct country input id, and added new report view templates to render role-specific data. 
- Project file updates: included new source files in `PSA.DataAccess`, `PSA.EntidadesDTO`, `PSA.WebAPI`, and `PSA.WebApp` project files. 

### Testing
- Ran `dotnet build` for the solution and the compilation completed successfully. 
- Ran `dotnet test` for the repository and existing automated tests (if present) completed without failures. 
- Executed the database schema migration script in a local/dev database to verify `IdIngeniero` can be made nullable and the new views are creatable (no runtime errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d861b4398c832da6ce6c1cc42e1238)