### PR TITLE
feat: migrar lógica de autenticación y landing a stored procedures

### DIFF
--- a/BaseDatos/Migraciones/2026-04-migracion-logica-auth-landing-stored-procedures.sql
+++ b/BaseDatos/Migraciones/2026-04-migracion-logica-auth-landing-stored-procedures.sql
@@ -1,0 +1,225 @@
+/*
+    Migración: Centraliza lógica crítica de autenticación y landing pages en Stored Procedures.
+    Fecha: 2026-04-12
+*/
+
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_RegistrarUsuario
+    @NombreCompleto NVARCHAR(150),
+    @Email NVARCHAR(150),
+    @PasswordHash NVARCHAR(300),
+    @IdRol INT,
+    @Estado VARCHAR(20),
+    @FechaCreacion DATETIME2,
+    @UltimoAcceso DATETIME2 = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    INSERT INTO dbo.Usuarios
+    (
+        NombreCompleto,
+        Email,
+        PasswordHash,
+        IdRol,
+        Estado,
+        FechaCreacion,
+        UltimoAcceso
+    )
+    VALUES
+    (
+        @NombreCompleto,
+        @Email,
+        @PasswordHash,
+        @IdRol,
+        @Estado,
+        @FechaCreacion,
+        @UltimoAcceso
+    );
+
+    SELECT CAST(SCOPE_IDENTITY() AS INT) AS IdUsuario;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ObtenerUsuarioPorEmail
+    @Email NVARCHAR(150)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT TOP 1
+        IdUsuario,
+        NombreCompleto,
+        Email,
+        PasswordHash,
+        IdRol,
+        Estado,
+        FechaCreacion,
+        UltimoAcceso
+    FROM dbo.Usuarios
+    WHERE Email = @Email;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ObtenerUsuarioPorId
+    @IdUsuario INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT TOP 1
+        IdUsuario,
+        NombreCompleto,
+        Email,
+        PasswordHash,
+        IdRol,
+        Estado,
+        FechaCreacion,
+        UltimoAcceso
+    FROM dbo.Usuarios
+    WHERE IdUsuario = @IdUsuario;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ExisteRol
+    @IdRol INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT TOP 1 1 AS Existe
+    FROM dbo.Roles
+    WHERE IdRol = @IdRol;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ActualizarPasswordHashPorEmail
+    @Email NVARCHAR(150),
+    @PasswordHash NVARCHAR(300)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.Usuarios
+    SET PasswordHash = @PasswordHash
+    WHERE Email = @Email;
+
+    SELECT @@ROWCOUNT AS FilasAfectadas;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ActualizarUltimoAcceso
+    @IdUsuario INT,
+    @UltimoAcceso DATETIME2
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.Usuarios
+    SET UltimoAcceso = @UltimoAcceso
+    WHERE IdUsuario = @IdUsuario;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Usuarios_AsignarRol
+    @IdUsuario INT,
+    @IdRol INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.Usuarios
+    SET IdRol = @IdRol
+    WHERE IdUsuario = @IdUsuario;
+
+    SELECT @@ROWCOUNT AS FilasAfectadas;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_InvalidarTokensActivos
+    @IdUsuario INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.TokensRecuperacion
+    SET Usado = 1,
+        FechaUso = SYSDATETIME()
+    WHERE IdUsuario = @IdUsuario
+      AND Usado = 0
+      AND FechaExpiracion > SYSDATETIME();
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_CrearTokenRecuperacion
+    @IdUsuario INT,
+    @Token NVARCHAR(255),
+    @FechaExpiracion DATETIME2
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    INSERT INTO dbo.TokensRecuperacion (IdUsuario, Token, FechaExpiracion, Usado)
+    VALUES (@IdUsuario, @Token, @FechaExpiracion, 0);
+
+    SELECT CAST(SCOPE_IDENTITY() AS INT) AS IdToken;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ObtenerTokenVigente
+    @Token NVARCHAR(255)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT TOP 1
+        IdToken,
+        IdUsuario,
+        Token,
+        FechaCreacion,
+        FechaExpiracion,
+        Usado,
+        FechaUso
+    FROM dbo.TokensRecuperacion
+    WHERE Token = @Token
+      AND Usado = 0
+      AND FechaExpiracion > SYSDATETIME();
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_MarcarTokenComoUsado
+    @IdToken INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.TokensRecuperacion
+    SET Usado = 1,
+        FechaUso = SYSDATETIME()
+    WHERE IdToken = @IdToken;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Landing_ObtenerEquipo
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        CAST(N'Equipo PSA Costa Rica' AS NVARCHAR(200)) AS Titulo,
+        CAST(N'Aplicamos arquitectura por capas, SQL Server y seguridad de datos orientada a procesos forestales.' AS NVARCHAR(500)) AS Descripcion;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Landing_ObtenerProducto
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        CAST(N'Producto PSA' AS NVARCHAR(200)) AS Titulo,
+        CAST(N'Plataforma para gestión de fincas, evaluaciones técnicas, pagos y trazabilidad con auditoría.' AS NVARCHAR(500)) AS Descripcion;
+END;
+GO

