### PR TITLE
fix: create wwwroot placeholder to prevent startup DirectoryNotFoundException

### DIFF
--- a/PSA.WebAPI/wwwroot/.placeholder
+++ b/PSA.WebAPI/wwwroot/.placeholder
@@ -1,0 +1,1 @@
+Este archivo asegura que exista la carpeta wwwroot para static web assets.


### PR DESCRIPTION
### Motivation
- ASP.NET Core can throw `System.IO.DirectoryNotFoundException` during static web assets initialization when the `wwwroot` folder is missing, so the repo should ensure the folder exists to prevent startup failures.

### Description
- Add `PSA.WebAPI/wwwroot/.placeholder` with a short message so the `wwwroot` directory is tracked in source control and always present after checkout.

### Testing
- Attempted `dotnet build PSA.WebAPI/PSA.WebAPI.csproj` but `dotnet` is not installed in this environment so the build could not be executed.
- Verified the placeholder file was created and present using `git status --short` and `nl -ba PSA.WebAPI/wwwroot/.placeholder`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dedce53dd0832d826e2baab1626ef3)