### PR TITLE
Move fincas/auth logic to stored procedures; add landing endpoints, role assignment and evidence handling

### DIFF
--- a/BaseDatos/Migraciones/2026-04-fix-fincas-catalogo-validacion-sp.sql
+++ b/BaseDatos/Migraciones/2026-04-fix-fincas-catalogo-validacion-sp.sql
@@ -1,0 +1,180 @@
+/*
+    Fix: robustecer validación de catálogo en SP de fincas para evitar caídas por catálogo no sembrado.
+    Fecha: 2026-04-12
+*/
+
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Fincas_Registrar
+    @IdPropietario INT,
+    @NombreFinca VARCHAR(150),
+    @Provincia VARCHAR(100),
+    @Canton VARCHAR(100),
+    @Distrito VARCHAR(100),
+    @DireccionExacta VARCHAR(250) = NULL,
+    @Latitud DECIMAL(9,6),
+    @Longitud DECIMAL(9,6),
+    @Hectareas DECIMAL(12,2),
+    @Vegetacion VARCHAR(100),
+    @TieneRecursosHidricos BIT,
+    @TieneRiosOQuebradas BIT,
+    @TieneNacientes BIT,
+    @CantidadNacientes INT,
+    @UsoSuelo VARCHAR(100),
+    @Pendiente VARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @IdPropietario <= 0
+        THROW 52001, 'El propietario es inválido.', 1;
+
+    IF @Hectareas <= 0
+        THROW 52002, 'El tamaño en hectáreas debe ser mayor a 0.', 1;
+
+    IF @Latitud < -90 OR @Latitud > 90
+        THROW 52003, 'La latitud debe estar entre -90 y 90.', 1;
+
+    IF @Longitud < -180 OR @Longitud > 180
+        THROW 52004, 'La longitud debe estar entre -180 y 180.', 1;
+
+    IF @TieneNacientes = 0
+        SET @CantidadNacientes = 0;
+
+    IF @TieneNacientes = 1 AND @CantidadNacientes <= 0
+        THROW 52005, 'Debe indicar una cantidad de nacientes mayor a 0.', 1;
+
+    IF @TieneNacientes = 0 AND @CantidadNacientes <> 0
+        THROW 52006, 'La cantidad de nacientes debe ser 0 cuando no posee nacientes.', 1;
+
+    IF @Vegetacion NOT IN ('Bosque primario', 'Bosque secundario', 'Plantación forestal', 'Pasto')
+        THROW 52007, 'El tipo de vegetación no es válido.', 1;
+
+    IF @UsoSuelo NOT IN ('Conservación', 'Producción forestal', 'Agroforestal', 'Ganadería', 'Mixto')
+        THROW 52008, 'El uso de suelo no es válido.', 1;
+
+    IF @Pendiente NOT IN ('Plana', 'Inclinada', 'Muy inclinada')
+        THROW 52009, 'El tipo de superficie (pendiente) no es válido.', 1;
+
+    INSERT INTO dbo.Fincas
+    (
+        IdPropietario,
+        NombreFinca,
+        Provincia,
+        Canton,
+        Distrito,
+        DireccionExacta,
+        Latitud,
+        Longitud,
+        Hectareas,
+        Vegetacion,
+        TieneRecursosHidricos,
+        TieneRiosOQuebradas,
+        TieneNacientes,
+        CantidadNacientes,
+        UsoSuelo,
+        Pendiente,
+        EstadoFinca
+    )
+    VALUES
+    (
+        @IdPropietario,
+        @NombreFinca,
+        @Provincia,
+        @Canton,
+        @Distrito,
+        @DireccionExacta,
+        @Latitud,
+        @Longitud,
+        @Hectareas,
+        @Vegetacion,
+        @TieneRecursosHidricos,
+        @TieneRiosOQuebradas,
+        @TieneNacientes,
+        @CantidadNacientes,
+        @UsoSuelo,
+        @Pendiente,
+        'Registrada'
+    );
+
+    SELECT CAST(SCOPE_IDENTITY() AS INT) AS IdFinca;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Fincas_Actualizar
+    @IdFinca INT,
+    @IdPropietario INT,
+    @NombreFinca VARCHAR(150),
+    @Provincia VARCHAR(100),
+    @Canton VARCHAR(100),
+    @Distrito VARCHAR(100),
+    @DireccionExacta VARCHAR(250) = NULL,
+    @Latitud DECIMAL(9,6),
+    @Longitud DECIMAL(9,6),
+    @Hectareas DECIMAL(12,2),
+    @Vegetacion VARCHAR(100),
+    @TieneRecursosHidricos BIT,
+    @TieneRiosOQuebradas BIT,
+    @TieneNacientes BIT,
+    @CantidadNacientes INT,
+    @UsoSuelo VARCHAR(100),
+    @Pendiente VARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @IdFinca <= 0 OR @IdPropietario <= 0
+        THROW 52010, 'Los identificadores de finca y propietario son obligatorios.', 1;
+
+    IF @Hectareas <= 0
+        THROW 52011, 'El tamaño en hectáreas debe ser mayor a 0.', 1;
+
+    IF @Latitud < -90 OR @Latitud > 90
+        THROW 52012, 'La latitud debe estar entre -90 y 90.', 1;
+
+    IF @Longitud < -180 OR @Longitud > 180
+        THROW 52013, 'La longitud debe estar entre -180 y 180.', 1;
+
+    IF @TieneNacientes = 0
+        SET @CantidadNacientes = 0;
+
+    IF @TieneNacientes = 1 AND @CantidadNacientes <= 0
+        THROW 52014, 'Debe indicar una cantidad de nacientes mayor a 0.', 1;
+
+    IF @TieneNacientes = 0 AND @CantidadNacientes <> 0
+        THROW 52015, 'La cantidad de nacientes debe ser 0 cuando no posee nacientes.', 1;
+
+    IF @Vegetacion NOT IN ('Bosque primario', 'Bosque secundario', 'Plantación forestal', 'Pasto')
+        THROW 52016, 'El tipo de vegetación no es válido.', 1;
+
+    IF @UsoSuelo NOT IN ('Conservación', 'Producción forestal', 'Agroforestal', 'Ganadería', 'Mixto')
+        THROW 52017, 'El uso de suelo no es válido.', 1;
+
+    IF @Pendiente NOT IN ('Plana', 'Inclinada', 'Muy inclinada')
+        THROW 52018, 'El tipo de superficie (pendiente) no es válido.', 1;
+
+    UPDATE dbo.Fincas
+    SET NombreFinca = @NombreFinca,
+        Provincia = @Provincia,
+        Canton = @Canton,
+        Distrito = @Distrito,
+        DireccionExacta = @DireccionExacta,
+        Latitud = @Latitud,
+        Longitud = @Longitud,
+        Hectareas = @Hectareas,
+        Vegetacion = @Vegetacion,
+        TieneRecursosHidricos = @TieneRecursosHidricos,
+        TieneRiosOQuebradas = @TieneRiosOQuebradas,
+        TieneNacientes = @TieneNacientes,
+        CantidadNacientes = @CantidadNacientes,
+        UsoSuelo = @UsoSuelo,
+        Pendiente = @Pendiente,
+        FechaActualizacion = SYSDATETIME()
+    WHERE IdFinca = @IdFinca
+      AND IdPropietario = @IdPropietario;
+
+    SELECT @@ROWCOUNT AS FilasAfectadas;
+END;
+GO

