### PR TITLE
feat: integrar módulo de Gestión de Visitas Técnicas y carga de evidencias

### DIFF
--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PSA.EntidadesDTO.DTOs.Evaluaciones;
 using PSA.WebApp.Models;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Claims;
 
@@ -20,6 +21,9 @@ namespace PSA.WebApp.Controllers
         [HttpGet]
         public async Task<IActionResult> FincasPendientes(string estado = "Todos")
         {
+            ConfigurarVistaBase(
+                "Gestión de visitas técnicas",
+                "Cola de propiedades pendientes de visita y seguimiento de evaluaciones.");
             var client = _httpClientFactory.CreateClient("AuthApi");
             var pendientes = await client.GetFromJsonAsync<List<BandejaEvaluacionPendienteDTO>>("api/EvaluacionesTecnicas/bandeja-pendientes") ?? new();
             if (!string.Equals(estado, "Todos", StringComparison.OrdinalIgnoreCase))
@@ -32,6 +36,9 @@ namespace PSA.WebApp.Controllers
         public async Task<IActionResult> NuevaEvaluacion(int idEvaluacion)
         {
             if (idEvaluacion <= 0) return RedirectToAction(nameof(FincasPendientes));
+            ConfigurarVistaBase(
+                "Gestión de visitas técnicas",
+                "Registro de resultados de la evaluación, ajustes y carga de evidencia.");
             var client = _httpClientFactory.CreateClient("AuthApi");
             var detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle");
             if (detalle == null) return RedirectToAction(nameof(FincasPendientes));
@@ -59,13 +66,39 @@ namespace PSA.WebApp.Controllers
                 return View(model);
             }
 
-            TempData["MensajeExito"] = "Evaluación técnica guardada correctamente.";
+            var totalEvidencias = model.Evidencias?.Count(e => e != null && e.Length > 0) ?? 0;
+            if (totalEvidencias > 0)
+            {
+                var detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle");
+                var idFinca = detalle?.IdFinca ?? 0;
+                var idUsuario = ObtenerIdUsuarioSesion();
+
+                if (idFinca > 0 && idUsuario > 0)
+                {
+                    var evidenciaSubida = await SubirEvidenciasAsync(client, idFinca, idUsuario, model.Evidencias);
+                    if (!evidenciaSubida)
+                    {
+                        TempData["MensajeError"] = "La evaluación se guardó, pero no fue posible cargar la evidencia adjunta.";
+                    }
+                }
+                else
+                {
+                    TempData["MensajeError"] = "La evaluación se guardó, pero no fue posible identificar la finca para cargar evidencia.";
+                }
+            }
+
+            TempData["MensajeExito"] = totalEvidencias > 0
+                ? "Evaluación técnica guardada correctamente junto con la evidencia adjunta."
+                : "Evaluación técnica guardada correctamente.";
             return RedirectToAction(nameof(HistorialEvaluaciones));
         }
 
         [HttpGet]
         public async Task<IActionResult> HistorialEvaluaciones(int? anio = null, int? mes = null, string? estadoEvaluacion = null, string? decisionTecnica = null)
         {
+            ConfigurarVistaBase(
+                "Gestión de visitas técnicas",
+                "Historial y métricas de resultados de evaluaciones técnicas.");
             var idIngeniero = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
             var client = _httpClientFactory.CreateClient("AuthApi");
             var url = $"api/EvaluacionesTecnicas/reportes?anio={anio}&mes={mes}&estadoEvaluacion={estadoEvaluacion}&decisionTecnica={decisionTecnica}&idIngeniero={idIngeniero}";
@@ -80,6 +113,9 @@ namespace PSA.WebApp.Controllers
         [HttpGet]
         public async Task<IActionResult> FincasIngeniero()
         {
+            ConfigurarVistaBase(
+                "Gestión de visitas técnicas",
+                "Resumen de fincas y evaluaciones asignadas al ingeniero.");
             var client = _httpClientFactory.CreateClient("AuthApi");
             var reporte = await client.GetFromJsonAsync<ReporteEvaluacionesDTO>("api/EvaluacionesTecnicas/reportes") ?? new ReporteEvaluacionesDTO();
             return View(reporte.Evaluaciones);
@@ -88,9 +124,42 @@ namespace PSA.WebApp.Controllers
         [HttpGet]
         public async Task<IActionResult> DetalleEvaluacion(int idEvaluacion)
         {
+            ConfigurarVistaBase(
+                "Gestión de visitas técnicas",
+                "Detalle de visita técnica y trazabilidad de ajustes.");
             var client = _httpClientFactory.CreateClient("AuthApi");
             var detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle") ?? new DetalleFincaParaEvaluacionDTO();
             return View(detalle);
+        }
+
+        private int ObtenerIdUsuarioSesion() => int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+
+        private static async Task<bool> SubirEvidenciasAsync(HttpClient client, int idFinca, int idUsuario, List<IFormFile> archivos)
+        {
+            using var form = new MultipartFormDataContent();
+            form.Add(new StringContent(idFinca.ToString()), "idFinca");
+            form.Add(new StringContent(idUsuario.ToString()), "cargadoPor");
+
+            foreach (var archivo in archivos.Where(a => a != null && a.Length > 0))
+            {
+                var contenido = new StreamContent(archivo.OpenReadStream());
+                contenido.Headers.ContentType = new MediaTypeHeaderValue(archivo.ContentType ?? "application/octet-stream");
+                form.Add(contenido, "archivos", archivo.FileName);
+            }
+
+            var response = await client.PostAsync("api/FincaEvidencias/subir", form);
+            return response.IsSuccessStatusCode;
+        }
+
+        private void ConfigurarVistaBase(string titulo, string subtitulo)
+        {
+            ViewBag.ModuloActivo = "evaluaciones";
+            ViewBag.RolActivo = "Ingeniero";
+            ViewBag.TituloPagina = titulo;
+            ViewBag.SubtituloPagina = subtitulo;
+            ViewBag.BreadcrumbPadreTexto = "Inicio";
+            ViewBag.BreadcrumbPadreUrl = Url.Action("Ingeniero", "Dashboard");
+            ViewBag.BreadcrumbActual = titulo;
         }
 
         private void CargarCatalogosEvaluacion()

--- a/PSA.WebApp/Models/EvaluacionesViewModels.cs
+++ b/PSA.WebApp/Models/EvaluacionesViewModels.cs
@@ -1,4 +1,5 @@
 using PSA.EntidadesDTO.DTOs.Evaluaciones;
+using Microsoft.AspNetCore.Http;
 
 namespace PSA.WebApp.Models
 {
@@ -12,6 +13,7 @@ namespace PSA.WebApp.Models
     {
         public DetalleFincaParaEvaluacionDTO Detalle { get; set; } = new();
         public RegistrarResultadoEvaluacionDTO Formulario { get; set; } = new();
+        public List<IFormFile> Evidencias { get; set; } = new();
     }
 
     public class ReporteEvaluacionesViewModel

--- a/PSA.WebApp/Views/Evaluaciones/FincasPendientes.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/FincasPendientes.cshtml
@@ -6,8 +6,8 @@
     <div class="cabecera-pagina">
         <div>
             <span class="eyebrow">Módulo técnico</span>
-            <h2>Fincas pendientes de evaluación</h2>
-            <p>Seleccione un expediente para iniciar o continuar la evaluación técnica.</p>
+            <h2>Cola de propiedades pendientes de visita</h2>
+            <p>Seleccione un expediente para iniciar o continuar la gestión de visita técnica.</p>
         </div>
         <a class="boton-secundario" asp-controller="Evaluaciones" asp-action="EvaluacionesEnProceso">Evaluaciones en proceso</a>
     </div>

--- a/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
@@ -126,20 +126,20 @@
             </div>
             <div class="campo-formulario">
                 <label>Evidencias (opcional)</label>
-                <input type="file" name="evidencias" multiple accept="image/*,.pdf" />
+                <input asp-for="Evidencias" type="file" multiple accept="image/*,.pdf" />
                 <small>Nota: la persistencia de archivos físicos se gestiona en el flujo de evidencias.</small>
             </div>
         </div>
 
         <div class="seccion-formulario">
             <h3>Ajustes técnicos del ingeniero</h3>
-            <p>Estos campos permiten registrar el dato ajustado y mantener trazabilidad respecto al dato original.</p>
+            <p class="texto-ajustes-tecnicos">Estos campos en verde permiten registrar el dato ajustado y mantener trazabilidad respecto al dato original.</p>
             <div class="grid-dos-columnas">
-                <div class="campo-formulario">
+                <div class="campo-formulario campo-ajustable">
                     <label asp-for="Formulario.HectareasAjustadas">Hectáreas ajustadas</label>
                     <input asp-for="Formulario.HectareasAjustadas" type="number" step="0.01" min="0.01" />
                 </div>
-                <div class="campo-formulario">
+                <div class="campo-formulario campo-ajustable">
                     <label asp-for="Formulario.PendienteAjustada">Pendiente ajustada</label>
                     <select asp-for="Formulario.PendienteAjustada">
                         <option value="">Sin ajuste</option>
@@ -149,7 +149,7 @@
                         }
                     </select>
                 </div>
-                <div class="campo-formulario">
+                <div class="campo-formulario campo-ajustable">
                     <label asp-for="Formulario.VegetacionAjustada">Vegetación ajustada</label>
                     <select asp-for="Formulario.VegetacionAjustada">
                         <option value="">Sin ajuste</option>
@@ -159,7 +159,7 @@
                         }
                     </select>
                 </div>
-                <div class="campo-formulario">
+                <div class="campo-formulario campo-ajustable">
                     <label asp-for="Formulario.UsoSueloAjustado">Uso de suelo ajustado</label>
                     <select asp-for="Formulario.UsoSueloAjustado">
                         <option value="">Sin ajuste</option>
@@ -169,7 +169,7 @@
                         }
                     </select>
                 </div>