--- a/PSA.AppCore/Managers/AutenticacionManager.cs
+++ b/PSA.AppCore/Managers/AutenticacionManager.cs
@@ -1,6 +1,7 @@
 using PSA.AppCore.Servicios;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
+using PSA.EntidadesDTO.DTOs.Usuarios;
 using PSA.EntidadesDTO.Entidades;
 
 namespace PSA.AppCore.Managers
@@ -123,6 +124,30 @@ namespace PSA.AppCore.Managers
                 UltimoAcceso = fechaAcceso,
                 Mensaje = "Inicio de sesión exitoso."
             };
+        }
+
+        public async Task AsignarRolAsync(AsignarRolUsuarioDTO dto)
+        {
+            if (dto.IdUsuario <= 0)
+                throw new Exception("El Id del usuario es inválido.");
+
+            if (dto.IdRol <= 0)
+                throw new Exception("El Id del rol es inválido.");
+
+            var rolExiste = await _usuarioDAO.ExisteRolAsync(dto.IdRol);
+            if (!rolExiste)
+                throw new Exception("El rol indicado no existe.");
+
+            await _usuarioDAO.AsignarRolAsync(dto.IdUsuario, dto.IdRol);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: dto.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: dto.IdUsuario,
+                accion: "ASIGNACION_ROL",
+                detalle: $"Rol {dto.IdRol} asignado al usuario {dto.IdUsuario}."
+            );
         }
     }
 }

--- a/PSA.AppCore/Managers/LandingManager.cs
+++ b/PSA.AppCore/Managers/LandingManager.cs
@@ -1,0 +1,35 @@
+using PSA.DataAccess.DAO;
+using PSA.EntidadesDTO.DTOs.Landing;
+
+namespace PSA.AppCore.Managers
+{
+    public class LandingManager
+    {
+        private readonly LandingDAO _landingDao;
+
+        public LandingManager(LandingDAO landingDao)
+        {
+            _landingDao = landingDao;
+        }
+
+        public async Task<LandingContenidoDTO> ObtenerEquipoAsync()
+        {
+            var data = await _landingDao.ObtenerContenidoEquipoAsync();
+            return new LandingContenidoDTO
+            {
+                Titulo = data.Titulo,
+                Descripcion = data.Descripcion
+            };
+        }
+
+        public async Task<LandingContenidoDTO> ObtenerProductoAsync()
+        {
+            var data = await _landingDao.ObtenerContenidoProductoAsync();
+            return new LandingContenidoDTO
+            {
+                Titulo = data.Titulo,
+                Descripcion = data.Descripcion
+            };
+        }
+    }
+}