--- a/BaseDatos/Migraciones/2026-04-migracion-fincas-registro-stored-procedures.sql
+++ b/BaseDatos/Migraciones/2026-04-migracion-fincas-registro-stored-procedures.sql
@@ -1,0 +1,278 @@
+/*
+    Migración: Encapsula lógica de registro y mantenimiento de propiedades (fincas) en Stored Procedures.
+    Fecha: 2026-04-12
+*/
+
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Fincas_Registrar
+    @IdPropietario INT,
+    @NombreFinca VARCHAR(150),
+    @Provincia VARCHAR(100),
+    @Canton VARCHAR(100),
+    @Distrito VARCHAR(100),
+    @DireccionExacta VARCHAR(250) = NULL,
+    @Latitud DECIMAL(9,6),
+    @Longitud DECIMAL(9,6),
+    @Hectareas DECIMAL(12,2),
+    @Vegetacion VARCHAR(100),
+    @TieneRecursosHidricos BIT,
+    @TieneRiosOQuebradas BIT,
+    @TieneNacientes BIT,
+    @CantidadNacientes INT,
+    @UsoSuelo VARCHAR(100),
+    @Pendiente VARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @IdPropietario <= 0
+        THROW 52001, 'El propietario es inválido.', 1;
+
+    IF @Hectareas <= 0
+        THROW 52002, 'El tamaño en hectáreas debe ser mayor a 0.', 1;
+
+    IF @Latitud < -90 OR @Latitud > 90
+        THROW 52003, 'La latitud debe estar entre -90 y 90.', 1;
+
+    IF @Longitud < -180 OR @Longitud > 180
+        THROW 52004, 'La longitud debe estar entre -180 y 180.', 1;
+
+    IF @TieneNacientes = 0
+        SET @CantidadNacientes = 0;
+
+    IF @TieneNacientes = 1 AND @CantidadNacientes <= 0
+        THROW 52005, 'Debe indicar una cantidad de nacientes mayor a 0.', 1;
+
+    IF @TieneNacientes = 0 AND @CantidadNacientes <> 0
+        THROW 52006, 'La cantidad de nacientes debe ser 0 cuando no posee nacientes.', 1;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM dbo.CatalogoFincaValores
+        WHERE TipoCatalogo = 'Vegetacion'
+          AND Valor = @Vegetacion
+          AND Activo = 1
+    )
+        THROW 52007, 'El tipo de vegetación no es válido.', 1;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM dbo.CatalogoFincaValores
+        WHERE TipoCatalogo = 'UsoSuelo'
+          AND Valor = @UsoSuelo
+          AND Activo = 1
+    )
+        THROW 52008, 'El uso de suelo no es válido.', 1;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM dbo.CatalogoFincaValores
+        WHERE TipoCatalogo = 'Pendiente'
+          AND Valor = @Pendiente
+          AND Activo = 1
+    )
+        THROW 52009, 'El tipo de superficie (pendiente) no es válido.', 1;
+
+    INSERT INTO dbo.Fincas
+    (
+        IdPropietario,
+        NombreFinca,
+        Provincia,
+        Canton,
+        Distrito,
+        DireccionExacta,
+        Latitud,
+        Longitud,
+        Hectareas,
+        Vegetacion,
+        TieneRecursosHidricos,
+        TieneRiosOQuebradas,
+        TieneNacientes,
+        CantidadNacientes,
+        UsoSuelo,
+        Pendiente,
+        EstadoFinca
+    )
+    VALUES
+    (
+        @IdPropietario,
+        @NombreFinca,
+        @Provincia,
+        @Canton,
+        @Distrito,
+        @DireccionExacta,
+        @Latitud,
+        @Longitud,
+        @Hectareas,
+        @Vegetacion,
+        @TieneRecursosHidricos,
+        @TieneRiosOQuebradas,
+        @TieneNacientes,
+        @CantidadNacientes,
+        @UsoSuelo,
+        @Pendiente,
+        'Registrada'
+    );
+
+    SELECT CAST(SCOPE_IDENTITY() AS INT) AS IdFinca;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Fincas_Actualizar
+    @IdFinca INT,
+    @IdPropietario INT,
+    @NombreFinca VARCHAR(150),
+    @Provincia VARCHAR(100),
+    @Canton VARCHAR(100),
+    @Distrito VARCHAR(100),
+    @DireccionExacta VARCHAR(250) = NULL,
+    @Latitud DECIMAL(9,6),
+    @Longitud DECIMAL(9,6),
+    @Hectareas DECIMAL(12,2),
+    @Vegetacion VARCHAR(100),
+    @TieneRecursosHidricos BIT,
+    @TieneRiosOQuebradas BIT,
+    @TieneNacientes BIT,
+    @CantidadNacientes INT,
+    @UsoSuelo VARCHAR(100),
+    @Pendiente VARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @IdFinca <= 0 OR @IdPropietario <= 0
+        THROW 52010, 'Los identificadores de finca y propietario son obligatorios.', 1;
+
+    IF @Hectareas <= 0
+        THROW 52011, 'El tamaño en hectáreas debe ser mayor a 0.', 1;
+
+    IF @Latitud < -90 OR @Latitud > 90
+        THROW 52012, 'La latitud debe estar entre -90 y 90.', 1;
+
+    IF @Longitud < -180 OR @Longitud > 180
+        THROW 52013, 'La longitud debe estar entre -180 y 180.', 1;
+
+    IF @TieneNacientes = 0
+        SET @CantidadNacientes = 0;
+
+    IF @TieneNacientes = 1 AND @CantidadNacientes <= 0
+        THROW 52014, 'Debe indicar una cantidad de nacientes mayor a 0.', 1;
+
+    IF @TieneNacientes = 0 AND @CantidadNacientes <> 0
+        THROW 52015, 'La cantidad de nacientes debe ser 0 cuando no posee nacientes.', 1;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM dbo.CatalogoFincaValores
+        WHERE TipoCatalogo = 'Vegetacion'
+          AND Valor = @Vegetacion
+          AND Activo = 1
+    )
+        THROW 52016, 'El tipo de vegetación no es válido.', 1;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM dbo.CatalogoFincaValores
+        WHERE TipoCatalogo = 'UsoSuelo'
+          AND Valor = @UsoSuelo
+          AND Activo = 1
+    )
+        THROW 52017, 'El uso de suelo no es válido.', 1;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM dbo.CatalogoFincaValores
+        WHERE TipoCatalogo = 'Pendiente'
+          AND Valor = @Pendiente
+          AND Activo = 1
+    )
+        THROW 52018, 'El tipo de superficie (pendiente) no es válido.', 1;
+
+    UPDATE dbo.Fincas
+    SET NombreFinca = @NombreFinca,
+        Provincia = @Provincia,
+        Canton = @Canton,
+        Distrito = @Distrito,
+        DireccionExacta = @DireccionExacta,
+        Latitud = @Latitud,
+        Longitud = @Longitud,
+        Hectareas = @Hectareas,
+        Vegetacion = @Vegetacion,
+        TieneRecursosHidricos = @TieneRecursosHidricos,
+        TieneRiosOQuebradas = @TieneRiosOQuebradas,
+        TieneNacientes = @TieneNacientes,
+        CantidadNacientes = @CantidadNacientes,
+        UsoSuelo = @UsoSuelo,
+        Pendiente = @Pendiente,
+        FechaActualizacion = SYSDATETIME()
+    WHERE IdFinca = @IdFinca
+      AND IdPropietario = @IdPropietario;
+
+    SELECT @@ROWCOUNT AS FilasAfectadas;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Fincas_Eliminar
+    @IdFinca INT,
+    @IdPropietario INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DELETE FROM dbo.Fincas
+    WHERE IdFinca = @IdFinca
+      AND IdPropietario = @IdPropietario;
+
+    SELECT @@ROWCOUNT AS FilasAfectadas;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Fincas_CatalogoValores
+    @TipoCatalogo VARCHAR(30)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT Valor
+    FROM dbo.CatalogoFincaValores
+    WHERE TipoCatalogo = @TipoCatalogo
+      AND Activo = 1
+    ORDER BY OrdenVisual, Valor;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_FincaEvidencias_Crear
+    @IdFinca INT,
+    @NombreArchivo VARCHAR(200),
+    @RutaArchivo VARCHAR(500),
+    @TipoArchivo VARCHAR(50),
+    @CargadoPor INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    INSERT INTO dbo.FincaEvidencias
+    (
+        IdFinca,
+        NombreArchivo,
+        RutaArchivo,
+        TipoArchivo,
+        FechaCarga,
+        CargadoPor
+    )
+    VALUES
+    (
+        @IdFinca,
+        @NombreArchivo,
+        @RutaArchivo,
+        @TipoArchivo,
+        SYSDATETIME(),
+        @CargadoPor
+    );
+
+    SELECT CAST(SCOPE_IDENTITY() AS INT) AS IdEvidencia;
+END;
+GO

