### PR TITLE
Admin UI polish, dark theme tweaks, permisos SQL and evidencia upload fix

### DIFF
--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -71,7 +71,8 @@ namespace PSA.WebApp.Controllers
                 return View(model);
             }
 
-            var totalEvidencias = model.Evidencias?.Count(e => e != null && e.Length > 0) ?? 0;
+            var evidenciasAdjuntas = model.Evidencias?.Where(e => e != null && e.Length > 0).ToList() ?? new List<IFormFile>();
+            var totalEvidencias = evidenciasAdjuntas.Count;
             if (totalEvidencias > 0)
             {
                 var detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle");
@@ -80,7 +81,7 @@ namespace PSA.WebApp.Controllers
 
                 if (idFinca > 0 && idUsuario > 0)
                 {
-                    var evidenciaSubida = await SubirEvidenciasAsync(client, idFinca, idUsuario, model.Evidencias);
+                    var evidenciaSubida = await SubirEvidenciasAsync(client, idFinca, idUsuario, evidenciasAdjuntas);
                     if (!evidenciaSubida)
                     {
                         TempData["MensajeError"] = "La evaluación se guardó, pero no fue posible cargar la evidencia adjunta.";

--- a/PSA.WebApp/Views/Administracion/GestionUsuarios.cshtml
+++ b/PSA.WebApp/Views/Administracion/GestionUsuarios.cshtml
@@ -6,21 +6,32 @@
         <div>
             <span class="eyebrow">Administración</span>
             <h2>Gestión de usuarios</h2>
-            <p>Base para administración de usuarios, roles y estados.</p>
+            <p>Gestione cuentas, asignaciones de clientes, roles y permisos del sistema.</p>
         </div>
         <a class="boton-primario" asp-controller="Autenticacion" asp-action="RegistroUsuario">Crear usuario</a>
     </div>
 
+    <section class="tarjeta-panel panel-resumen-admin">
+        <h3>Alcance administrativo</h3>
+        <ul class="lista-capacidades-admin">
+            <li><strong>Crear, modificar y eliminar usuarios</strong> según políticas internas.</li>
+            <li><strong>Mover clientes entre asesores</strong> para balance de cartera y continuidad operativa.</li>
+            <li><strong>Configurar roles y permisos</strong> con visibilidad por módulos críticos.</li>
+            <li><strong>Monitorear actividad</strong> desde auditoría y bitácoras del sistema.</li>
+        </ul>
+    </section>
+
     <section class="tarjeta-panel">
         <div class="tabla-responsive">
-            <table class="tabla-base">
+            <table class="tabla-base tabla-usuarios-admin">
                 <thead>
                     <tr>
                         <th>Nombre</th>
                         <th>Correo</th>
                         <th>Rol</th>
                         <th>Estado</th>
-                        <th>Acción</th>
+                        <th>Clientes asignados</th>
+                        <th>Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -29,14 +40,28 @@
                         <td>dennis@psa.cr</td>
                         <td>Administrador</td>
                         <td><span class="badge-estado badge-exito">Activo</span></td>
-                        <td><a class="boton-link" asp-controller="Administracion" asp-action="ParametrosPago">Ver permisos</a></td>
+                        <td>12</td>
+                        <td>
+                            <div class="grupo-acciones-tabla">
+                                <a class="boton-link" asp-controller="Administracion" asp-action="ParametrosPago">Permisos</a>
+                                <a class="boton-link" asp-controller="Administracion" asp-action="AuditoriaLogs">Editar</a>
+                                <a class="boton-link" asp-controller="Administracion" asp-action="AuditoriaLogs">Eliminar</a>
+                            </div>
+                        </td>
                     </tr>
                     <tr>
                         <td>Laura Mora</td>
                         <td>laura@psa.cr</td>
-                        <td>Dueño</td>
+                        <td>Asesor</td>
                         <td><span class="badge-estado badge-pendiente">Pendiente</span></td>
-                        <td><a class="boton-link" asp-controller="Administracion" asp-action="ValidacionCuentasBancarias">Validar cuenta</a></td>
+                        <td>26</td>
+                        <td>
+                            <div class="grupo-acciones-tabla">
+                                <a class="boton-link" asp-controller="Administracion" asp-action="ValidacionCuentasBancarias">Validar cuenta</a>
+                                <a class="boton-link" asp-controller="Administracion" asp-action="AuditoriaLogs">Mover clientes</a>
+                                <a class="boton-link" asp-controller="Administracion" asp-action="ParametrosPago">Roles</a>
+                            </div>
+                        </td>
                     </tr>
                 </tbody>
             </table>

--- a/PSA.WebApp/Views/Dashboard/Administrador.cshtml
+++ b/PSA.WebApp/Views/Dashboard/Administrador.cshtml
@@ -10,7 +10,7 @@
         <div>
             <span class="eyebrow">Vista operativa</span>
             <h2>Resumen administrativo</h2>
-            <p>Monitoree usuarios, parámetros, validaciones bancarias y auditoría.</p>
+            <p>Monitoree administración del sistema: usuarios, permisos, configuración de pagos y auditoría.</p>
         </div>
         <a class="boton-primario" asp-controller="Administracion" asp-action="GestionUsuarios">Gestionar usuarios</a>
     </div>
@@ -32,6 +32,20 @@
             <small>Últimas 24 horas</small>
         </article>
     </div>
+
+
+    <section class="tarjeta-panel panel-modulos-administracion">
+        <div class="cabecera-bloque">
+            <h3>Administración del sistema</h3>
+        </div>
+        <ul class="lista-capacidades-admin">
+            <li><strong>Gestión de usuarios:</strong> crear, modificar, eliminar y mover clientes entre asesores.</li>
+            <li><strong>Roles y permisos:</strong> control de accesos por perfil operativo y administrativo.</li>
+            <li><strong>Precio por hectárea:</strong> configuración del valor base para cálculos de pago.</li>
+            <li><strong>% de ajustes:</strong> parametrización de porcentajes aplicables en liquidaciones.</li>
+            <li><strong>Monitoreo y auditoría:</strong> seguimiento de actividad crítica y trazabilidad del sistema.</li>
+        </ul>
+    </section>
 
     <section class="tarjeta-panel">
         <div class="cabecera-bloque">

--- a/PSA.WebApp/wwwroot/css/administrador.css
+++ b/PSA.WebApp/wwwroot/css/administrador.css
@@ -1,3 +1,47 @@
 .administrador-dashboard .tarjeta-kpi strong {
     color: var(--color-texto-principal);
 }
+
+.lista-capacidades-admin {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: var(--espacio-2);
+    color: var(--color-texto-secundario);
+}
+
+.lista-capacidades-admin strong {
+    color: var(--color-texto-principal);
+}
+
+.panel-modulos-administracion {
+    border-left: 4px solid var(--color-accion);
+}
+
+.panel-resumen-admin h3 {
+    margin-top: 0;
+    margin-bottom: var(--espacio-3);
+}
+
+.grupo-acciones-tabla {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--espacio-2);
+}
+
+.tabla-usuarios-admin td {
+    vertical-align: middle;
+}
+
+html[data-tema="oscuro"] .boton-link {
+    color: #8EDC9A;
+}
+
+html[data-tema="oscuro"] .tabla-base th {
+    color: #D5E4D6;
+}
+
+html[data-tema="oscuro"] .badge-pendiente {
+    background: rgba(201, 150, 18, 0.2);
+    color: #F8DB8A;
+}

--- a/PSA.WebApp/wwwroot/css/variables.css
+++ b/PSA.WebApp/wwwroot/css/variables.css
@@ -32,11 +32,11 @@
 
 html[data-tema="oscuro"] {
     --color-fondo: #07140B;
-    --color-superficie: #0E1F12;
-    --color-superficie-secundaria: #122818;
-    --color-borde-suave: #1E3A24;
+    --color-superficie: #14251A;
+    --color-superficie-secundaria: #1A3022;
+    --color-borde-suave: #31533A;
     --color-texto-principal: #EAF2EA;
-    --color-texto-secundario: #A9B5A9;
+    --color-texto-secundario: #C6D5C6;
     --color-primario: #2E9739;
     --color-accion: #39A845;
     --sombra-sm: 0 8px 18px rgba(0, 0, 0, 0.25);

--- a/ScriptsActualizacion/2026-04-roles-permisos-y-auditoria-usuarios.sql
+++ b/ScriptsActualizacion/2026-04-roles-permisos-y-auditoria-usuarios.sql
@@ -1,0 +1,130 @@
+/*
+    Script de actualización puntual - Roles, permisos y auditoría de usuarios
+    Fecha: 2026-04-17
+    Objetivo:
+    - Introducir catálogo de permisos y relación RolPermisos.
+    - Sembrar permisos administrativos base.
+    - Asignar permisos al rol Administrador.
+    - Asegurar trigger de auditoría de Usuarios con CREATE OR ALTER.
+*/
+
+USE PSA_CostaRica;
+GO
+
+IF OBJECT_ID('dbo.Permisos', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.Permisos
+    (
+        IdPermiso INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        Codigo VARCHAR(80) NOT NULL,
+        Nombre VARCHAR(120) NOT NULL,
+        Descripcion VARCHAR(250) NULL,
+        Activo BIT NOT NULL CONSTRAINT DF_Permisos_Activo DEFAULT (1),
+        CONSTRAINT UQ_Permisos_Codigo UNIQUE (Codigo)
+    );
+END;
+GO
+
+IF OBJECT_ID('dbo.RolPermisos', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.RolPermisos
+    (
+        IdRolPermiso INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        IdRol INT NOT NULL,
+        IdPermiso INT NOT NULL,
+        CONSTRAINT FK_RolPermisos_Roles
+            FOREIGN KEY (IdRol) REFERENCES dbo.Roles(IdRol),
+        CONSTRAINT FK_RolPermisos_Permisos
+            FOREIGN KEY (IdPermiso) REFERENCES dbo.Permisos(IdPermiso),
+        CONSTRAINT UQ_RolPermisos UNIQUE (IdRol, IdPermiso)
+    );
+END;
+GO
+
+MERGE dbo.Permisos AS target
+USING (VALUES
+    ('ADMIN_USUARIOS_VER',       'Ver usuarios',             'Consulta el listado administrativo de usuarios'),
+    ('ADMIN_USUARIOS_CREAR',     'Crear usuarios',           'Permite crear usuarios desde el módulo administrativo'),
+    ('ADMIN_USUARIOS_EDITAR',    'Editar usuarios',          'Permite modificar datos, rol y estado de usuarios'),
+    ('ADMIN_USUARIOS_ELIMINAR',  'Eliminar usuarios',        'Permite eliminar usuarios sin dependencias operativas'),
+    ('ADMIN_USUARIOS_REASIGNAR', 'Reasignar clientes',       'Permite mover clientes a otro asesor'),
+    ('ADMIN_PAGOS_CONFIGURAR',   'Configurar pagos',         'Permite crear configuraciones de pago vigentes'),
+    ('ADMIN_CUENTAS_VALIDAR',    'Validar cuentas bancarias','Permite aprobar o rechazar cuentas bancarias'),
+    ('ADMIN_AUDITORIA_VER',      'Consultar auditoría',      'Permite revisar eventos y trazabilidad del sistema')
+) AS source (Codigo, Nombre, Descripcion)
+ON target.Codigo = source.Codigo
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Codigo, Nombre, Descripcion, Activo)
+    VALUES (source.Codigo, source.Nombre, source.Descripcion, 1);
+GO
+
+DECLARE @IdRolAdministrador INT =
+(
+    SELECT TOP 1 IdRol
+    FROM dbo.Roles
+    WHERE Nombre = 'Administrador'
+);
+
+IF @IdRolAdministrador IS NOT NULL
+BEGIN
+    INSERT INTO dbo.RolPermisos (IdRol, IdPermiso)
+    SELECT @IdRolAdministrador, p.IdPermiso
+    FROM dbo.Permisos p
+    WHERE NOT EXISTS
+    (
+        SELECT 1
+        FROM dbo.RolPermisos rp
+        WHERE rp.IdRol = @IdRolAdministrador
+          AND rp.IdPermiso = p.IdPermiso
+    );
+END;
+GO
+
+CREATE OR ALTER TRIGGER dbo.TR_Usuarios_Auditoria
+ON dbo.Usuarios
+AFTER INSERT, UPDATE, DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    INSERT INTO dbo.AuditoriaLog
+    (
+        IdUsuario, Modulo, TablaAfectada, IdRegistroAfectado,
+        Accion, ValorAnterior, ValorNuevo, FechaAccion, Detalle
+    )
+    SELECT i.IdUsuario, 'Usuarios', 'Usuarios', i.IdUsuario, 'INSERT', NULL,
+           (SELECT i.IdUsuario, i.NombreCompleto, i.Email, i.IdRol, i.Estado, i.FechaCreacion, i.UltimoAcceso
+            FOR JSON PATH, WITHOUT_ARRAY_WRAPPER),
+           SYSDATETIME(), CONCAT('Usuario creado: ', i.Email)
+    FROM inserted i
+    LEFT JOIN deleted d ON d.IdUsuario = i.IdUsuario
+    WHERE d.IdUsuario IS NULL;
+
+    INSERT INTO dbo.AuditoriaLog
+    (
+        IdUsuario, Modulo, TablaAfectada, IdRegistroAfectado,
+        Accion, ValorAnterior, ValorNuevo, FechaAccion, Detalle
+    )
+    SELECT i.IdUsuario, 'Usuarios', 'Usuarios', i.IdUsuario, 'UPDATE',
+           (SELECT d.IdUsuario, d.NombreCompleto, d.Email, d.IdRol, d.Estado, d.FechaCreacion, d.UltimoAcceso
+            FOR JSON PATH, WITHOUT_ARRAY_WRAPPER),
+           (SELECT i.IdUsuario, i.NombreCompleto, i.Email, i.IdRol, i.Estado, i.FechaCreacion, i.UltimoAcceso
+            FOR JSON PATH, WITHOUT_ARRAY_WRAPPER),
+           SYSDATETIME(), CONCAT('Usuario actualizado: ', i.Email)
+    FROM inserted i
+    INNER JOIN deleted d ON d.IdUsuario = i.IdUsuario;
+
+    INSERT INTO dbo.AuditoriaLog
+    (
+        IdUsuario, Modulo, TablaAfectada, IdRegistroAfectado,
+        Accion, ValorAnterior, ValorNuevo, FechaAccion, Detalle
+    )
+    SELECT d.IdUsuario, 'Usuarios', 'Usuarios', d.IdUsuario, 'DELETE',
+           (SELECT d.IdUsuario, d.NombreCompleto, d.Email, d.IdRol, d.Estado, d.FechaCreacion, d.UltimoAcceso
+            FOR JSON PATH, WITHOUT_ARRAY_WRAPPER),
+           NULL, SYSDATETIME(), CONCAT('Usuario eliminado: ', d.Email)
+    FROM deleted d
+    LEFT JOIN inserted i ON i.IdUsuario = d.IdUsuario
+    WHERE i.IdUsuario IS NULL;
+END;
+GO


### PR DESCRIPTION
### Motivation
- Provide clearer administrative UX with a capabilities panel, expanded actions and user table improvements for the admin dashboard and user management views.
- Ensure evidence upload is robust by ignoring null/empty files before counting and uploading attached evidence.
- Introduce a permissions model and auditing trigger to support role-based admin actions in the database and improve dark-theme contrast.

### Description
- Update `EvaluacionesController.NuevaEvaluacion` to filter out null/empty `IFormFile` entries into `evidenciasAdjuntas`, compute `totalEvidencias` from that list and pass it to `SubirEvidenciasAsync` to avoid attempting uploads of empty entries.
- Enhance `Views/Administracion/GestionUsuarios.cshtml` to add an "Alcance administrativo" panel, adjust the users table columns and actions, and improve descriptive copy for administration flows.
- Enhance `Views/Dashboard/Administrador.cshtml` to include an "Administración del sistema" capabilities panel and updated descriptive text and CTA.
- Add `wwwroot/css/administrador.css` with styles for `.lista-capacidades-admin`, `.panel-modulos-administracion`, `.tabla-usuarios-admin`, action groups and dark-theme tweaks; adjust `wwwroot/css/variables.css` to modify dark-theme surface and text color variables for improved contrast.
- Add SQL migration script `ScriptsActualizacion/2026-04-roles-permisos-y-auditoria-usuarios.sql` that creates `Permisos` and `RolPermisos` tables, seeds a set of administrative permissions, assigns them to the `Administrador` role, and creates/alter trigger `TR_Usuarios_Auditoria` to log inserts/updates/deletes to `AuditoriaLog`.

### Testing
- No automated tests were added or modified as part of this change.
- No automated tests were executed as part of this rollout; existing CI should run the repository's test suite to validate integration with these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18539eda4832d82b47bf9f0a23d65)