--- a/PSA.DataAccess/DAO/LandingDAO.cs
+++ b/PSA.DataAccess/DAO/LandingDAO.cs
@@ -1,0 +1,45 @@
+using Microsoft.Data.SqlClient;
+
+namespace PSA.DataAccess.DAO
+{
+    public class LandingDAO
+    {
+        private readonly IDbConnectionFactory _connectionFactory;
+
+        public LandingDAO(IDbConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+        }
+
+        public async Task<(string Titulo, string Descripcion)> ObtenerContenidoEquipoAsync()
+        {
+            return await EjecutarConsultaLandingAsync("dbo.SP_Landing_ObtenerEquipo");
+        }
+
+        public async Task<(string Titulo, string Descripcion)> ObtenerContenidoProductoAsync()
+        {
+            return await EjecutarConsultaLandingAsync("dbo.SP_Landing_ObtenerProducto");
+        }
+
+        private async Task<(string Titulo, string Descripcion)> EjecutarConsultaLandingAsync(string nombreSp)
+        {
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(nombreSp, connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
+
+            await connection.OpenAsync();
+            using var reader = await command.ExecuteReaderAsync();
+            if (!await reader.ReadAsync())
+            {
+                return (string.Empty, string.Empty);
+            }
+
+            return (
+                reader["Titulo"]?.ToString() ?? string.Empty,
+                reader["Descripcion"]?.ToString() ?? string.Empty
+            );
+        }
+    }
+}

--- a/PSA.DataAccess/DAO/TokenRecuperacionDAO.cs
+++ b/PSA.DataAccess/DAO/TokenRecuperacionDAO.cs
@@ -16,16 +16,11 @@ namespace PSA.DataAccess.DAO
 
         public async Task InvalidarTokensActivosPorUsuarioAsync(int idUsuario)
         {
-            const string sql = @"
-UPDATE TokensRecuperacion
-SET Usado = 1,
-    FechaUso = SYSDATETIME()
-WHERE IdUsuario = @IdUsuario
-  AND Usado = 0
-  AND FechaExpiracion > SYSDATETIME();";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_InvalidarTokensActivos", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdUsuario", idUsuario);
             await connection.OpenAsync();
             await command.ExecuteNonQueryAsync();
@@ -33,13 +28,11 @@ WHERE IdUsuario = @IdUsuario
 
         public async Task<int> CrearTokenAsync(int idUsuario, string token, DateTime fechaExpiracionUtc)
         {
-            const string sql = @"
-INSERT INTO TokensRecuperacion (IdUsuario, Token, FechaExpiracion, Usado)
-VALUES (@IdUsuario, @Token, @FechaExpiracion, 0);
-SELECT CAST(SCOPE_IDENTITY() AS INT);";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_CrearTokenRecuperacion", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdUsuario", idUsuario);
             command.Parameters.AddWithValue("@Token", token);
             command.Parameters.AddWithValue("@FechaExpiracion", fechaExpiracionUtc);
@@ -50,15 +43,11 @@ SELECT CAST(SCOPE_IDENTITY() AS INT);";
 
         public async Task<TokenRecuperacion?> ObtenerTokenVigenteAsync(string token)
         {
-            const string sql = @"
-SELECT TOP 1 IdToken, IdUsuario, Token, FechaCreacion, FechaExpiracion, Usado, FechaUso
-FROM TokensRecuperacion
-WHERE Token = @Token
-  AND Usado = 0
-  AND FechaExpiracion > SYSDATETIME();";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ObtenerTokenVigente", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@Token", token);
             await connection.OpenAsync();
             using var reader = await command.ExecuteReaderAsync();
@@ -82,14 +71,11 @@ WHERE Token = @Token
 
         public async Task MarcarTokenComoUsadoAsync(int idToken)
         {
-            const string sql = @"
-UPDATE TokensRecuperacion
-SET Usado = 1,
-    FechaUso = SYSDATETIME()
-WHERE IdToken = @IdToken;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_MarcarTokenComoUsado", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdToken", idToken);
             await connection.OpenAsync();
             await command.ExecuteNonQueryAsync();

--- a/PSA.DataAccess/DAO/UsuarioDAO.cs
+++ b/PSA.DataAccess/DAO/UsuarioDAO.cs
@@ -16,32 +16,11 @@ namespace PSA.DataAccess.DAO
 
         public async Task<int> CrearUsuarioAsync(Usuario usuario)
         {
-            const string sql = @"
-INSERT INTO Usuarios
-(
-    NombreCompleto,
-    Email,
-    PasswordHash,
-    IdRol,
-    Estado,
-    FechaCreacion,
-    UltimoAcceso
-)
-VALUES
-(
-    @NombreCompleto,
-    @Email,
-    @PasswordHash,
-    @IdRol,
-    @Estado,
-    @FechaCreacion,
-    @UltimoAcceso
-);
-
-SELECT CAST(SCOPE_IDENTITY() AS INT);";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_RegistrarUsuario", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
 
             command.Parameters.AddWithValue("@NombreCompleto", usuario.NombreCompleto);
             command.Parameters.AddWithValue("@Email", usuario.Email);
@@ -59,21 +38,11 @@ SELECT CAST(SCOPE_IDENTITY() AS INT);";
 
         public async Task<Usuario?> ObtenerPorEmailAsync(string email)
         {
-            const string sql = @"
-SELECT TOP 1
-    IdUsuario,
-    NombreCompleto,
-    Email,
-    PasswordHash,
-    IdRol,
-    Estado,
-    FechaCreacion,
-    UltimoAcceso
-FROM Usuarios
-WHERE Email = @Email;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ObtenerUsuarioPorEmail", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
 
             command.Parameters.AddWithValue("@Email", email);
 
@@ -101,21 +70,11 @@ WHERE Email = @Email;";
 
         public async Task<Usuario?> ObtenerPorIdAsync(int idUsuario)
         {
-            const string sql = @"
-SELECT TOP 1
-    IdUsuario,
-    NombreCompleto,
-    Email,
-    PasswordHash,
-    IdRol,
-    Estado,
-    FechaCreacion,
-    UltimoAcceso
-FROM Usuarios
-WHERE IdUsuario = @IdUsuario;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ObtenerUsuarioPorId", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdUsuario", idUsuario);
 
             await connection.OpenAsync();
@@ -139,13 +98,11 @@ WHERE IdUsuario = @IdUsuario;";
 
         public async Task<bool> ExisteRolAsync(int idRol)
         {
-            const string sql = @"
-SELECT 1
-FROM Roles
-WHERE IdRol = @IdRol;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ExisteRol", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdRol", idRol);
 
             await connection.OpenAsync();
@@ -157,18 +114,16 @@ WHERE IdRol = @IdRol;";
 
         public async Task ActualizarPasswordHashPorEmailAsync(string email, string passwordHash)
         {
-            const string sql = @"
-UPDATE Usuarios
-SET PasswordHash = @PasswordHash
-WHERE Email = @Email;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ActualizarPasswordHashPorEmail", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@PasswordHash", passwordHash);
             command.Parameters.AddWithValue("@Email", email);
 
             await connection.OpenAsync();
-            var filas = await command.ExecuteNonQueryAsync();
+            var filas = Convert.ToInt32(await command.ExecuteScalarAsync() ?? 0);
 
             if (filas <= 0)
             {
@@ -178,18 +133,35 @@ WHERE Email = @Email;";
 
         public async Task ActualizarUltimoAccesoAsync(int idUsuario, DateTime fechaUltimoAcceso)
         {
-            const string sql = @"
-UPDATE Usuarios
-SET UltimoAcceso = @UltimoAcceso
-WHERE IdUsuario = @IdUsuario;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ActualizarUltimoAcceso", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@UltimoAcceso", fechaUltimoAcceso);
             command.Parameters.AddWithValue("@IdUsuario", idUsuario);
 
             await connection.OpenAsync();
             await command.ExecuteNonQueryAsync();
+        }
+
+        public async Task AsignarRolAsync(int idUsuario, int idRol)
+        {
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand("dbo.SP_Usuarios_AsignarRol", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
+
+            command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+            command.Parameters.AddWithValue("@IdRol", idRol);
+
+            await connection.OpenAsync();
+            var filas = Convert.ToInt32(await command.ExecuteScalarAsync() ?? 0);
+            if (filas <= 0)
+            {
+                throw new InvalidOperationException("No se pudo asignar el rol al usuario indicado.");
+            }
         }
     }
 }

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -23,6 +23,7 @@
 		<Compile Include="DAO\ReportesDAO.cs" />
 		<Compile Include="DAO\TokenRecuperacionDAO.cs" />
 		<Compile Include="DAO\UsuarioDAO.cs" />
+		<Compile Include="DAO\LandingDAO.cs" />
 		<ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
 	</ItemGroup>

--- a/PSA.EntidadesDTO/DTOs/Landing/LandingContenidoDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Landing/LandingContenidoDTO.cs
@@ -1,0 +1,8 @@
+namespace PSA.EntidadesDTO.DTOs.Landing
+{
+    public class LandingContenidoDTO
+    {
+        public string Titulo { get; set; } = string.Empty;
+        public string Descripcion { get; set; } = string.Empty;
+    }
+}

--- a/PSA.EntidadesDTO/DTOs/Usuarios/AsignarRolUsuarioDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Usuarios/AsignarRolUsuarioDTO.cs
@@ -1,0 +1,8 @@
+namespace PSA.EntidadesDTO.DTOs.Usuarios
+{
+    public class AsignarRolUsuarioDTO
+    {
+        public int IdUsuario { get; set; }
+        public int IdRol { get; set; }
+    }
+}

--- a/PSA.WebAPI/Controllers/AutenticacionController.cs
+++ b/PSA.WebAPI/Controllers/AutenticacionController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using PSA.AppCore.Managers;
 using PSA.EntidadesDTO.DTOs;
 using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
+using PSA.EntidadesDTO.DTOs.Usuarios;
 using PSA.WebAPI.Services;
 
 namespace PSA.WebAPI.Controllers
@@ -58,6 +59,20 @@ namespace PSA.WebAPI.Controllers
                 {
                     Mensaje = ex.Message
                 });
+            }
+        }
+
+        [HttpPost("asignar-rol")]
+        public async Task<IActionResult> AsignarRol([FromBody] AsignarRolUsuarioDTO dto)
+        {
+            try
+            {
+                await _autenticacionManager.AsignarRolAsync(dto);
+                return Ok(new { Mensaje = "Rol asignado correctamente." });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
             }
         }
 

--- a/PSA.WebAPI/Controllers/LandingController.cs
+++ b/PSA.WebAPI/Controllers/LandingController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using PSA.AppCore.Managers;
+
+namespace PSA.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class LandingController : ControllerBase
+    {
+        private readonly LandingManager _landingManager;
+
+        public LandingController(LandingManager landingManager)
+        {
+            _landingManager = landingManager;
+        }
+
+        [HttpGet("equipo")]
+        public async Task<IActionResult> ObtenerEquipo()
+        {
+            var data = await _landingManager.ObtenerEquipoAsync();
+            return Ok(data);
+        }
+
+        [HttpGet("producto")]
+        public async Task<IActionResult> ObtenerProducto()
+        {
+            var data = await _landingManager.ObtenerProductoAsync();
+            return Ok(data);
+        }
+    }
+}

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -16,6 +16,7 @@
     <Compile Include="Controllers\EvaluacionesTecnicasController.cs" />
     <Compile Include="Controllers\FincasController.cs" />
     <Compile Include="Controllers\HealthController.cs" />
+    <Compile Include="Controllers\LandingController.cs" />
     <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Controllers\Middleware\ExceptionMiddleware.cs" />
     <Compile Include="Controllers\Models\ApiResponse.cs" />

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddScoped<EvaluacionDAO>();
 builder.Services.AddScoped<AuditoriaLogDAO>();
 builder.Services.AddScoped<DashboardDAO>();
 builder.Services.AddScoped<ReportesDAO>();
+builder.Services.AddScoped<LandingDAO>();
 
 builder.Services.AddScoped<FincaService>();
 builder.Services.AddScoped<EvaluacionService>();
@@ -56,6 +57,7 @@ builder.Services.AddScoped<RecuperacionContrasenaManager>();
 builder.Services.AddScoped<EvaluacionTecnicaManager>();
 builder.Services.AddScoped<FincaManager>();
 builder.Services.AddScoped<ReportesManager>();
+builder.Services.AddScoped<LandingManager>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
### Motivation
- Centralizar la lógica crítica de autenticación, recuperación de contraseña, asignación de roles y contenido de landing en el motor de base de datos para no exponer reglas de negocio en capas inapropiadas. 
- Atender la retroalimentación recibida sobre el uso de `Stored Procedures` y preparar la aplicación para migraciones adicionales que reduzcan SQL inline en los DAOs. 

### Description
- Se agregó la migración SQL `BaseDatos/Migraciones/2026-04-migracion-logica-auth-landing-stored-procedures.sql` con múltiples stored procedures para registro, obtención de usuarios por email/id, validación de roles, actualización de password/último acceso, gestión de tokens de recuperación, asignación de roles y lectura de contenido de landing (`equipo`/`producto`). 
- `UsuarioDAO` y `TokenRecuperacionDAO` fueron modificados para invocar los stored procedures (`dbo.SP_Auth_*`), y se añadió `UsuarioDAO.AsignarRolAsync` que usa `dbo.SP_Usuarios_AsignarRol`. 
- Se añadió la capa de landing con `PSA.DataAccess/DAO/LandingDAO.cs`, `PSA.AppCore/Managers/LandingManager.cs` y el DTO `PSA.EntidadesDTO/DTOs/Landing/LandingContenidoDTO.cs`, además del controlador `PSA.WebAPI/Controllers/LandingController.cs` y sus endpoints `GET /api/Landing/equipo` y `GET /api/Landing/producto`. 
- Se introdujo la funcionalidad de asignación de roles vía API con `PSA.EntidadesDTO/DTOs/Usuarios/AsignarRolUsuarioDTO.cs`, el método `AutenticacionManager.AsignarRolAsync` y el endpoint `POST /api/Autenticacion/asignar-rol`, y se registraron las nuevas dependencias en `Program.cs` y los `.csproj` afectados. 

### Testing
- Se intentó compilar con `dotnet build PSA-Costa-Rica.slnx`, pero la ejecución falló por ausencia del SDK en el entorno (`/bin/bash: dotnet: command not found`). 
- Se ejecutaron búsquedas automáticas (`rg`) para verificar que los nuevos stored procedures se referencian desde los DAOs y que los nuevos controladores/métodos están integrados en el código, y las referencias encontradas coinciden con los cambios aplicados. 
- No se ejecutaron tests unitarios o de integración (no estaban disponibles en este entorno); se recomienda ejecutar `dotnet build` y la suite de tests en CI o en un entorno con `dotnet` instalado antes de desplegar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf0f41ec4832d92a0033783563ad7)