--- a/BaseDatos/Migraciones/2026-04-migracion-logica-auth-landing-stored-procedures.sql
+++ b/BaseDatos/Migraciones/2026-04-migracion-logica-auth-landing-stored-procedures.sql
@@ -1,0 +1,225 @@
+/*
+    Migración: Centraliza lógica crítica de autenticación y landing pages en Stored Procedures.
+    Fecha: 2026-04-12
+*/
+
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_RegistrarUsuario
+    @NombreCompleto NVARCHAR(150),
+    @Email NVARCHAR(150),
+    @PasswordHash NVARCHAR(300),
+    @IdRol INT,
+    @Estado VARCHAR(20),
+    @FechaCreacion DATETIME2,
+    @UltimoAcceso DATETIME2 = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    INSERT INTO dbo.Usuarios
+    (
+        NombreCompleto,
+        Email,
+        PasswordHash,
+        IdRol,
+        Estado,
+        FechaCreacion,
+        UltimoAcceso
+    )
+    VALUES
+    (
+        @NombreCompleto,
+        @Email,
+        @PasswordHash,
+        @IdRol,
+        @Estado,
+        @FechaCreacion,
+        @UltimoAcceso
+    );
+
+    SELECT CAST(SCOPE_IDENTITY() AS INT) AS IdUsuario;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ObtenerUsuarioPorEmail
+    @Email NVARCHAR(150)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT TOP 1
+        IdUsuario,
+        NombreCompleto,
+        Email,
+        PasswordHash,
+        IdRol,
+        Estado,
+        FechaCreacion,
+        UltimoAcceso
+    FROM dbo.Usuarios
+    WHERE Email = @Email;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ObtenerUsuarioPorId
+    @IdUsuario INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT TOP 1
+        IdUsuario,
+        NombreCompleto,
+        Email,
+        PasswordHash,
+        IdRol,
+        Estado,
+        FechaCreacion,
+        UltimoAcceso
+    FROM dbo.Usuarios
+    WHERE IdUsuario = @IdUsuario;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ExisteRol
+    @IdRol INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SELECT TOP 1 1 AS Existe
+    FROM dbo.Roles
+    WHERE IdRol = @IdRol;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ActualizarPasswordHashPorEmail
+    @Email NVARCHAR(150),
+    @PasswordHash NVARCHAR(300)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.Usuarios
+    SET PasswordHash = @PasswordHash
+    WHERE Email = @Email;
+
+    SELECT @@ROWCOUNT AS FilasAfectadas;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ActualizarUltimoAcceso
+    @IdUsuario INT,
+    @UltimoAcceso DATETIME2
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.Usuarios
+    SET UltimoAcceso = @UltimoAcceso
+    WHERE IdUsuario = @IdUsuario;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Usuarios_AsignarRol
+    @IdUsuario INT,
+    @IdRol INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.Usuarios
+    SET IdRol = @IdRol
+    WHERE IdUsuario = @IdUsuario;
+
+    SELECT @@ROWCOUNT AS FilasAfectadas;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_InvalidarTokensActivos
+    @IdUsuario INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.TokensRecuperacion
+    SET Usado = 1,
+        FechaUso = SYSDATETIME()
+    WHERE IdUsuario = @IdUsuario
+      AND Usado = 0
+      AND FechaExpiracion > SYSDATETIME();
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_CrearTokenRecuperacion
+    @IdUsuario INT,
+    @Token NVARCHAR(255),
+    @FechaExpiracion DATETIME2
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    INSERT INTO dbo.TokensRecuperacion (IdUsuario, Token, FechaExpiracion, Usado)
+    VALUES (@IdUsuario, @Token, @FechaExpiracion, 0);
+
+    SELECT CAST(SCOPE_IDENTITY() AS INT) AS IdToken;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_ObtenerTokenVigente
+    @Token NVARCHAR(255)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT TOP 1
+        IdToken,
+        IdUsuario,
+        Token,
+        FechaCreacion,
+        FechaExpiracion,
+        Usado,
+        FechaUso
+    FROM dbo.TokensRecuperacion
+    WHERE Token = @Token
+      AND Usado = 0
+      AND FechaExpiracion > SYSDATETIME();
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Auth_MarcarTokenComoUsado
+    @IdToken INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    UPDATE dbo.TokensRecuperacion
+    SET Usado = 1,
+        FechaUso = SYSDATETIME()
+    WHERE IdToken = @IdToken;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Landing_ObtenerEquipo
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        CAST(N'Equipo PSA Costa Rica' AS NVARCHAR(200)) AS Titulo,
+        CAST(N'Aplicamos arquitectura por capas, SQL Server y seguridad de datos orientada a procesos forestales.' AS NVARCHAR(500)) AS Descripcion;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Landing_ObtenerProducto
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        CAST(N'Producto PSA' AS NVARCHAR(200)) AS Titulo,
+        CAST(N'Plataforma para gestión de fincas, evaluaciones técnicas, pagos y trazabilidad con auditoría.' AS NVARCHAR(500)) AS Descripcion;
+END;
+GO

--- a/PSA.AppCore/Managers/AutenticacionManager.cs
+++ b/PSA.AppCore/Managers/AutenticacionManager.cs
@@ -1,6 +1,7 @@
 using PSA.AppCore.Servicios;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
+using PSA.EntidadesDTO.DTOs.Usuarios;
 using PSA.EntidadesDTO.Entidades;
 
 namespace PSA.AppCore.Managers
@@ -123,6 +124,30 @@ namespace PSA.AppCore.Managers
                 UltimoAcceso = fechaAcceso,
                 Mensaje = "Inicio de sesión exitoso."
             };
+        }
+
+        public async Task AsignarRolAsync(AsignarRolUsuarioDTO dto)
+        {
+            if (dto.IdUsuario <= 0)
+                throw new Exception("El Id del usuario es inválido.");
+
+            if (dto.IdRol <= 0)
+                throw new Exception("El Id del rol es inválido.");
+
+            var rolExiste = await _usuarioDAO.ExisteRolAsync(dto.IdRol);
+            if (!rolExiste)
+                throw new Exception("El rol indicado no existe.");
+
+            await _usuarioDAO.AsignarRolAsync(dto.IdUsuario, dto.IdRol);
+
+            await _auditoriaLogDAO.RegistrarEventoAsync(
+                idUsuario: dto.IdUsuario,
+                modulo: "Autenticacion",
+                tablaAfectada: "Usuarios",
+                idRegistroAfectado: dto.IdUsuario,
+                accion: "ASIGNACION_ROL",
+                detalle: $"Rol {dto.IdRol} asignado al usuario {dto.IdUsuario}."
+            );
         }
     }
 }

--- a/PSA.AppCore/Managers/FincaManager.cs
+++ b/PSA.AppCore/Managers/FincaManager.cs
@@ -19,18 +19,25 @@ public class FincaManager
 
     public async Task<int> RegistrarFincaAsync(RegistrarFincaDTO dto)
     {
-        var idFinca = await _fincaDao.CrearFincaAsync(dto);
-
         try
         {
-            await _evaluacionTecnicaManager.CrearPendientePorNuevaFincaAsync(idFinca);
+            var idFinca = await _fincaDao.CrearFincaAsync(dto);
+
+            try
+            {
+                await _evaluacionTecnicaManager.CrearPendientePorNuevaFincaAsync(idFinca);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"No se pudo crear la evaluación técnica pendiente para la finca {idFinca}: {ex.Message}");
+            }
+
+            return idFinca;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"No se pudo crear la evaluación técnica pendiente para la finca {idFinca}: {ex.Message}");
+            throw new InvalidOperationException($"No se pudo registrar la finca: {ex.Message}", ex);
         }
-
-        return idFinca;
     }
 
     public Task<bool> ActualizarFincaAsync(int idFinca, RegistrarFincaDTO dto) => _fincaDao.ActualizarFincaAsync(idFinca, dto);

--- a/PSA.AppCore/Managers/LandingManager.cs
+++ b/PSA.AppCore/Managers/LandingManager.cs
@@ -1,0 +1,35 @@
+using PSA.DataAccess.DAO;
+using PSA.EntidadesDTO.DTOs.Landing;
+
+namespace PSA.AppCore.Managers
+{
+    public class LandingManager
+    {
+        private readonly LandingDAO _landingDao;
+
+        public LandingManager(LandingDAO landingDao)
+        {
+            _landingDao = landingDao;
+        }
+
+        public async Task<LandingContenidoDTO> ObtenerEquipoAsync()
+        {
+            var data = await _landingDao.ObtenerContenidoEquipoAsync();
+            return new LandingContenidoDTO
+            {
+                Titulo = data.Titulo,
+                Descripcion = data.Descripcion
+            };
+        }
+
+        public async Task<LandingContenidoDTO> ObtenerProductoAsync()
+        {
+            var data = await _landingDao.ObtenerContenidoProductoAsync();
+            return new LandingContenidoDTO
+            {
+                Titulo = data.Titulo,
+                Descripcion = data.Descripcion
+            };
+        }
+    }
+}

--- a/PSA.DataAccess/DAO/FincaDAO.cs
+++ b/PSA.DataAccess/DAO/FincaDAO.cs
@@ -311,136 +311,122 @@ WHERE IdFinca = @IdFinca";
                 command.Parameters.AddWithValue("@FechaActualizacion", finca.FechaActualizacion);
             }
 
