### PR TITLE
Cola de visitas en dashboard de ingeniero y visualización/carga de evidencias en evaluaciones

### DIFF
--- a/PSA.WebApp/Controllers/DashboardController.cs
+++ b/PSA.WebApp/Controllers/DashboardController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PSA.EntidadesDTO.DTOs.Evaluaciones;
 using PSA.WebApp.Models;
 using System.Net.Http.Json;
 using System.Security.Claims;
@@ -54,12 +55,21 @@ namespace PSA.WebApp.Controllers
             var idUsuario = ObtenerIdUsuarioSesion();
             var client = _httpClientFactory.CreateClient("AuthApi");
             var resumen = await client.GetFromJsonAsync<DashboardIngenieroApiModel>($"api/Dashboard/ingeniero-resumen/{idUsuario}") ?? new();
+            var pendientes = await client.GetFromJsonAsync<List<BandejaEvaluacionPendienteDTO>>("api/EvaluacionesTecnicas/bandeja-pendientes") ?? new();
+
             return View(new DashboardIngenieroViewModel
             {
                 FincasPendientes = resumen.FincasPendientes,
                 EvaluacionesAbiertas = resumen.EvaluacionesAbiertas,
                 DecisionesMesActual = resumen.DecisionesMesActual,
-                ProximasAcciones = resumen.ProximasAcciones.Select(x => new ActividadDashboardViewModel { Titulo = x.NombreFinca }).ToList()
+                ProximasAcciones = resumen.ProximasAcciones.Select(x => new ActividadDashboardViewModel { Titulo = x.NombreFinca }).ToList(),
+                ColaPendientesVisita = pendientes
+                    .Where(p => string.Equals(p.EstadoEvaluacion, "Pendiente", StringComparison.OrdinalIgnoreCase)
+                             || string.Equals(p.EstadoEvaluacion, "En proceso", StringComparison.OrdinalIgnoreCase))
+                    .OrderBy(p => p.EstadoEvaluacion == "En proceso" ? 1 : 0)
+                    .ThenBy(p => p.IdEvaluacion)
+                    .Take(8)
+                    .ToList()
             });
         }
 

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PSA.EntidadesDTO.DTOs.Evaluaciones;
+using PSA.EntidadesDTO.DTOs.Fincas;
 using PSA.WebApp.Models;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -42,13 +43,15 @@ namespace PSA.WebApp.Controllers
             var client = _httpClientFactory.CreateClient("AuthApi");
             var detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle");
             if (detalle == null) return RedirectToAction(nameof(FincasPendientes));
+            var evidencias = await ObtenerEvidenciasPorFincaAsync(client, detalle.IdFinca);
 
             CargarCatalogosEvaluacion();
 
             return View(new NuevaEvaluacionViewModel
             {
                 Detalle = detalle,
-                Formulario = new RegistrarResultadoEvaluacionDTO { FechaVisita = DateTime.Today }
+                Formulario = new RegistrarResultadoEvaluacionDTO { FechaVisita = DateTime.Today },
+                EvidenciasExistentes = evidencias
             });
         }
 
@@ -62,6 +65,8 @@ namespace PSA.WebApp.Controllers
             if (!response.IsSuccessStatusCode)
             {
                 TempData["MensajeError"] = "No fue posible guardar la evaluación.";
+                model.Detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle") ?? new();
+                model.EvidenciasExistentes = await ObtenerEvidenciasPorFincaAsync(client, model.Detalle.IdFinca);
                 CargarCatalogosEvaluacion();
                 return View(model);
             }
@@ -133,6 +138,12 @@ namespace PSA.WebApp.Controllers
         }
 
         private int ObtenerIdUsuarioSesion() => int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+