-                <div class="campo-formulario">
+                <div class="campo-formulario campo-ajustable">
                     <label asp-for="Formulario.RecursosHidricosAjustado">Recursos hídricos ajustados</label>
                     <select asp-for="Formulario.RecursosHidricosAjustado">
                         <option value="">Sin ajuste</option>
@@ -190,3 +190,16 @@
 @section Scripts {
     <script src="~/js/evaluaciones.js" asp-append-version="true"></script>
 }
+
+<style>
+    .texto-ajustes-tecnicos {
+        margin-bottom: 1rem;
+    }
+
+    .campo-ajustable {
+        border-left: 4px solid #2e8b57;
+        padding-left: 0.75rem;
+        background-color: #f3fff7;
+        border-radius: 0.4rem;
+    }
+</style>

--- a/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
+++ b/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
@@ -26,8 +26,8 @@
         @if (rolActivo == "ingeniero")
         {
             <a class="item-menu @(moduloActivo == "dashboard" ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Ingeniero">Inicio</a>
-            <a class="item-menu @(moduloActivo == "evaluaciones" ? "activo" : string.Empty)" asp-controller="Evaluaciones" asp-action="FincasPendientes">Fincas por evaluar</a>
-            <a class="item-menu @(moduloActivo == "evaluaciones" ? "activo" : string.Empty)" asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">Evaluaciones técnicas</a>
+            <a class="item-menu @(moduloActivo == "evaluaciones" ? "activo" : string.Empty)" asp-controller="Evaluaciones" asp-action="FincasPendientes">Visitas técnicas pendientes</a>
+            <a class="item-menu @(moduloActivo == "evaluaciones" ? "activo" : string.Empty)" asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">Resultados de visitas técnicas</a>
             <a class="item-menu @(moduloActivo == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
             <a class="item-menu item-menu--proximamente" href="#" data-omitir-trobber-global="true" aria-disabled="true">Notificaciones</a>
             <a class="item-menu @(moduloActivo == "mi-perfil" ? "activo" : string.Empty)" asp-controller="MiPerfil" asp-action="Index">Mi perfil</a>


### PR DESCRIPTION
### Motivation
- Integrar el módulo "Gestión de Visitas Técnicas" para que el flujo del ingeniero incluya la cola de propiedades pendientes de visita, el registro de resultados con posibilidad de ajustar datos (campos marcados en verde) y la carga de evidencias asociadas a la visita.

### Description
- Controlador: se añadió lógica en `EvaluacionesController` para configurar `ViewBag`/breadcrumbs (`ConfigurarVistaBase`), procesar el guardado de resultado y, cuando hay archivos, subir evidencias vía multipart a `api/FincaEvidencias/subir` (`SubirEvidenciasAsync`) y resolver mensajes parciales de éxito/fracaso; además se agregó `ObtenerIdUsuarioSesion` para extraer el usuario en sesión.
- ViewModel: `NuevaEvaluacionViewModel` ahora incluye `List<IFormFile> Evidencias` para binder archivos desde el formulario (`PSA.WebApp/Models/EvaluacionesViewModels.cs`).
- Vistas: `NuevaEvaluacion.cshtml` enlaza el input de archivos con `asp-for="Evidencias"` y resalta visualmente (estilo verde) los campos ajustables por el ingeniero; `FincasPendientes.cshtml` actualiza copy para mostrar la "Cola de propiedades pendientes de visita"; y la barra lateral renombra las opciones del módulo para el rol Ingeniero a `Visitas técnicas pendientes` y `Resultados de visitas técnicas`.
- Archivos modificados clave: `PSA.WebApp/Controllers/EvaluacionesController.cs`, `PSA.WebApp/Models/EvaluacionesViewModels.cs`, `PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml`, `PSA.WebApp/Views/Evaluaciones/FincasPendientes.cshtml`, `PSA.WebApp/Views/Shared/_BarraLateral.cshtml`.

### Testing
- Se intentó compilar la solución con `dotnet build psa-costa-rica.slnx -v minimal`, pero el entorno no dispone del SDK de .NET y la ejecución falló con `/bin/bash: line 1: dotnet: command not found`.
- No se ejecutaron pruebas automatizadas adicionales en este entorno por la falta del SDK; funcionalidad de subida de archivos fue integrada para usar el endpoint existente `api/FincaEvidencias/subir` y está diseñada para comportarse de forma tolerante (mensaje parcial si la evaluación se guarda pero la carga de evidencia falla).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deed1e99e0832d8afc9339116ad3f2)