-            public async Task<int> CrearFincaAsync(RegistrarFincaDTO dto)
+        public async Task<int> CrearFincaAsync(RegistrarFincaDTO dto)
         {
-            const string sql = @"
-INSERT INTO Fincas
-(
-    IdPropietario,
-    NombreFinca,
-    Provincia,
-    Canton,
-    Distrito,
-    DireccionExacta,
-    Latitud,
-    Longitud,
-    Hectareas,
-    Vegetacion,
-    TieneRecursosHidricos,
-    UsoSuelo,
-    Pendiente,
-    EstadoFinca
-)
-VALUES
-(
-    @IdPropietario,
-    @NombreFinca,
-    @Provincia,
-    @Canton,
-    @Distrito,
-    @DireccionExacta,
-    @Latitud,
-    @Longitud,
-    @Hectareas,
-    @Vegetacion,
-    @TieneRecursosHidricos,
-    @UsoSuelo,
-    @Pendiente,
-    'Registrada'
-);
-SELECT CAST(SCOPE_IDENTITY() AS INT);";
+            try
+            {
+                using var connection = _connectionFactory.CreateConnection();
+                using var command = new SqlCommand("dbo.SP_Fincas_Registrar", connection)
+                {
+                    CommandType = System.Data.CommandType.StoredProcedure
+                };
+                command.Parameters.AddWithValue("@IdPropietario", dto.IdPropietario);
+                command.Parameters.AddWithValue("@NombreFinca", dto.NombreFinca);
+                command.Parameters.AddWithValue("@Provincia", dto.Provincia);
+                command.Parameters.AddWithValue("@Canton", dto.Canton);
+                command.Parameters.AddWithValue("@Distrito", dto.Distrito);
+                command.Parameters.AddWithValue("@DireccionExacta", (object?)dto.DireccionExacta ?? DBNull.Value);
+                command.Parameters.AddWithValue("@Latitud", dto.Latitud);
+                command.Parameters.AddWithValue("@Longitud", dto.Longitud);
+                command.Parameters.AddWithValue("@Hectareas", dto.Hectareas);
+                command.Parameters.AddWithValue("@Vegetacion", dto.Vegetacion);
+                command.Parameters.AddWithValue("@TieneRecursosHidricos", dto.TieneRecursosHidricos);
+                command.Parameters.AddWithValue("@TieneRiosOQuebradas", dto.TieneRiosOQuebradas);
+                command.Parameters.AddWithValue("@TieneNacientes", dto.TieneNacientes);
+                command.Parameters.AddWithValue("@CantidadNacientes", dto.CantidadNacientes);
+                command.Parameters.AddWithValue("@UsoSuelo", dto.UsoSuelo);
+                command.Parameters.AddWithValue("@Pendiente", dto.Pendiente);
 
-            using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
-            command.Parameters.AddWithValue("@IdPropietario", dto.IdPropietario);
-            command.Parameters.AddWithValue("@NombreFinca", dto.NombreFinca);
-            command.Parameters.AddWithValue("@Provincia", dto.Provincia);
-            command.Parameters.AddWithValue("@Canton", dto.Canton);
-            command.Parameters.AddWithValue("@Distrito", dto.Distrito);
-            command.Parameters.AddWithValue("@DireccionExacta", (object?)dto.DireccionExacta ?? DBNull.Value);
-            command.Parameters.AddWithValue("@Latitud", dto.Latitud);
-            command.Parameters.AddWithValue("@Longitud", dto.Longitud);
-            command.Parameters.AddWithValue("@Hectareas", dto.Hectareas);
-            command.Parameters.AddWithValue("@Vegetacion", dto.Vegetacion);
-            command.Parameters.AddWithValue("@TieneRecursosHidricos", dto.TieneRecursosHidricos);
-            command.Parameters.AddWithValue("@UsoSuelo", dto.UsoSuelo);
-            command.Parameters.AddWithValue("@Pendiente", dto.Pendiente);
-
-            await connection.OpenAsync();
-            var resultado = await command.ExecuteScalarAsync();
-            return resultado != null ? Convert.ToInt32(resultado) : 0;
+                await connection.OpenAsync();
+                var resultado = await command.ExecuteScalarAsync();
+                return resultado != null ? Convert.ToInt32(resultado) : 0;
+            }
+            catch (SqlException ex)
+            {
+                throw new InvalidOperationException($"No fue posible registrar la finca: {ex.Message}", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("Error inesperado al registrar la finca.", ex);
+            }
         }
 
         public async Task<bool> ActualizarFincaAsync(int idFinca, RegistrarFincaDTO dto)
         {
-            const string sql = @"
-UPDATE Fincas
-SET NombreFinca = @NombreFinca,
-    Provincia = @Provincia,
-    Canton = @Canton,
-    Distrito = @Distrito,
-    DireccionExacta = @DireccionExacta,
-    Latitud = @Latitud,
-    Longitud = @Longitud,
-    Hectareas = @Hectareas,
-    Vegetacion = @Vegetacion,
-    TieneRecursosHidricos = @TieneRecursosHidricos,
-    UsoSuelo = @UsoSuelo,
-    Pendiente = @Pendiente,
-    FechaActualizacion = SYSDATETIME()
-WHERE IdFinca = @IdFinca
-  AND IdPropietario = @IdPropietario;";
+            try
+            {
+                using var connection = _connectionFactory.CreateConnection();
+                using var command = new SqlCommand("dbo.SP_Fincas_Actualizar", connection)
+                {
+                    CommandType = System.Data.CommandType.StoredProcedure
+                };
+                command.Parameters.AddWithValue("@IdFinca", idFinca);
+                command.Parameters.AddWithValue("@IdPropietario", dto.IdPropietario);
+                command.Parameters.AddWithValue("@NombreFinca", dto.NombreFinca);
+                command.Parameters.AddWithValue("@Provincia", dto.Provincia);
+                command.Parameters.AddWithValue("@Canton", dto.Canton);
+                command.Parameters.AddWithValue("@Distrito", dto.Distrito);
+                command.Parameters.AddWithValue("@DireccionExacta", (object?)dto.DireccionExacta ?? DBNull.Value);
+                command.Parameters.AddWithValue("@Latitud", dto.Latitud);
+                command.Parameters.AddWithValue("@Longitud", dto.Longitud);
+                command.Parameters.AddWithValue("@Hectareas", dto.Hectareas);
+                command.Parameters.AddWithValue("@Vegetacion", dto.Vegetacion);
+                command.Parameters.AddWithValue("@TieneRecursosHidricos", dto.TieneRecursosHidricos);
+                command.Parameters.AddWithValue("@TieneRiosOQuebradas", dto.TieneRiosOQuebradas);
+                command.Parameters.AddWithValue("@TieneNacientes", dto.TieneNacientes);
+                command.Parameters.AddWithValue("@CantidadNacientes", dto.CantidadNacientes);
+                command.Parameters.AddWithValue("@UsoSuelo", dto.UsoSuelo);
+                command.Parameters.AddWithValue("@Pendiente", dto.Pendiente);
 
-            using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
-            command.Parameters.AddWithValue("@IdFinca", idFinca);
-            command.Parameters.AddWithValue("@IdPropietario", dto.IdPropietario);
-            command.Parameters.AddWithValue("@NombreFinca", dto.NombreFinca);
-            command.Parameters.AddWithValue("@Provincia", dto.Provincia);
-            command.Parameters.AddWithValue("@Canton", dto.Canton);
-            command.Parameters.AddWithValue("@Distrito", dto.Distrito);
-            command.Parameters.AddWithValue("@DireccionExacta", (object?)dto.DireccionExacta ?? DBNull.Value);
-            command.Parameters.AddWithValue("@Latitud", dto.Latitud);
-            command.Parameters.AddWithValue("@Longitud", dto.Longitud);
-            command.Parameters.AddWithValue("@Hectareas", dto.Hectareas);
-            command.Parameters.AddWithValue("@Vegetacion", dto.Vegetacion);
-            command.Parameters.AddWithValue("@TieneRecursosHidricos", dto.TieneRecursosHidricos);
-            command.Parameters.AddWithValue("@UsoSuelo", dto.UsoSuelo);
-            command.Parameters.AddWithValue("@Pendiente", dto.Pendiente);
-
-            await connection.OpenAsync();
-            return await command.ExecuteNonQueryAsync() > 0;
+                await connection.OpenAsync();
+                var filasAfectadas = Convert.ToInt32(await command.ExecuteScalarAsync() ?? 0);
+                return filasAfectadas > 0;
+            }
+            catch (SqlException ex)
+            {
+                throw new InvalidOperationException($"No fue posible actualizar la finca: {ex.Message}", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("Error inesperado al actualizar la finca.", ex);
+            }
         }
 
         public async Task<bool> EliminarFincaAsync(int idFinca, int idPropietario)
         {
-            const string sql = @"
-DELETE FROM Fincas
-WHERE IdFinca = @IdFinca
-  AND IdPropietario = @IdPropietario;";
+            try
+            {
+                using var connection = _connectionFactory.CreateConnection();
+                using var command = new SqlCommand("dbo.SP_Fincas_Eliminar", connection)
+                {
+                    CommandType = System.Data.CommandType.StoredProcedure
+                };
+                command.Parameters.AddWithValue("@IdFinca", idFinca);
+                command.Parameters.AddWithValue("@IdPropietario", idPropietario);
 
-            using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
-            command.Parameters.AddWithValue("@IdFinca", idFinca);
-            command.Parameters.AddWithValue("@IdPropietario", idPropietario);
-
-            await connection.OpenAsync();
-            return await command.ExecuteNonQueryAsync() > 0;
+                await connection.OpenAsync();
+                var filasAfectadas = Convert.ToInt32(await command.ExecuteScalarAsync() ?? 0);
+                return filasAfectadas > 0;
+            }
+            catch (SqlException ex)
+            {
+                throw new InvalidOperationException($"No fue posible eliminar la finca: {ex.Message}", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("Error inesperado al eliminar la finca.", ex);
+            }
         }
 
         public async Task<List<string>> ObtenerCatalogoFactorAsync(string tipoFactor)
         {
-            const string sql = @"
-SELECT Valor
-FROM CatalogoFincaValores
-WHERE TipoCatalogo = @TipoCatalogo
-  AND Activo = 1
-ORDER BY OrdenVisual, Valor;";
-
             var resultados = new List<string>();
 
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Fincas_CatalogoValores", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@TipoCatalogo", tipoFactor);
 
             await connection.OpenAsync();

--- a/PSA.DataAccess/DAO/FincaEvidenciaDAO.cs
+++ b/PSA.DataAccess/DAO/FincaEvidenciaDAO.cs
@@ -17,29 +17,11 @@ namespace PSA.DataAccess.DAO
 
         public async Task<int> CrearAsync(FincaEvidencia evidencia)
         {
-            const string sql = @"
-INSERT INTO FincaEvidencias
-(
-    IdFinca,
-    NombreArchivo,
-    RutaArchivo,
-    TipoArchivo,
-    FechaCarga,
-    CargadoPor
-)
-VALUES
-(
-    @IdFinca,
-    @NombreArchivo,
-    @RutaArchivo,
-    @TipoArchivo,
-    SYSDATETIME(),
-    @CargadoPor
-);
-SELECT CAST(SCOPE_IDENTITY() AS INT);";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_FincaEvidencias_Crear", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
 
             command.Parameters.AddWithValue("@IdFinca", evidencia.FincaId);
             command.Parameters.AddWithValue("@NombreArchivo", evidencia.NombreArchivo);

--- a/PSA.DataAccess/DAO/LandingDAO.cs
+++ b/PSA.DataAccess/DAO/LandingDAO.cs
@@ -1,0 +1,45 @@
+using Microsoft.Data.SqlClient;
+
+namespace PSA.DataAccess.DAO
+{
+    public class LandingDAO
+    {
+        private readonly IDbConnectionFactory _connectionFactory;
+
+        public LandingDAO(IDbConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+        }
+
+        public async Task<(string Titulo, string Descripcion)> ObtenerContenidoEquipoAsync()
+        {
+            return await EjecutarConsultaLandingAsync("dbo.SP_Landing_ObtenerEquipo");
+        }
+
+        public async Task<(string Titulo, string Descripcion)> ObtenerContenidoProductoAsync()
+        {
+            return await EjecutarConsultaLandingAsync("dbo.SP_Landing_ObtenerProducto");
+        }
+
+        private async Task<(string Titulo, string Descripcion)> EjecutarConsultaLandingAsync(string nombreSp)
+        {
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(nombreSp, connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
+
+            await connection.OpenAsync();
+            using var reader = await command.ExecuteReaderAsync();
+            if (!await reader.ReadAsync())
+            {
+                return (string.Empty, string.Empty);
+            }
+
+            return (
+                reader["Titulo"]?.ToString() ?? string.Empty,
+                reader["Descripcion"]?.ToString() ?? string.Empty
+            );
+        }
+    }
+}

--- a/PSA.DataAccess/DAO/TokenRecuperacionDAO.cs
+++ b/PSA.DataAccess/DAO/TokenRecuperacionDAO.cs
@@ -16,16 +16,11 @@ namespace PSA.DataAccess.DAO
 
         public async Task InvalidarTokensActivosPorUsuarioAsync(int idUsuario)
         {
-            const string sql = @"
-UPDATE TokensRecuperacion
-SET Usado = 1,
-    FechaUso = SYSDATETIME()
-WHERE IdUsuario = @IdUsuario
-  AND Usado = 0
-  AND FechaExpiracion > SYSDATETIME();";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_InvalidarTokensActivos", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdUsuario", idUsuario);
             await connection.OpenAsync();
             await command.ExecuteNonQueryAsync();
@@ -33,13 +28,11 @@ WHERE IdUsuario = @IdUsuario
 
         public async Task<int> CrearTokenAsync(int idUsuario, string token, DateTime fechaExpiracionUtc)
         {
-            const string sql = @"
-INSERT INTO TokensRecuperacion (IdUsuario, Token, FechaExpiracion, Usado)
-VALUES (@IdUsuario, @Token, @FechaExpiracion, 0);
-SELECT CAST(SCOPE_IDENTITY() AS INT);";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_CrearTokenRecuperacion", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdUsuario", idUsuario);
             command.Parameters.AddWithValue("@Token", token);
             command.Parameters.AddWithValue("@FechaExpiracion", fechaExpiracionUtc);
@@ -50,15 +43,11 @@ SELECT CAST(SCOPE_IDENTITY() AS INT);";
 
         public async Task<TokenRecuperacion?> ObtenerTokenVigenteAsync(string token)
         {
-            const string sql = @"
-SELECT TOP 1 IdToken, IdUsuario, Token, FechaCreacion, FechaExpiracion, Usado, FechaUso
-FROM TokensRecuperacion
-WHERE Token = @Token
-  AND Usado = 0
-  AND FechaExpiracion > SYSDATETIME();";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ObtenerTokenVigente", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@Token", token);
             await connection.OpenAsync();
             using var reader = await command.ExecuteReaderAsync();
@@ -82,14 +71,11 @@ WHERE Token = @Token
 
         public async Task MarcarTokenComoUsadoAsync(int idToken)
         {
-            const string sql = @"
-UPDATE TokensRecuperacion
-SET Usado = 1,
-    FechaUso = SYSDATETIME()
-WHERE IdToken = @IdToken;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_MarcarTokenComoUsado", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdToken", idToken);
             await connection.OpenAsync();
             await command.ExecuteNonQueryAsync();

--- a/PSA.DataAccess/DAO/UsuarioDAO.cs
+++ b/PSA.DataAccess/DAO/UsuarioDAO.cs
@@ -16,32 +16,11 @@ namespace PSA.DataAccess.DAO
 
         public async Task<int> CrearUsuarioAsync(Usuario usuario)
         {
-            const string sql = @"
-INSERT INTO Usuarios
-(
-    NombreCompleto,
-    Email,
-    PasswordHash,
-    IdRol,
-    Estado,
-    FechaCreacion,
-    UltimoAcceso
-)
-VALUES
-(
-    @NombreCompleto,
-    @Email,
-    @PasswordHash,
-    @IdRol,
-    @Estado,
-    @FechaCreacion,
-    @UltimoAcceso
-);
-
-SELECT CAST(SCOPE_IDENTITY() AS INT);";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_RegistrarUsuario", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
 
             command.Parameters.AddWithValue("@NombreCompleto", usuario.NombreCompleto);
             command.Parameters.AddWithValue("@Email", usuario.Email);
@@ -59,21 +38,11 @@ SELECT CAST(SCOPE_IDENTITY() AS INT);";
 
         public async Task<Usuario?> ObtenerPorEmailAsync(string email)
         {
-            const string sql = @"
-SELECT TOP 1
-    IdUsuario,
-    NombreCompleto,
-    Email,
-    PasswordHash,
-    IdRol,
-    Estado,
-    FechaCreacion,
-    UltimoAcceso
-FROM Usuarios
-WHERE Email = @Email;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ObtenerUsuarioPorEmail", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
 
             command.Parameters.AddWithValue("@Email", email);
 
@@ -101,21 +70,11 @@ WHERE Email = @Email;";
 
         public async Task<Usuario?> ObtenerPorIdAsync(int idUsuario)
         {
-            const string sql = @"
-SELECT TOP 1
-    IdUsuario,
-    NombreCompleto,
-    Email,
-    PasswordHash,
-    IdRol,
-    Estado,
-    FechaCreacion,
-    UltimoAcceso
-FROM Usuarios
-WHERE IdUsuario = @IdUsuario;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ObtenerUsuarioPorId", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdUsuario", idUsuario);
 
             await connection.OpenAsync();
@@ -139,13 +98,11 @@ WHERE IdUsuario = @IdUsuario;";
 
         public async Task<bool> ExisteRolAsync(int idRol)
         {
-            const string sql = @"
-SELECT 1
-FROM Roles
-WHERE IdRol = @IdRol;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ExisteRol", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@IdRol", idRol);
 
             await connection.OpenAsync();
@@ -157,18 +114,16 @@ WHERE IdRol = @IdRol;";
 
         public async Task ActualizarPasswordHashPorEmailAsync(string email, string passwordHash)
         {
-            const string sql = @"
-UPDATE Usuarios
-SET PasswordHash = @PasswordHash
-WHERE Email = @Email;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ActualizarPasswordHashPorEmail", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@PasswordHash", passwordHash);
             command.Parameters.AddWithValue("@Email", email);
 
             await connection.OpenAsync();
-            var filas = await command.ExecuteNonQueryAsync();
+            var filas = Convert.ToInt32(await command.ExecuteScalarAsync() ?? 0);
 
             if (filas <= 0)
             {
@@ -178,18 +133,35 @@ WHERE Email = @Email;";
 
         public async Task ActualizarUltimoAccesoAsync(int idUsuario, DateTime fechaUltimoAcceso)
         {
-            const string sql = @"
-UPDATE Usuarios
-SET UltimoAcceso = @UltimoAcceso
-WHERE IdUsuario = @IdUsuario;";
-
             using var connection = _connectionFactory.CreateConnection();
-            using var command = new SqlCommand(sql, connection);
+            using var command = new SqlCommand("dbo.SP_Auth_ActualizarUltimoAcceso", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command.Parameters.AddWithValue("@UltimoAcceso", fechaUltimoAcceso);
             command.Parameters.AddWithValue("@IdUsuario", idUsuario);
 
             await connection.OpenAsync();
             await command.ExecuteNonQueryAsync();
+        }
+
+        public async Task AsignarRolAsync(int idUsuario, int idRol)
+        {
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand("dbo.SP_Usuarios_AsignarRol", connection)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
+
+            command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+            command.Parameters.AddWithValue("@IdRol", idRol);
+
+            await connection.OpenAsync();
+            var filas = Convert.ToInt32(await command.ExecuteScalarAsync() ?? 0);
+            if (filas <= 0)
+            {
+                throw new InvalidOperationException("No se pudo asignar el rol al usuario indicado.");
+            }
         }
     }
 }

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -23,6 +23,7 @@
 		<Compile Include="DAO\ReportesDAO.cs" />
 		<Compile Include="DAO\TokenRecuperacionDAO.cs" />
 		<Compile Include="DAO\UsuarioDAO.cs" />
+		<Compile Include="DAO\LandingDAO.cs" />
 		<ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
 	</ItemGroup>

--- a/PSA.EntidadesDTO/DTOs/Landing/LandingContenidoDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Landing/LandingContenidoDTO.cs
@@ -1,0 +1,8 @@
+namespace PSA.EntidadesDTO.DTOs.Landing
+{
+    public class LandingContenidoDTO
+    {
+        public string Titulo { get; set; } = string.Empty;
+        public string Descripcion { get; set; } = string.Empty;
+    }
+}

--- a/PSA.EntidadesDTO/DTOs/Usuarios/AsignarRolUsuarioDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Usuarios/AsignarRolUsuarioDTO.cs
@@ -1,0 +1,8 @@
+namespace PSA.EntidadesDTO.DTOs.Usuarios
+{
+    public class AsignarRolUsuarioDTO
+    {
+        public int IdUsuario { get; set; }
+        public int IdRol { get; set; }
+    }
+}

--- a/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
+++ b/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
@@ -23,6 +23,7 @@
     <Compile Include="DTOs\Fincas\FincaDTO.cs" />
     <Compile Include="DTOs\Fincas\FincaEvidenciaDTO.cs" />
     <Compile Include="DTOs\InicioSesionDTO.cs" />
+    <Compile Include="DTOs\Landing\LandingContenidoDTO.cs" />
     <Compile Include="DTOs\Notificaciones\NotificacionDTO.cs" />
     <Compile Include="DTOs\Pagos\ConfiguracionPagoDTO.cs" />
     <Compile Include="DTOs\Pagos\CuentaBancariaDTO.cs" />
@@ -39,6 +40,7 @@
     <Compile Include="DTOs\RespuestaInicioSesionDTO.cs" />
     <Compile Include="DTOs\RestablecerContrasenaDTO.cs" />
     <Compile Include="DTOs\Usuarios\RolDTO.cs" />
+    <Compile Include="DTOs\Usuarios\AsignarRolUsuarioDTO.cs" />
     <Compile Include="DTOs\Usuarios\TokenRecuperacionDTO.cs" />
     <Compile Include="DTOs\Usuarios\UsuarioDTO.cs" />
     <Compile Include="DTOs\ValidarTokenRecuperacionDTO.cs" />

--- a/PSA.WebAPI/Controllers/AutenticacionController.cs
+++ b/PSA.WebAPI/Controllers/AutenticacionController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using PSA.AppCore.Managers;
 using PSA.EntidadesDTO.DTOs;
 using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
+using PSA.EntidadesDTO.DTOs.Usuarios;
 using PSA.WebAPI.Services;
 
 namespace PSA.WebAPI.Controllers
@@ -58,6 +59,20 @@ namespace PSA.WebAPI.Controllers
                 {
                     Mensaje = ex.Message
                 });
+            }
+        }
+
+        [HttpPost("asignar-rol")]
+        public async Task<IActionResult> AsignarRol([FromBody] AsignarRolUsuarioDTO dto)
+        {
+            try
+            {
+                await _autenticacionManager.AsignarRolAsync(dto);
+                return Ok(new { Mensaje = "Rol asignado correctamente." });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
             }
         }
 

--- a/PSA.WebAPI/Controllers/FincasController.cs
+++ b/PSA.WebAPI/Controllers/FincasController.cs
@@ -18,40 +18,87 @@ namespace PSA.WebAPI.Controllers
         [HttpGet("mis-fincas")]
         public async Task<IActionResult> ObtenerMisFincas([FromQuery] int idPropietario)
         {
-            if (idPropietario <= 0) return BadRequest(new { Mensaje = "El idPropietario debe ser mayor a 0." });
-            return Ok(await _fincaManager.ObtenerPorPropietarioAsync(idPropietario));
+            try
+            {
+                if (idPropietario <= 0) return BadRequest(new { Mensaje = "El idPropietario debe ser mayor a 0." });
+                return Ok(await _fincaManager.ObtenerPorPropietarioAsync(idPropietario));
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { Mensaje = $"Error al obtener fincas: {ex.Message}" });
+            }
         }
 
         [HttpGet("{idFinca:int}/detalle")]
         public async Task<IActionResult> ObtenerDetalle([FromRoute] int idFinca, [FromQuery] int idPropietario)
         {
-            if (idFinca <= 0 || idPropietario <= 0) return BadRequest(new { Mensaje = "Parámetros inválidos." });
-            var detalle = await _fincaManager.ObtenerDetalleAsync(idFinca, idPropietario);
-            return detalle == null ? NotFound(new { Mensaje = "No se encontró la finca solicitada." }) : Ok(detalle);
+            try
+            {
+                if (idFinca <= 0 || idPropietario <= 0) return BadRequest(new { Mensaje = "Parámetros inválidos." });
+                var detalle = await _fincaManager.ObtenerDetalleAsync(idFinca, idPropietario);
+                return detalle == null ? NotFound(new { Mensaje = "No se encontró la finca solicitada." }) : Ok(detalle);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { Mensaje = $"Error al obtener detalle de finca: {ex.Message}" });
+            }
         }
 
         [HttpPost]
         public async Task<IActionResult> RegistrarFinca([FromBody] RegistrarFincaDTO dto)
         {
-            if (!ModelState.IsValid || dto.IdPropietario <= 0) return ValidationProblem(ModelState);
-            var idFinca = await _fincaManager.RegistrarFincaAsync(dto);
-            return CreatedAtAction(nameof(ObtenerDetalle), new { idFinca, idPropietario = dto.IdPropietario }, new { IdFinca = idFinca, Mensaje = "Finca registrada correctamente." });
+            try
+            {
+                if (!ModelState.IsValid || dto.IdPropietario <= 0) return ValidationProblem(ModelState);
+                var idFinca = await _fincaManager.RegistrarFincaAsync(dto);
+                return CreatedAtAction(nameof(ObtenerDetalle), new { idFinca, idPropietario = dto.IdPropietario }, new { IdFinca = idFinca, Mensaje = "Finca registrada correctamente." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { Mensaje = $"Error inesperado al registrar finca: {ex.Message}" });
+            }
         }
 
         [HttpPut("{idFinca:int}")]
         public async Task<IActionResult> ActualizarFinca([FromRoute] int idFinca, [FromBody] RegistrarFincaDTO dto)
         {
-            if (!ModelState.IsValid || idFinca <= 0 || dto.IdPropietario <= 0) return ValidationProblem(ModelState);
-            var actualizado = await _fincaManager.ActualizarFincaAsync(idFinca, dto);
-            return actualizado ? Ok(new { Mensaje = "Finca actualizada correctamente." }) : NotFound(new { Mensaje = "No fue posible actualizar la finca solicitada." });
+            try
+            {
+                if (!ModelState.IsValid || idFinca <= 0 || dto.IdPropietario <= 0) return ValidationProblem(ModelState);
+                var actualizado = await _fincaManager.ActualizarFincaAsync(idFinca, dto);
+                return actualizado ? Ok(new { Mensaje = "Finca actualizada correctamente." }) : NotFound(new { Mensaje = "No fue posible actualizar la finca solicitada." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { Mensaje = $"Error inesperado al actualizar finca: {ex.Message}" });
+            }
         }
 
         [HttpDelete("{idFinca:int}")]
         public async Task<IActionResult> EliminarFinca([FromRoute] int idFinca, [FromQuery] int idPropietario)
         {
-            if (idFinca <= 0 || idPropietario <= 0) return BadRequest(new { Mensaje = "Datos inválidos." });
-            var eliminado = await _fincaManager.EliminarFincaAsync(idFinca, idPropietario);
-            return eliminado ? Ok(new { Mensaje = "Finca eliminada correctamente." }) : NotFound(new { Mensaje = "No se encontró la finca para eliminar." });
+            try
+            {
+                if (idFinca <= 0 || idPropietario <= 0) return BadRequest(new { Mensaje = "Datos inválidos." });
+                var eliminado = await _fincaManager.EliminarFincaAsync(idFinca, idPropietario);
+                return eliminado ? Ok(new { Mensaje = "Finca eliminada correctamente." }) : NotFound(new { Mensaje = "No se encontró la finca para eliminar." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { Mensaje = $"Error inesperado al eliminar finca: {ex.Message}" });
+            }
         }
     }
 }

--- a/PSA.WebAPI/Controllers/LandingController.cs
+++ b/PSA.WebAPI/Controllers/LandingController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using PSA.AppCore.Managers;
+
+namespace PSA.WebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class LandingController : ControllerBase
+    {
+        private readonly LandingManager _landingManager;
+
+        public LandingController(LandingManager landingManager)
+        {
+            _landingManager = landingManager;
+        }
+
+        [HttpGet("equipo")]
+        public async Task<IActionResult> ObtenerEquipo()
+        {
+            var data = await _landingManager.ObtenerEquipoAsync();
+            return Ok(data);
+        }
+
+        [HttpGet("producto")]
+        public async Task<IActionResult> ObtenerProducto()
+        {
+            var data = await _landingManager.ObtenerProductoAsync();
+            return Ok(data);
+        }
+    }
+}

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -14,8 +14,10 @@
     <Compile Include="Controllers\BaseApiController.cs" />
     <Compile Include="Controllers\DashboardController.cs" />
     <Compile Include="Controllers\EvaluacionesTecnicasController.cs" />
+    <Compile Include="Controllers\FincaEvidenciasController.cs" />
     <Compile Include="Controllers\FincasController.cs" />
     <Compile Include="Controllers\HealthController.cs" />
+    <Compile Include="Controllers\LandingController.cs" />
     <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Controllers\Middleware\ExceptionMiddleware.cs" />
     <Compile Include="Controllers\Models\ApiResponse.cs" />

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddScoped<EvaluacionDAO>();
 builder.Services.AddScoped<AuditoriaLogDAO>();
 builder.Services.AddScoped<DashboardDAO>();
 builder.Services.AddScoped<ReportesDAO>();
+builder.Services.AddScoped<LandingDAO>();
 
 builder.Services.AddScoped<FincaService>();
 builder.Services.AddScoped<EvaluacionService>();
@@ -56,6 +57,7 @@ builder.Services.AddScoped<RecuperacionContrasenaManager>();
 builder.Services.AddScoped<EvaluacionTecnicaManager>();
 builder.Services.AddScoped<FincaManager>();
 builder.Services.AddScoped<ReportesManager>();
+builder.Services.AddScoped<LandingManager>();
 
 var app = builder.Build();
 

--- a/PSA.WebApp/Controllers/FincasController.cs
+++ b/PSA.WebApp/Controllers/FincasController.cs
@@ -2,8 +2,10 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PSA.EntidadesDTO.DTOs;
 using PSA.EntidadesDTO.DTOs.Fincas;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Text.Json;
 
 namespace PSA.WebApp.Controllers
 {
@@ -27,7 +29,7 @@ namespace PSA.WebApp.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> RegistrarFinca(RegistrarFincaDTO dto)
+        public async Task<IActionResult> RegistrarFinca(RegistrarFincaDTO dto, List<IFormFile>? archivos)
         {
             CargarViewBag();
             dto.IdPropietario = ObtenerIdUsuarioSesion();
@@ -45,6 +47,17 @@ namespace PSA.WebApp.Controllers
                 TempData["MensajeError"] = "No fue posible registrar la finca.";
                 CargarCatalogosFormularioFinca();
                 return View(dto);
+            }
+
+            var idFinca = await ExtraerIdFincaAsync(response);
+
+            if (idFinca > 0 && archivos != null && archivos.Count > 0)
+            {
+                var evidenciaResponse = await SubirEvidenciasAsync(client, idFinca, dto.IdPropietario, archivos);
+                if (!evidenciaResponse)
+                {
+                    TempData["MensajeError"] = "La finca se registró, pero no fue posible subir las evidencias.";
+                }
             }
 
             TempData["MensajeExito"] = "Finca registrada correctamente.";
@@ -74,22 +87,113 @@ namespace PSA.WebApp.Controllers
             if ((id ?? 0) <= 0) return RedirectToAction(nameof(MisFincas));
 
             var client = _httpClientFactory.CreateClient("AuthApi");
-            var detalle = await client.GetFromJsonAsync<FincaDetalleDTO>($"api/Fincas/{id}/detalle?idPropietario={idPropietario}");
-            if (detalle == null)
+
+            FincaDetalleDTO? detalle;
+            try
             {
-                TempData["MensajeError"] = "No se encontró la finca solicitada.";
+                detalle = await client.GetFromJsonAsync<FincaDetalleDTO>($"api/Fincas/{id}/detalle?idPropietario={idPropietario}");
+                if (detalle == null)
+                {
+                    TempData["MensajeError"] = "No se encontró la finca solicitada.";
+                    return RedirectToAction(nameof(MisFincas));
+                }
+            }
+            catch (HttpRequestException)
+            {
+                TempData["MensajeError"] = "No fue posible conectarse con el API para cargar el detalle de la finca.";
+                return RedirectToAction(nameof(MisFincas));
+            }
+            catch (TaskCanceledException)
+            {
+                TempData["MensajeError"] = "La consulta del detalle de finca tardó demasiado. Intente nuevamente.";
+                return RedirectToAction(nameof(MisFincas));
+            }
+            catch (Exception)
+            {
+                TempData["MensajeError"] = "Ocurrió un error al cargar el detalle de la finca.";
                 return RedirectToAction(nameof(MisFincas));
             }
 
+            var evidencias = new List<FincaEvidenciaDTO>();
+            try
+            {
+                evidencias = await client.GetFromJsonAsync<List<FincaEvidenciaDTO>>($"api/FincaEvidencias/por-finca/{id}")
+                    ?? new List<FincaEvidenciaDTO>();
+            }
+            catch
+            {
+                // No se bloquea el render del detalle si falla la carga de evidencias.
+                TempData["MensajeError"] = "No fue posible cargar las evidencias de la finca en este momento.";
+            }
+
+            var baseAddress = client.BaseAddress?.ToString().TrimEnd('/') ?? string.Empty;
+            foreach (var evidencia in evidencias)
+            {
+                if (!string.IsNullOrWhiteSpace(evidencia.UrlDescarga) && evidencia.UrlDescarga.StartsWith('/'))
+                {
+                    evidencia.UrlDescarga = $"{baseAddress}{evidencia.UrlDescarga}";
+                }
+            }
+            ViewBag.Evidencias = evidencias;
+
             return View(detalle);
+        }
+
+        private static async Task<int> ExtraerIdFincaAsync(HttpResponseMessage response)
+        {
+            try
+            {
+                using var contenido = await response.Content.ReadAsStreamAsync();
+                using var documento = await JsonDocument.ParseAsync(contenido);
+                if (documento.RootElement.TryGetProperty("idFinca", out var idFincaLower))
+                {
+                    return idFincaLower.GetInt32();
+                }
+
+                if (documento.RootElement.TryGetProperty("IdFinca", out var idFincaUpper))
+                {
+                    return idFincaUpper.GetInt32();
+                }
+            }
+            catch
+            {
+                // Se ignora para no bloquear flujo principal de registro.
+            }
+
+            return 0;
+        }
+
+        private static async Task<bool> SubirEvidenciasAsync(HttpClient client, int idFinca, int idUsuario, List<IFormFile> archivos)
+        {
+            using var form = new MultipartFormDataContent();
+            form.Add(new StringContent(idFinca.ToString()), "idFinca");
+            form.Add(new StringContent(idUsuario.ToString()), "cargadoPor");
+
+            foreach (var archivo in archivos.Where(a => a != null && a.Length > 0))
+            {
+                var contenido = new StreamContent(archivo.OpenReadStream());
+                contenido.Headers.ContentType = new MediaTypeHeaderValue(archivo.ContentType ?? "application/octet-stream");
+                form.Add(contenido, "archivos", archivo.FileName);
+            }
+
+            var response = await client.PostAsync("api/FincaEvidencias/subir", form);
+            return response.IsSuccessStatusCode;
         }
 
         private int ObtenerIdUsuarioSesion() => int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
         private void CargarCatalogosFormularioFinca()
         {
-            ViewBag.OpcionesPendiente = new[] { "Baja", "Media", "Alta" };
-            ViewBag.OpcionesVegetacion = new[] { "Bosque", "Pasto", "Cultivo" };
-            ViewBag.OpcionesUsoSuelo = new[] { "Conservación", "Ganadería", "Agricultura" };
+            var pendientes = new[] { "Plana", "Inclinada", "Muy inclinada" };
+            var vegetaciones = new[] { "Bosque primario", "Bosque secundario", "Plantación forestal", "Pasto" };
+            var usosSuelo = new[] { "Conservación", "Producción forestal", "Agroforestal", "Ganadería", "Mixto" };
+
+            ViewBag.OpcionesPendiente = pendientes;
+            ViewBag.OpcionesVegetacion = vegetaciones;
+            ViewBag.OpcionesUsoSuelo = usosSuelo;
+
+            ViewBag.CatalogoPendiente = pendientes;
+            ViewBag.CatalogoVegetacion = vegetaciones;
+            ViewBag.CatalogoUsoSuelo = usosSuelo;
         }
 
         private void CargarViewBag()

--- a/PSA.WebApp/Views/Fincas/DetalleFinca.cshtml
+++ b/PSA.WebApp/Views/Fincas/DetalleFinca.cshtml
@@ -6,6 +6,7 @@
     var cantidadEvidencias = Model.CantidadEvidencias < 0 ? 0 : Model.CantidadEvidencias;
     var latitudData = Model.Latitud.ToString(System.Globalization.CultureInfo.InvariantCulture);
     var longitudData = Model.Longitud.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    var evidencias = ViewBag.Evidencias as List<PSA.EntidadesDTO.DTOs.Fincas.FincaEvidenciaDTO> ?? new List<PSA.EntidadesDTO.DTOs.Fincas.FincaEvidenciaDTO>();
 }
 
 <section class="seccion-pagina propietario-detalle-finca">
@@ -70,9 +71,41 @@
             <div class="cabecera-bloque">
                 <h3>Evidencias adjuntas</h3>
             </div>
-            @if (cantidadEvidencias > 0)
+            @if (evidencias.Count > 0)
             {
-                <p>Hay evidencias adjuntas para esta finca.</p>
+                <div class="lista-evidencias">
+                    @foreach (var evidencia in evidencias)
+                    {
+                        var esImagen = !string.IsNullOrWhiteSpace(evidencia.TipoArchivo) && evidencia.TipoArchivo.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+                        var esPdf = string.Equals(evidencia.TipoArchivo, "application/pdf", StringComparison.OrdinalIgnoreCase)
+                        || evidencia.NombreArchivo.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
+
+                        <article class="evidencia-item">
+                            <header>
+                                <strong>@evidencia.NombreArchivo</strong>
+                                <div class="texto-ayuda">Subido: @evidencia.FechaCarga.ToString("dd/MM/yyyy HH:mm")</div>
+                            </header>
+
+                            @if (esImagen && !string.IsNullOrWhiteSpace(evidencia.UrlDescarga))
+                            {
+                                <img src="@evidencia.UrlDescarga" alt="@evidencia.NombreArchivo" class="evidencia-preview-imagen" />
+                            }
+                            else if (esPdf && !string.IsNullOrWhiteSpace(evidencia.UrlDescarga))
+                            {
+                                <iframe src="@evidencia.UrlDescarga" title="@evidencia.NombreArchivo" class="evidencia-preview-pdf"></iframe>
+                            }
+                            else
+                            {
+                                <p class="texto-ayuda">Vista previa no disponible para este tipo de archivo.</p>
+                            }
+
+                            @if (!string.IsNullOrWhiteSpace(evidencia.UrlDescarga))
+                            {
+                                <a href="@evidencia.UrlDescarga" target="_blank" rel="noopener" class="boton-secundario">Abrir archivo</a>
+                            }
+                        </article>
+                    }
+                </div>
             }
             else
             {
@@ -109,6 +142,36 @@
             border-radius: var(--radio-md);
             overflow: hidden;
             box-shadow: var(--sombra-sm);
+        }
+
+        .lista-evidencias {
+            display: grid;
+            gap: var(--espacio-2);
+        }
+
+        .evidencia-item {
+            border: 1px solid var(--color-borde-suave);
+            border-radius: var(--radio-md);
+            padding: var(--espacio-2);
+            background: #fff;
+        }
+
+        .evidencia-preview-imagen {
+            width: 100%;
+            max-height: 320px;
+            object-fit: contain;
+            border-radius: var(--radio-sm);
+            border: 1px solid var(--color-borde-suave);
+            margin: var(--espacio-1) 0;
+        }
+
+        .evidencia-preview-pdf {
+            width: 100%;
+            height: 320px;
+            border: 1px solid var(--color-borde-suave);
+            border-radius: var(--radio-sm);
+            margin: var(--espacio-1) 0;
+            background: #fff;
         }
     </style>
 }

--- a/PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml
+++ b/PSA.WebApp/Views/Fincas/RegistrarFinca.cshtml
@@ -3,7 +3,7 @@
     ViewData["Title"] = "Registrar finca";
     var catalogoPendiente = ViewBag.CatalogoPendiente as IEnumerable<string> ?? new[] { "Plana", "Inclinada", "Muy inclinada" };
     var catalogoVegetacion = ViewBag.CatalogoVegetacion as IEnumerable<string> ?? new[] { "Bosque primario", "Bosque secundario", "Plantación forestal", "Pasto" };
-    var catalogoUsoSuelo = ViewBag.CatalogoUsoSuelo as IEnumerable<string> ?? new[] { "Conservación", "Producción forestal", "Agroforestal", "Ganadería", "Uso mixto" };
+    var catalogoUsoSuelo = ViewBag.CatalogoUsoSuelo as IEnumerable<string> ?? new[] { "Conservación", "Producción forestal", "Agroforestal", "Ganadería", "Mixto" };
 }
 <section class="seccion-pagina">
     <div class="cabecera-pagina">


### PR DESCRIPTION
### Motivation
- Centralizar la lógica de registro y mantenimiento de fincas y de autenticación en el servidor de BD para robustecer validaciones y evitar fallos por catálogos no sembrados.
- Proteger el flujo de registro de fincas para que la creación de la evaluación técnica pendiente no rompa la operación principal.
- Exponer contenido estático de landing y permitir asignación de roles y gestión de evidencias desde la UI.

### Description
- Se agregan migraciones SQL con Stored Procedures para fincas (`SP_Fincas_Registrar`, `SP_Fincas_Actualizar`, `SP_Fincas_Eliminar`, `SP_Fincas_CatalogoValores`) y para auth/landing (`SP_Auth_*`, `SP_Landing_*`, `SP_FincaEvidencias_Crear`) con validaciones que consultan `CatalogoFincaValores` y generan errores controlados con `THROW`.
- Se actualizan DAOs para usar los stored procedures: `FincaDAO`, `FincaEvidenciaDAO`, `UsuarioDAO`, `TokenRecuperacionDAO` pasan a invocar `dbo.SP_*` y manejan excepciones SQL para mensajes más claros; se añade `LandingDAO` para consultas de landing.
- Se añade `LandingManager`, `LandingContenidoDTO`, y controladores `LandingController` para exponer endpoints de landing; se añade `AsignarRolUsuarioDTO`, y se implementa asignación de rol en `AutenticacionManager` y nuevo endpoint `POST api/Autenticacion/asignar-rol` enlazado a `UsuarioDAO.AsignarRolAsync` y SP `SP_Usuarios_AsignarRol`.
- Se modifican `FincaManager` y `FincasController` para mejorar manejo de errores y hacer la creación de evaluación técnica pendiente tolerante a fallos; `FincaDAO` y controladores Web/API se adaptan a la nueva contract y retornos de los SP.
- Se amplía la WebApp: soporte de envío de evidencias al registrar finca (multipart upload), extracción del `IdFinca` desde la respuesta, carga y renderizado de evidencias en `DetalleFinca`, además de ajustes en catálogos y vistas; se actualizan los proyectos (`*.csproj`) para incluir nuevos archivos.

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio (ningún test unitario o de integración fue corrido automáticamente durante la rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf0f41ec4832d92a0033783563ad7)