+        private static async Task<List<FincaEvidenciaDTO>> ObtenerEvidenciasPorFincaAsync(HttpClient client, int idFinca)
+        {
+            if (idFinca <= 0) return new();
+            return await client.GetFromJsonAsync<List<FincaEvidenciaDTO>>($"api/FincaEvidencias/finca/{idFinca}") ?? new();
+        }
 
         private static async Task<bool> SubirEvidenciasAsync(HttpClient client, int idFinca, int idUsuario, List<IFormFile> archivos)
         {

--- a/PSA.WebApp/Models/DashboardViewModels.cs
+++ b/PSA.WebApp/Models/DashboardViewModels.cs
@@ -1,3 +1,5 @@
+using PSA.EntidadesDTO.DTOs.Evaluaciones;
+
 namespace PSA.WebApp.Models
 {
     public class ActividadDashboardViewModel
@@ -20,6 +22,7 @@ namespace PSA.WebApp.Models
         public int EvaluacionesAbiertas { get; set; }
         public int DecisionesMesActual { get; set; }
         public List<ActividadDashboardViewModel> ProximasAcciones { get; set; } = new();
+        public List<BandejaEvaluacionPendienteDTO> ColaPendientesVisita { get; set; } = new();
     }
 
     public class DashboardAdministradorViewModel

--- a/PSA.WebApp/Models/EvaluacionesViewModels.cs
+++ b/PSA.WebApp/Models/EvaluacionesViewModels.cs
@@ -1,4 +1,5 @@
 using PSA.EntidadesDTO.DTOs.Evaluaciones;
+using PSA.EntidadesDTO.DTOs.Fincas;
 using Microsoft.AspNetCore.Http;
 
 namespace PSA.WebApp.Models
@@ -14,6 +15,7 @@ namespace PSA.WebApp.Models
         public DetalleFincaParaEvaluacionDTO Detalle { get; set; } = new();
         public RegistrarResultadoEvaluacionDTO Formulario { get; set; } = new();
         public List<IFormFile> Evidencias { get; set; } = new();
+        public List<FincaEvidenciaDTO> EvidenciasExistentes { get; set; } = new();
     }
 
     public class ReporteEvaluacionesViewModel

--- a/PSA.WebApp/Views/Dashboard/Ingeniero.cshtml
+++ b/PSA.WebApp/Views/Dashboard/Ingeniero.cshtml
@@ -110,4 +110,48 @@
             }
         </ul>
     </section>
+
+    <section class="tarjeta-panel mt-4">
+        <div class="cabecera-bloque">
+            <h3>Cola de propiedades pendientes de visita</h3>
+        </div>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Evaluación</th>
+                        <th>Finca</th>
+                        <th>Ubicación</th>
+                        <th>Estado</th>
+                        <th>Acción</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if (Model.ColaPendientesVisita.Any())
+                    {
+                        @foreach (var item in Model.ColaPendientesVisita)
+                        {
+                            <tr>
+                                <td>#@item.IdEvaluacion</td>
+                                <td>@item.NombreFinca</td>
+                                <td>@item.Provincia, @item.Canton, @item.Distrito</td>
+                                <td>@item.EstadoEvaluacion</td>
+                                <td>
+                                    <a class="boton-link" asp-controller="Evaluaciones" asp-action="NuevaEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">
+                                        @(item.EstadoEvaluacion == "En proceso" ? "Continuar" : "Iniciar")
+                                    </a>
+                                </td>
+                            </tr>
+                        }
+                    }
+                    else
+                    {
+                        <tr>
+                            <td colspan="5">No hay propiedades pendientes de visita en este momento.</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </section>
 </section>

--- a/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
@@ -1,6 +1,7 @@
 @model PSA.WebApp.Models.NuevaEvaluacionViewModel
 @{
     ViewData["Title"] = "Nueva evaluación técnica";
+    var evidenciasExistentes = Model.EvidenciasExistentes ?? new List<PSA.EntidadesDTO.DTOs.Fincas.FincaEvidenciaDTO>();
 }
 <section class="seccion-pagina">
     <div class="cabecera-pagina">
@@ -132,6 +133,50 @@
         </div>
 
         <div class="seccion-formulario">
+            <h3>Evidencias existentes de la finca</h3>
+            @if (evidenciasExistentes.Count > 0)
+            {
+                <div class="lista-evidencias">
+                    @foreach (var evidencia in evidenciasExistentes)
+                    {
+                        var esImagen = !string.IsNullOrWhiteSpace(evidencia.TipoArchivo) && evidencia.TipoArchivo.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+                        var esPdf = string.Equals(evidencia.TipoArchivo, "application/pdf", StringComparison.OrdinalIgnoreCase)
+                            || evidencia.NombreArchivo.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
+
+                        <article class="evidencia-item">
+                            <header>
+                                <strong>@evidencia.NombreArchivo</strong>
+                                <div class="texto-ayuda">Subido: @evidencia.FechaCarga.ToString("dd/MM/yyyy HH:mm")</div>
+                            </header>
+
+                            @if (esImagen && !string.IsNullOrWhiteSpace(evidencia.UrlDescarga))
+                            {
+                                <img src="@evidencia.UrlDescarga" alt="@evidencia.NombreArchivo" class="evidencia-preview-imagen" />
+                            }
+                            else if (esPdf && !string.IsNullOrWhiteSpace(evidencia.UrlDescarga))
+                            {
+                                <iframe src="@evidencia.UrlDescarga" title="@evidencia.NombreArchivo" class="evidencia-preview-pdf"></iframe>
+                            }
+                            else
+                            {
+                                <p class="texto-ayuda">Vista previa no disponible para este tipo de archivo.</p>
+                            }
+
+                            @if (!string.IsNullOrWhiteSpace(evidencia.UrlDescarga))
+                            {
+                                <a href="@evidencia.UrlDescarga" target="_blank" rel="noopener" class="boton-secundario">Abrir archivo</a>
+                            }
+                        </article>
+                    }
+                </div>
+            }
+            else
+            {
+                <p>No hay evidencias previas registradas para esta finca.</p>
+            }
+        </div>
+
+        <div class="seccion-formulario">
             <h3>Ajustes técnicos del ingeniero</h3>
             <p class="texto-ajustes-tecnicos">Estos campos en verde permiten registrar el dato ajustado y mantener trazabilidad respecto al dato original.</p>
             <div class="grid-dos-columnas">
@@ -201,5 +246,35 @@
         padding-left: 0.75rem;
         background-color: #f3fff7;
         border-radius: 0.4rem;
+    }
+
+    .lista-evidencias {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .evidencia-item {
+        border: 1px solid #d6dde6;
+        border-radius: 0.5rem;
+        padding: 1rem;
+        background: #fff;
+    }
+
+    .evidencia-preview-imagen {
+        width: 100%;
+        max-height: 320px;
+        object-fit: contain;
+        border-radius: 0.4rem;
+        border: 1px solid #d6dde6;
+        margin: 0.5rem 0;
+    }
+
+    .evidencia-preview-pdf {
+        width: 100%;
+        height: 320px;
+        border: 1px solid #d6dde6;
+        border-radius: 0.4rem;
+        margin: 0.5rem 0;
+        background: #fff;
     }
 </style>


### PR DESCRIPTION
### Motivation
- Exponer en el `Dashboard` del ingeniero una cola rápida de propiedades pendientes de visita para agilizar la toma/continuación de evaluaciones.
- Permitir el registro de resultados de la evaluación técnica con carga de evidencias (imágenes/PDF) y que el ingeniero pueda ajustar ciertos campos del registro una vez realiza la visita.
- Mostrar las evidencias en la pantalla de evaluación de forma consistente con la sección de "Evidencias adjuntas" del detalle de finca para mantener la misma experiencia de visualización.

### Description
- Agrega la propiedad `ColaPendientesVisita` al `DashboardIngenieroViewModel` y carga la lista desde `api/EvaluacionesTecnicas/bandeja-pendientes` en `DashboardController.Ingeniero`, ordenando/limitando para vista rápida (archivo modificado: `PSA.WebApp/Controllers/DashboardController.cs`, `PSA.WebApp/Models/DashboardViewModels.cs`).
- Extiende `NuevaEvaluacionViewModel` con `EvidenciasExistentes` y añade el helper `ObtenerEvidenciasPorFincaAsync` para recuperar evidencias de `api/FincaEvidencias/finca/{id}` (archivo modificado: `PSA.WebApp/Controllers/EvaluacionesController.cs`, `PSA.WebApp/Models/EvaluacionesViewModels.cs`).
- En la vista de nueva evaluación (`PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml`) muestra las evidencias existentes con previsualización de imágenes/PDF y botón de apertura, y mantiene el control de carga de archivos para adjuntar nuevas evidencias.
- Añade una sección en el `Dashboard` del ingeniero (`PSA.WebApp/Views/Dashboard/Ingeniero.cshtml`) que lista evaluación, finca, ubicación, estado y enlace para iniciar/continuar la evaluación.
- Mejora del flujo POST de `NuevaEvaluacion` para recargar `Detalle` y `Evidencias` cuando el guardado falla, evitando pérdida de contexto en la vista (controlador: `PSA.WebApp/Controllers/EvaluacionesController.cs`).

### Testing
- Se intentó ejecutar `dotnet build PSA-Costa-Rica.slnx` en el entorno para validar compilación y falló debido a que `dotnet` no está disponible en este entorno (resultado: fallo por entorno: `dotnet: command not found`).
- No se ejecutaron otras pruebas automáticas en el entorno por la misma limitación de tooling; los cambios están limitados a capas de controlador/modelo/vista y requieren compilación/validación en un entorno con SDK .NET instalado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e050d6a160832da11ffc81d2349ed5)