### PR TITLE
Add administration manager, DAOs and WebApp admin UI for user/roles/payments/audit

### DIFF
--- a/PSA.AppCore/Managers/AdministracionManager.cs
+++ b/PSA.AppCore/Managers/AdministracionManager.cs
@@ -1,0 +1,239 @@
+using PSA.AppCore.Servicios;
+using PSA.DataAccess.DAO;
+using PSA.EntidadesDTO.DTOs.Administracion;
+using PSA.EntidadesDTO.DTOs.Usuarios;
+using PSA.EntidadesDTO.Entidades;
+
+namespace PSA.AppCore.Managers;
+
+public class AdministracionManager
+{
+    private readonly UsuarioDAO _usuarioDao;
+    private readonly RolPermisoDAO _rolPermisoDao;
+    private readonly ConfiguracionPagoDAO _configuracionPagoDao;
+    private readonly CuentaBancariaDAO _cuentaBancariaDao;
+    private readonly AuditoriaLogDAO _auditoriaLogDao;
+    private readonly IServicioHashContrasena _servicioHashContrasena;
+
+    public AdministracionManager(
+        UsuarioDAO usuarioDao,
+        RolPermisoDAO rolPermisoDao,
+        ConfiguracionPagoDAO configuracionPagoDao,
+        CuentaBancariaDAO cuentaBancariaDao,
+        AuditoriaLogDAO auditoriaLogDao,
+        IServicioHashContrasena servicioHashContrasena)
+    {
+        _usuarioDao = usuarioDao;
+        _rolPermisoDao = rolPermisoDao;
+        _configuracionPagoDao = configuracionPagoDao;
+        _cuentaBancariaDao = cuentaBancariaDao;
+        _auditoriaLogDao = auditoriaLogDao;
+        _servicioHashContrasena = servicioHashContrasena;
+    }
+
+    public Task<List<UsuarioAdminListadoDTO>> ObtenerUsuariosAsync(int? idRol = null)
+        => _usuarioDao.ObtenerUsuariosAdminAsync(idRol);
+
+    public Task<UsuarioAdminEdicionDTO?> ObtenerUsuarioAsync(int idUsuario)
+        => _usuarioDao.ObtenerUsuarioAdminPorIdAsync(idUsuario);
+
+    public async Task CrearUsuarioAsync(UsuarioAdminEdicionDTO model, int idAdmin, string? ip)
+    {
+        ValidarUsuarioAdmin(model, requiereContrasena: true);
+
+        var existente = await _usuarioDao.ObtenerPorEmailAsync(model.Email.Trim());
+        if (existente != null)
+        {
+            throw new InvalidOperationException("Ya existe un usuario con el correo indicado.");
+        }
+
+        var nuevo = new Usuario
+        {
+            NombreCompleto = model.NombreCompleto.Trim(),
+            Email = model.Email.Trim(),
+            PasswordHash = _servicioHashContrasena.GenerarHash(model.Contrasena!),
+            IdRol = model.IdRol,
+            Estado = model.Estado,
+            FechaCreacion = DateTime.UtcNow,
+            UltimoAcceso = null
+        };
+
+        var idCreado = await _usuarioDao.CrearUsuarioAsync(nuevo);
+
+        await _auditoriaLogDao.RegistrarEventoAsync(
+            idUsuario: idAdmin,
+            modulo: "Administracion",
+            tablaAfectada: "Usuarios",
+            accion: "CREAR_USUARIO",
+            detalle: $"Usuario creado: {model.Email}",
+            idRegistroAfectado: idCreado,
+            ipOrigen: ip);
+    }
+
+    public async Task ActualizarUsuarioAsync(UsuarioAdminEdicionDTO model, int idAdmin, string? ip)
+    {
+        if (model.IdUsuario <= 0)
+        {
+            throw new InvalidOperationException("El Id del usuario es inválido.");
+        }
+
+        ValidarUsuarioAdmin(model, requiereContrasena: false);
+
+        string? nuevoHash = null;
+        if (!string.IsNullOrWhiteSpace(model.Contrasena))
+        {
+            if (model.Contrasena != model.ConfirmacionContrasena)
+            {
+                throw new InvalidOperationException("La contraseña y su confirmación no coinciden.");
+            }
+
+            nuevoHash = _servicioHashContrasena.GenerarHash(model.Contrasena);
+        }
+
+        var actualizados = await _usuarioDao.ActualizarUsuarioAdminAsync(model, nuevoHash);
+        if (actualizados <= 0)
+        {
+            throw new InvalidOperationException("No se encontró el usuario a actualizar.");
+        }
+
+        await _auditoriaLogDao.RegistrarEventoAsync(
+            idUsuario: idAdmin,
+            modulo: "Administracion",
+            tablaAfectada: "Usuarios",
+            accion: "ACTUALIZAR_USUARIO",
+            detalle: $"Usuario actualizado: {model.IdUsuario}",
+            idRegistroAfectado: model.IdUsuario,
+            ipOrigen: ip);
+    }
+
+    public async Task EliminarUsuarioAsync(int idUsuario, int idAdmin, string? ip)
+    {
+        if (idUsuario <= 0)
+        {
+            throw new InvalidOperationException("El Id del usuario es inválido.");
+        }
+
+        var filas = await _usuarioDao.EliminarUsuarioAdminAsync(idUsuario);
+        if (filas <= 0)
+        {
+            throw new InvalidOperationException("No se encontró el usuario a desactivar.");
+        }
+
+        await _auditoriaLogDao.RegistrarEventoAsync(
+            idUsuario: idAdmin,
+            modulo: "Administracion",
+            tablaAfectada: "Usuarios",
+            accion: "DESACTIVAR_USUARIO",
+            detalle: $"Usuario desactivado: {idUsuario}",
+            idRegistroAfectado: idUsuario,
+            ipOrigen: ip);
+    }
+
+    public async Task ReasignarClienteAsync(ReasignacionClienteDTO model, int idAdmin, string? ip)
+    {
+        if (model.IdPropietario <= 0 || model.IdIngenieroDestino <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar propietario e ingeniero destino válidos.");
+        }
+
+        await _usuarioDao.ReasignarClientesAIngenieroAsync(model.IdPropietario, model.IdIngenieroDestino);
+
+        await _auditoriaLogDao.RegistrarEventoAsync(
+            idUsuario: idAdmin,
+            modulo: "Administracion",
+            tablaAfectada: "EvaluacionesTecnicas",
+            accion: "REASIGNAR_CLIENTE",
+            detalle: $"Propietario {model.IdPropietario} reasignado al ingeniero {model.IdIngenieroDestino}",
+            idRegistroAfectado: model.IdPropietario,
+            ipOrigen: ip);
+    }
+
+    public Task<List<RolDTO>> ObtenerRolesAsync()
+        => _rolPermisoDao.ObtenerRolesAsync();
+
+    public Task<List<RolPermisoDTO>> ObtenerRolesConPermisosAsync()
+        => _rolPermisoDao.ObtenerRolesConPermisosAsync();
+
+    public async Task GuardarPermisosRolAsync(GuardarPermisosRolDTO model, int idAdmin, string? ip)
+    {
+        await _rolPermisoDao.GuardarPermisosRolAsync(model);
+
+        await _auditoriaLogDao.RegistrarEventoAsync(
+            idUsuario: idAdmin,
+            modulo: "Administracion",
+            tablaAfectada: "RolesPermisos",
+            accion: "GUARDAR_PERMISOS_ROL",
+            detalle: $"Permisos actualizados para rol {model.IdRol}",
+            idRegistroAfectado: model.IdRol,
+            ipOrigen: ip);
+    }
+
+    public Task<ConfiguracionPagoAdminDTO?> ObtenerConfiguracionVigenteAsync()
+        => _configuracionPagoDao.ObtenerConfiguracionVigenteAsync();
+
+    public Task<List<ConfiguracionPagoAdminDTO>> ObtenerHistorialConfiguracionesAsync()
+        => _configuracionPagoDao.ObtenerHistorialAsync();
+
+    public async Task CrearConfiguracionPagoAsync(ConfiguracionPagoAdminDTO model, int idAdmin, string? ip)
+    {
+        model.CreadoPor = idAdmin;
+        var idConfiguracion = await _configuracionPagoDao.CrearConfiguracionAsync(model);
+
+        await _auditoriaLogDao.RegistrarEventoAsync(
+            idUsuario: idAdmin,
+            modulo: "Administracion",
+            tablaAfectada: "ConfiguracionesPago",
+            accion: "CREAR_CONFIGURACION_PAGO",
+            detalle: $"Nueva configuración de pago creada: {model.NombreVersion}",
+            idRegistroAfectado: idConfiguracion,
+            ipOrigen: ip);
+    }
+
+    public Task<List<CuentaBancariaPendienteDTO>> ObtenerCuentasPendientesAsync()
+        => _cuentaBancariaDao.ObtenerPendientesValidacionAsync();
+
+    public async Task ValidarCuentaBancariaAsync(ValidacionCuentaBancariaDTO model, string? ip)
+    {
+        await _cuentaBancariaDao.ValidarCuentaAsync(model);
+
+        await _auditoriaLogDao.RegistrarEventoAsync(
+            idUsuario: model.IdAdministrador,
+            modulo: "Administracion",
+            tablaAfectada: "CuentasBancarias",
+            accion: "VALIDAR_CUENTA_BANCARIA",
+            detalle: $"Cuenta {model.IdCuentaBancaria} validada con resultado: {(model.Aprobada ? "Aprobada" : "Rechazada")}",
+            idRegistroAfectado: model.IdCuentaBancaria,
+            ipOrigen: ip);
+    }
+
+    public Task<List<AuditoriaEventoDTO>> ObtenerEventosAuditoriaAsync(AuditoriaFiltroDTO filtro)
+        => _auditoriaLogDao.ObtenerEventosAsync(filtro);
+
+    private static void ValidarUsuarioAdmin(UsuarioAdminEdicionDTO model, bool requiereContrasena)
+    {
+        if (string.IsNullOrWhiteSpace(model.NombreCompleto))
+        {
+            throw new InvalidOperationException("El nombre completo es obligatorio.");
+        }
+
+        if (string.IsNullOrWhiteSpace(model.Email))
+        {
+            throw new InvalidOperationException("El correo es obligatorio.");
+        }
+
+        if (model.IdRol <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un rol válido.");
+        }
+
+        if (string.IsNullOrWhiteSpace(model.Estado))
+        {
+            throw new InvalidOperationException("Debe indicar un estado válido.");
+        }
+
+        if (requiereContrasena && string.IsNullOrWhiteSpace(model.Contrasena))
+        {
+            throw new InvalidOperationException("La contraseña es obligatoria para crear usuarios.");
+        }
+    }
+}

--- a/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
+++ b/PSA.DataAccess/DAO/AuditoriaLogDAO.cs
@@ -1,4 +1,5 @@
 using Microsoft.Data.SqlClient;
+using PSA.EntidadesDTO.DTOs.Administracion;
 
 using PSA.DataAccess;
 
@@ -65,6 +66,63 @@ VALUES
 
             await connection.OpenAsync();
             await command.ExecuteNonQueryAsync();
+        }
+
+        public async Task<List<AuditoriaEventoDTO>> ObtenerEventosAsync(AuditoriaFiltroDTO filtro)
+        {
+            var sql = @"
+SELECT TOP (@MaximoRegistros)
+    a.IdLog,
+    a.IdUsuario,
+    u.NombreCompleto AS NombreUsuario,
+    a.Modulo,
+    a.TablaAfectada,
+    a.IdRegistroAfectado,
+    a.Accion,
+    a.Detalle,
+    a.IpOrigen,
+    a.FechaAccion,
+    a.ValorAnterior,
+    a.ValorNuevo
+FROM dbo.AuditoriaLog a
+LEFT JOIN dbo.Usuarios u ON u.IdUsuario = a.IdUsuario
+WHERE (@Modulo IS NULL OR a.Modulo = @Modulo)
+  AND (@Accion IS NULL OR a.Accion = @Accion)
+  AND (@FechaDesde IS NULL OR a.FechaAccion >= @FechaDesde)
+  AND (@FechaHasta IS NULL OR a.FechaAccion <= @FechaHasta)
+ORDER BY a.IdLog DESC;";
+
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@MaximoRegistros", filtro.MaximoRegistros <= 0 ? 50 : filtro.MaximoRegistros);
+            command.Parameters.AddWithValue("@Modulo", (object?)filtro.Modulo ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Accion", (object?)filtro.Accion ?? DBNull.Value);
+            command.Parameters.AddWithValue("@FechaDesde", (object?)filtro.FechaDesde ?? DBNull.Value);
+            command.Parameters.AddWithValue("@FechaHasta", (object?)filtro.FechaHasta ?? DBNull.Value);
+
+            var eventos = new List<AuditoriaEventoDTO>();
+            await connection.OpenAsync();
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                eventos.Add(new AuditoriaEventoDTO
+                {
+                    IdLog = reader.GetInt32(reader.GetOrdinal("IdLog")),
+                    IdUsuario = reader["IdUsuario"] == DBNull.Value ? null : reader.GetInt32(reader.GetOrdinal("IdUsuario")),
+                    NombreUsuario = reader["NombreUsuario"] == DBNull.Value ? null : reader["NombreUsuario"]?.ToString(),
+                    Modulo = reader["Modulo"]?.ToString() ?? string.Empty,
+                    TablaAfectada = reader["TablaAfectada"]?.ToString() ?? string.Empty,
+                    IdRegistroAfectado = reader["IdRegistroAfectado"] == DBNull.Value ? null : reader.GetInt32(reader.GetOrdinal("IdRegistroAfectado")),
+                    Accion = reader["Accion"]?.ToString() ?? string.Empty,
+                    Detalle = reader["Detalle"] == DBNull.Value ? null : reader["Detalle"]?.ToString(),
+                    IpOrigen = reader["IpOrigen"] == DBNull.Value ? null : reader["IpOrigen"]?.ToString(),
+                    FechaAccion = reader.GetDateTime(reader.GetOrdinal("FechaAccion")),
+                    ValorAnterior = reader["ValorAnterior"] == DBNull.Value ? null : reader["ValorAnterior"]?.ToString(),
+                    ValorNuevo = reader["ValorNuevo"] == DBNull.Value ? null : reader["ValorNuevo"]?.ToString()
+                });
+            }
+
+            return eventos;
         }
     }
 }

--- a/PSA.DataAccess/DAO/ConfiguracionPagoDAO.cs
+++ b/PSA.DataAccess/DAO/ConfiguracionPagoDAO.cs
@@ -1,156 +1,145 @@
-using PSA.DataAccess.BaseDatos;
-using PSA.EntidadesDTO.DTOs.Administracion;
 using Microsoft.Data.SqlClient;
-using System.Data;
+using PSA.DataAccess;
+using PSA.EntidadesDTO.DTOs.Administracion;
 
-namespace PSA.DataAccess.DAO
+namespace PSA.DataAccess.DAO;
+
+public class ConfiguracionPagoDAO
 {
-    public class ConfiguracionPagoDAO
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public ConfiguracionPagoDAO(IDbConnectionFactory connectionFactory)
     {
-        private readonly DbContextHelper _dbContext;
+        _connectionFactory = connectionFactory;
+    }
 
-        public ConfiguracionPagoDAO(DbContextHelper dbContext)
+    public async Task<int> CrearConfiguracionAsync(ConfiguracionPagoAdminDTO dto)
+    {
+        const string sql = @"
+INSERT INTO dbo.ConfiguracionesPago
+(
+    Version,
+    NombreVersion,
+    PrecioBasePorHectarea,
+    PorcentajeTopeAjuste,
+    FechaVigenciaDesde,
+    FechaVigenciaHasta,
+    Estado,
+    IdAdministrador,
+    FechaCreacion
+)
+VALUES
+(
+    @Version,
+    @NombreVersion,
+    @PrecioBasePorHectarea,
+    @PorcentajeTopeAjuste,
+    @FechaVigenciaDesde,
+    @FechaVigenciaHasta,
+    CASE WHEN @Activa = 1 THEN 'Activa' ELSE 'Inactiva' END,
+    @IdAdministrador,
+    SYSUTCDATETIME()
+);
+SELECT CAST(SCOPE_IDENTITY() AS int);";
+
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+
+        command.Parameters.AddWithValue("@Version", dto.Version <= 0 ? 1 : dto.Version);
+        command.Parameters.AddWithValue("@NombreVersion", dto.NombreVersion);
+        command.Parameters.AddWithValue("@PrecioBasePorHectarea", dto.PrecioBasePorHectarea);
+        command.Parameters.AddWithValue("@PorcentajeTopeAjuste", dto.TopePorcentajeAjuste);
+        command.Parameters.AddWithValue("@FechaVigenciaDesde", dto.FechaVigenciaDesde);
+        command.Parameters.AddWithValue("@FechaVigenciaHasta", (object?)dto.FechaVigenciaHasta ?? DBNull.Value);
+        command.Parameters.AddWithValue("@Activa", dto.Activa);
+        command.Parameters.AddWithValue("@IdAdministrador", dto.CreadoPor);
+
+        await connection.OpenAsync();
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
+    }
+
+    public async Task<ConfiguracionPagoAdminDTO?> ObtenerConfiguracionVigenteAsync()
+    {
+        const string sql = @"
+SELECT TOP 1
+    IdConfiguracionPago,
+    Version,
+    NombreVersion,
+    PrecioBasePorHectarea,
+    PorcentajeTopeAjuste,
+    FechaVigenciaDesde,
+    FechaVigenciaHasta,
+    Estado,
+    IdAdministrador,
+    FechaCreacion
+FROM dbo.ConfiguracionesPago
+WHERE Estado = 'Activa'
+ORDER BY FechaVigenciaDesde DESC, IdConfiguracionPago DESC;";
+
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+
+        if (!await reader.ReadAsync())
         {
-            _dbContext = dbContext;
+            return null;
         }
 
-        public async Task<int> CrearConfiguracionAsync(ConfiguracionPagoAdminDTO dto)
+        return MapConfiguracion(reader);
+    }
+
+    public async Task<List<ConfiguracionPagoAdminDTO>> ObtenerHistorialAsync()
+    {
+        const string sql = @"
+SELECT
+    IdConfiguracionPago,
+    Version,
+    NombreVersion,
+    PrecioBasePorHectarea,
+    PorcentajeTopeAjuste,
+    FechaVigenciaDesde,
+    FechaVigenciaHasta,
+    Estado,
+    IdAdministrador,
+    FechaCreacion
+FROM dbo.ConfiguracionesPago
+ORDER BY FechaVigenciaDesde DESC, IdConfiguracionPago DESC;";
+
+        var resultado = new List<ConfiguracionPagoAdminDTO>();
+
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
         {
-            using var conn = _dbContext.CrearConexion();
-            await conn.OpenAsync();
-
-            using var tx = conn.BeginTransaction();
-            try
-            {
-                var cmd = conn.CreateCommand();
-                cmd.Transaction = tx;
-                cmd.CommandType = CommandType.StoredProcedure;
-                cmd.CommandText = "SP_CREAR_CONFIGURACION_PAGO";
-
-                cmd.Parameters.AddWithValue("@PrecioBasePorHectarea", dto.PrecioBasePorHectarea);
-                cmd.Parameters.AddWithValue("@PorcentajeTopeAjuste", dto.PorcentajeTopeAjuste);
-                cmd.Parameters.AddWithValue("@FechaVigenciaDesde", dto.FechaVigenciaDesde);
-                cmd.Parameters.AddWithValue("@Observaciones", (object?)dto.Observaciones ?? DBNull.Value);
-                cmd.Parameters.AddWithValue("@IdAdministrador", dto.IdAdministradorCreador ?? (object)DBNull.Value);
-
-                var idConfiguracion = Convert.ToInt32(await cmd.ExecuteScalarAsync());
-
-                if (dto.Ajustes != null)
-                {
-                    foreach (var ajuste in dto.Ajustes)
-                    {
-                        var cmdDetalle = conn.CreateCommand();
-                        cmdDetalle.Transaction = tx;
-                        cmdDetalle.CommandType = CommandType.StoredProcedure;
-                        cmdDetalle.CommandText = "SP_CREAR_CONFIGURACION_PAGO_AJUSTE";
-
-                        cmdDetalle.Parameters.AddWithValue("@IdConfiguracionPago", idConfiguracion);
-                        cmdDetalle.Parameters.AddWithValue("@TipoFactor", ajuste.TipoFactor);
-                        cmdDetalle.Parameters.AddWithValue("@ValorFactor", ajuste.ValorFactor);
-                        cmdDetalle.Parameters.AddWithValue("@PorcentajeAjuste", ajuste.PorcentajeAjuste);
-                        cmdDetalle.Parameters.AddWithValue("@Activo", ajuste.Activo);
-
-                        await cmdDetalle.ExecuteNonQueryAsync();
-                    }
-                }
-
-                tx.Commit();
-                return idConfiguracion;
-            }
-            catch
-            {
-                tx.Rollback();
-                throw;
-            }
+            resultado.Add(MapConfiguracion(reader));
         }
 
-        public async Task<ConfiguracionPagoAdminDTO?> ObtenerConfiguracionVigenteAsync()
+        return resultado;
+    }
+
+    private static ConfiguracionPagoAdminDTO MapConfiguracion(SqlDataReader reader)
+    {
+        var estado = reader["Estado"]?.ToString() ?? string.Empty;
+
+        return new ConfiguracionPagoAdminDTO
         {
-            using var conn = _dbContext.CrearConexion();
-            using var cmd = conn.CreateCommand();
-            cmd.CommandType = CommandType.StoredProcedure;
-            cmd.CommandText = "SP_OBTENER_CONFIGURACION_PAGO_VIGENTE";
-
-            await conn.OpenAsync();
-            using var reader = await cmd.ExecuteReaderAsync();
-
-            ConfiguracionPagoAdminDTO? configuracion = null;
-            while (await reader.ReadAsync())
-            {
-                if (configuracion == null)
-                {
-                    configuracion = new ConfiguracionPagoAdminDTO
-                    {
-                        IdConfiguracionPago = reader.GetInt32(reader.GetOrdinal("IdConfiguracionPago")),
-                        PrecioBasePorHectarea = reader.GetDecimal(reader.GetOrdinal("PrecioBasePorHectarea")),
-                        PorcentajeTopeAjuste = reader.GetDecimal(reader.GetOrdinal("PorcentajeTopeAjuste")),
-                        FechaVigenciaDesde = reader.GetDateTime(reader.GetOrdinal("FechaVigenciaDesde")),
-                        FechaCreacion = reader.GetDateTime(reader.GetOrdinal("FechaCreacion")),
-                        Observaciones = reader.IsDBNull(reader.GetOrdinal("Observaciones")) ? null : reader.GetString(reader.GetOrdinal("Observaciones")),
-                        Ajustes = new List<ConfiguracionPagoAjusteDTO>()
-                    };
-                }
-
-                if (!reader.IsDBNull(reader.GetOrdinal("IdConfiguracionPagoAjuste")))
-                {
-                    configuracion.Ajustes.Add(new ConfiguracionPagoAjusteDTO
-                    {
-                        IdConfiguracionPagoAjuste = reader.GetInt32(reader.GetOrdinal("IdConfiguracionPagoAjuste")),
-                        TipoFactor = reader.GetString(reader.GetOrdinal("TipoFactor")),
-                        ValorFactor = reader.GetString(reader.GetOrdinal("ValorFactor")),
-                        PorcentajeAjuste = reader.GetDecimal(reader.GetOrdinal("PorcentajeAjuste")),
-                        Activo = reader.GetBoolean(reader.GetOrdinal("Activo"))
-                    });
-                }
-            }
-
-            return configuracion;
-        }
-
-        public async Task<List<ConfiguracionPagoAdminDTO>> ObtenerHistorialAsync()
-        {
-            using var conn = _dbContext.CrearConexion();
-            using var cmd = conn.CreateCommand();
-            cmd.CommandType = CommandType.StoredProcedure;
-            cmd.CommandText = "SP_OBTENER_HISTORIAL_CONFIGURACION_PAGO";
-
-            await conn.OpenAsync();
-            using var reader = await cmd.ExecuteReaderAsync();
-
-            var configuraciones = new Dictionary<int, ConfiguracionPagoAdminDTO>();
-
-            while (await reader.ReadAsync())
-            {
-                var idConfiguracion = reader.GetInt32(reader.GetOrdinal("IdConfiguracionPago"));
-                if (!configuraciones.TryGetValue(idConfiguracion, out var configuracion))
-                {
-                    configuracion = new ConfiguracionPagoAdminDTO
-                    {
-                        IdConfiguracionPago = idConfiguracion,
-                        PrecioBasePorHectarea = reader.GetDecimal(reader.GetOrdinal("PrecioBasePorHectarea")),
-                        PorcentajeTopeAjuste = reader.GetDecimal(reader.GetOrdinal("PorcentajeTopeAjuste")),
-                        FechaVigenciaDesde = reader.GetDateTime(reader.GetOrdinal("FechaVigenciaDesde")),
-                        FechaCreacion = reader.GetDateTime(reader.GetOrdinal("FechaCreacion")),
-                        Observaciones = reader.IsDBNull(reader.GetOrdinal("Observaciones")) ? null : reader.GetString(reader.GetOrdinal("Observaciones")),
-                        Ajustes = new List<ConfiguracionPagoAjusteDTO>()
-                    };
-                    configuraciones[idConfiguracion] = configuracion;
-                }
-
-                if (!reader.IsDBNull(reader.GetOrdinal("IdConfiguracionPagoAjuste")))
-                {
-                    configuracion.Ajustes.Add(new ConfiguracionPagoAjusteDTO
-                    {
-                        IdConfiguracionPagoAjuste = reader.GetInt32(reader.GetOrdinal("IdConfiguracionPagoAjuste")),
-                        TipoFactor = reader.GetString(reader.GetOrdinal("TipoFactor")),
-                        ValorFactor = reader.GetString(reader.GetOrdinal("ValorFactor")),
-                        PorcentajeAjuste = reader.GetDecimal(reader.GetOrdinal("PorcentajeAjuste")),
-                        Activo = reader.GetBoolean(reader.GetOrdinal("Activo"))
-                    });
-                }
-            }
-
-            return configuraciones.Values.OrderByDescending(x => x.FechaVigenciaDesde).ToList();
-        }
+            IdConfiguracionPago = reader.GetInt32(reader.GetOrdinal("IdConfiguracionPago")),
+            Version = reader["Version"] == DBNull.Value ? 1 : reader.GetInt32(reader.GetOrdinal("Version")),
+            NombreVersion = reader["NombreVersion"]?.ToString() ?? string.Empty,
+            PrecioBasePorHectarea = reader.GetDecimal(reader.GetOrdinal("PrecioBasePorHectarea")),
+            TopePorcentajeAjuste = reader.GetDecimal(reader.GetOrdinal("PorcentajeTopeAjuste")),
+            FechaVigenciaDesde = reader.GetDateTime(reader.GetOrdinal("FechaVigenciaDesde")),
+            FechaVigenciaHasta = reader["FechaVigenciaHasta"] == DBNull.Value ? null : reader.GetDateTime(reader.GetOrdinal("FechaVigenciaHasta")),
+            Activa = string.Equals(estado, "Activa", StringComparison.OrdinalIgnoreCase),
+            CreadoPor = reader["IdAdministrador"] == DBNull.Value ? 0 : reader.GetInt32(reader.GetOrdinal("IdAdministrador")),
+            FechaCreacion = reader.GetDateTime(reader.GetOrdinal("FechaCreacion")),
+            Ajustes = new List<ConfiguracionPagoAjusteDTO>()
+        };
     }
 }

--- a/PSA.DataAccess/DAO/CuentaBancariaDAO.cs
+++ b/PSA.DataAccess/DAO/CuentaBancariaDAO.cs
@@ -1,63 +1,87 @@
-using PSA.DataAccess.BaseDatos;
-using PSA.EntidadesDTO.DTOs.Administracion;
 using Microsoft.Data.SqlClient;
-using System.Data;
+using PSA.DataAccess;
+using PSA.EntidadesDTO.DTOs.Administracion;
 
-namespace PSA.DataAccess.DAO
+namespace PSA.DataAccess.DAO;
+
+public class CuentaBancariaDAO
 {
-    public class CuentaBancariaDAO
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public CuentaBancariaDAO(IDbConnectionFactory connectionFactory)
     {
-        private readonly DbContextHelper _dbContext;
+        _connectionFactory = connectionFactory;
+    }
 
-        public CuentaBancariaDAO(DbContextHelper dbContext)
+    public async Task<List<CuentaBancariaPendienteDTO>> ObtenerPendientesValidacionAsync()
+    {
+        const string sql = @"
+SELECT
+    cb.IdCuentaBancaria,
+    cb.IdUsuario,
+    u.NombreCompleto AS NombreUsuario,
+    u.Email AS EmailUsuario,
+    cb.Banco,
+    cb.NumeroCuenta,
+    cb.TipoCuenta,
+    cb.Titular,
+    cb.EstadoValidacion,
+    cb.ObservacionesValidacion,
+    cb.Estado AS EstadoCuenta,
+    cb.FechaCreacion
+FROM dbo.CuentasBancarias cb
+INNER JOIN dbo.Usuarios u ON u.IdUsuario = cb.IdUsuario
+WHERE cb.EstadoValidacion = 'Pendiente'
+ORDER BY cb.FechaCreacion ASC;";
+
+        var resultado = new List<CuentaBancariaPendienteDTO>();
+
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
         {
-            _dbContext = dbContext;
-        }
-
-        public async Task<List<CuentaBancariaPendienteDTO>> ObtenerPendientesValidacionAsync()
-        {
-            using var conn = _dbContext.CrearConexion();
-            using var cmd = conn.CreateCommand();
-            cmd.CommandType = CommandType.StoredProcedure;
-            cmd.CommandText = "SP_OBTENER_CUENTAS_BANCARIAS_PENDIENTES";
-
-            await conn.OpenAsync();
-            using var reader = await cmd.ExecuteReaderAsync();
-            var lista = new List<CuentaBancariaPendienteDTO>();
-
-            while (await reader.ReadAsync())
+            resultado.Add(new CuentaBancariaPendienteDTO
             {
-                lista.Add(new CuentaBancariaPendienteDTO
-                {
-                    IdCuentaBancaria = reader.GetInt32(reader.GetOrdinal("IdCuentaBancaria")),
-                    IdUsuario = reader.GetInt32(reader.GetOrdinal("IdUsuario")),
-                    NombreUsuario = reader.GetString(reader.GetOrdinal("NombreUsuario")),
-                    CorreoUsuario = reader.GetString(reader.GetOrdinal("CorreoUsuario")),
-                    Banco = reader.GetString(reader.GetOrdinal("Banco")),
-                    NumeroCuenta = reader.GetString(reader.GetOrdinal("NumeroCuenta")),
-                    TipoCuenta = reader.GetString(reader.GetOrdinal("TipoCuenta")),
-                    CuentaIBAN = reader.IsDBNull(reader.GetOrdinal("CuentaIBAN")) ? null : reader.GetString(reader.GetOrdinal("CuentaIBAN")),
-                    FechaRegistro = reader.GetDateTime(reader.GetOrdinal("FechaRegistro"))
-                });
-            }
-
-            return lista;
+                IdCuentaBancaria = reader.GetInt32(reader.GetOrdinal("IdCuentaBancaria")),
+                IdUsuario = reader.GetInt32(reader.GetOrdinal("IdUsuario")),
+                NombreUsuario = reader["NombreUsuario"]?.ToString() ?? string.Empty,
+                EmailUsuario = reader["EmailUsuario"]?.ToString() ?? string.Empty,
+                Banco = reader["Banco"]?.ToString() ?? string.Empty,
+                NumeroCuenta = reader["NumeroCuenta"]?.ToString() ?? string.Empty,
+                TipoCuenta = reader["TipoCuenta"]?.ToString() ?? string.Empty,
+                Titular = reader["Titular"]?.ToString() ?? string.Empty,
+                EstadoValidacion = reader["EstadoValidacion"]?.ToString() ?? string.Empty,
+                ObservacionesValidacion = reader["ObservacionesValidacion"] == DBNull.Value ? null : reader["ObservacionesValidacion"]?.ToString(),
+                Activa = string.Equals(reader["EstadoCuenta"]?.ToString(), "Activa", StringComparison.OrdinalIgnoreCase),
+                FechaRegistro = reader.GetDateTime(reader.GetOrdinal("FechaCreacion"))
+            });
         }
 
-        public async Task ValidarCuentaAsync(ValidacionCuentaBancariaDTO dto)
-        {
-            using var conn = _dbContext.CrearConexion();
-            using var cmd = conn.CreateCommand();
-            cmd.CommandType = CommandType.StoredProcedure;
-            cmd.CommandText = "SP_VALIDAR_CUENTA_BANCARIA";
+        return resultado;
+    }
 
-            cmd.Parameters.AddWithValue("@IdCuentaBancaria", dto.IdCuentaBancaria);
-            cmd.Parameters.AddWithValue("@IdAdministrador", dto.IdAdministrador);
-            cmd.Parameters.AddWithValue("@EstadoValidacion", dto.EstadoValidacion);
-            cmd.Parameters.AddWithValue("@Observaciones", (object?)dto.Observaciones ?? DBNull.Value);
+    public async Task ValidarCuentaAsync(ValidacionCuentaBancariaDTO dto)
+    {
+        const string sql = @"
+UPDATE dbo.CuentasBancarias
+SET
+    EstadoValidacion = @EstadoValidacion,
+    ObservacionesValidacion = @Observaciones,
+    FechaActualizacion = SYSUTCDATETIME()
+WHERE IdCuentaBancaria = @IdCuentaBancaria;";
 
-            await conn.OpenAsync();
-            await cmd.ExecuteNonQueryAsync();
-        }
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+
+        command.Parameters.AddWithValue("@IdCuentaBancaria", dto.IdCuentaBancaria);
+        command.Parameters.AddWithValue("@EstadoValidacion", dto.Aprobada ? "Aprobada" : "Rechazada");
+        command.Parameters.AddWithValue("@Observaciones", (object?)dto.Observaciones ?? DBNull.Value);
+
+        await connection.OpenAsync();
+        await command.ExecuteNonQueryAsync();
     }
 }

--- a/PSA.DataAccess/DAO/RolPermisoDAO.cs
+++ b/PSA.DataAccess/DAO/RolPermisoDAO.cs
@@ -1,127 +1,167 @@
-using PSA.DataAccess.BaseDatos;
-using PSA.EntidadesDTO.DTOs.Administracion;
 using Microsoft.Data.SqlClient;
-using System.Data;
+using PSA.DataAccess;
+using PSA.EntidadesDTO.DTOs.Administracion;
 
-namespace PSA.DataAccess.DAO
+namespace PSA.DataAccess.DAO;
+
+public class RolPermisoDAO
 {
-    public class RolPermisoDAO
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public RolPermisoDAO(IDbConnectionFactory connectionFactory)
     {
-        private readonly DbContextHelper _dbContext;
+        _connectionFactory = connectionFactory;
+    }
 
-        public RolPermisoDAO(DbContextHelper dbContext)
+    public async Task<List<RolPermisoDTO>> ObtenerRolesConPermisosAsync()
+    {
+        const string sql = @"
+SELECT
+    r.IdRol,
+    r.Nombre AS NombreRol,
+    r.Descripcion AS DescripcionRol,
+    CAST(CASE WHEN r.Estado = 'Activo' THEN 1 ELSE 0 END AS bit) AS Activo,
+    p.Codigo AS CodigoPermisoAsignado,
+    p.IdPermiso,
+    p.Nombre,
+    p.Descripcion
+FROM dbo.Roles r
+LEFT JOIN dbo.RolesPermisos rp ON rp.IdRol = r.IdRol
+LEFT JOIN dbo.Permisos p ON p.IdPermiso = rp.IdPermiso
+ORDER BY r.Nombre, p.Codigo;";
+
+        var roles = new Dictionary<int, RolPermisoDTO>();
+
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
         {
-            _dbContext = dbContext;
+            var idRol = reader.GetInt32(reader.GetOrdinal("IdRol"));
+            if (!roles.TryGetValue(idRol, out var rol))
+            {
+                rol = new RolPermisoDTO
+                {
+                    IdRol = idRol,
+                    NombreRol = reader["NombreRol"]?.ToString() ?? string.Empty,
+                    DescripcionRol = reader["DescripcionRol"] == DBNull.Value ? null : reader["DescripcionRol"]?.ToString(),
+                    Activo = reader.GetBoolean(reader.GetOrdinal("Activo"))
+                };
+
+                roles[idRol] = rol;
+            }
+
+            if (reader["CodigoPermisoAsignado"] != DBNull.Value)
+            {
+                var codigo = reader["CodigoPermisoAsignado"]?.ToString();
+                if (!string.IsNullOrWhiteSpace(codigo))
+                {
+                    rol.CodigosPermisoAsignados.Add(codigo);
+                }
+            }
+
+            if (reader["IdPermiso"] != DBNull.Value)
+            {
+                rol.PermisosDisponibles.Add(new PermisoDTO
+                {
+                    IdPermiso = reader.GetInt32(reader.GetOrdinal("IdPermiso")),
+                    Codigo = reader["CodigoPermisoAsignado"]?.ToString() ?? string.Empty,
+                    Nombre = reader["Nombre"]?.ToString() ?? string.Empty,
+                    Descripcion = reader["Descripcion"] == DBNull.Value ? null : reader["Descripcion"]?.ToString()
+                });
+            }
         }
 
-        public async Task<List<RolPermisoDTO>> ObtenerRolesConPermisosAsync()
+        foreach (var rol in roles.Values)
         {
-            using var conn = _dbContext.CrearConexion();
-            using var cmd = conn.CreateCommand();
-            cmd.CommandType = CommandType.StoredProcedure;
-            cmd.CommandText = "SP_OBTENER_ROLES_CON_PERMISOS";
+            rol.CodigosPermisoAsignados = rol.CodigosPermisoAsignados
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(x => x)
+                .ToList();
 
-            await conn.OpenAsync();
-            using var reader = await cmd.ExecuteReaderAsync();
-
-            var roles = new Dictionary<int, RolPermisoDTO>();
-            var permisosDisponibles = new List<PermisoDTO>();
-
-            while (await reader.ReadAsync())
-            {
-                if (permisosDisponibles.Count == 0 && !reader.IsDBNull(reader.GetOrdinal("IdPermisoDisponible")))
-                {
-                    permisosDisponibles.Add(new PermisoDTO
-                    {
-                        IdPermiso = reader.GetInt32(reader.GetOrdinal("IdPermisoDisponible")),
-                        NombrePermiso = reader.GetString(reader.GetOrdinal("NombrePermisoDisponible")),
-                        Descripcion = reader.IsDBNull(reader.GetOrdinal("DescripcionPermisoDisponible")) ? null : reader.GetString(reader.GetOrdinal("DescripcionPermisoDisponible")),
-                        Modulo = reader.IsDBNull(reader.GetOrdinal("ModuloPermisoDisponible")) ? null : reader.GetString(reader.GetOrdinal("ModuloPermisoDisponible"))
-                    });
-                }
-
-                var idRol = reader.GetInt32(reader.GetOrdinal("IdRol"));
-                if (!roles.TryGetValue(idRol, out var rol))
-                {
-                    rol = new RolPermisoDTO
-                    {
-                        IdRol = idRol,
-                        NombreRol = reader.GetString(reader.GetOrdinal("NombreRol")),
-                        Descripcion = reader.IsDBNull(reader.GetOrdinal("DescripcionRol")) ? null : reader.GetString(reader.GetOrdinal("DescripcionRol")),
-                        PermisosAsignados = new List<PermisoDTO>(),
-                        PermisosDisponibles = new List<PermisoDTO>()
-                    };
-                    roles[idRol] = rol;
-                }
-
-                if (!reader.IsDBNull(reader.GetOrdinal("IdPermisoAsignado")))
-                {
-                    rol.PermisosAsignados.Add(new PermisoDTO
-                    {
-                        IdPermiso = reader.GetInt32(reader.GetOrdinal("IdPermisoAsignado")),
-                        NombrePermiso = reader.GetString(reader.GetOrdinal("NombrePermisoAsignado")),
-                        Descripcion = reader.IsDBNull(reader.GetOrdinal("DescripcionPermisoAsignado")) ? null : reader.GetString(reader.GetOrdinal("DescripcionPermisoAsignado")),
-                        Modulo = reader.IsDBNull(reader.GetOrdinal("ModuloPermisoAsignado")) ? null : reader.GetString(reader.GetOrdinal("ModuloPermisoAsignado"))
-                    });
-                }
-            }
-
-            foreach (var rol in roles.Values)
-            {
-                rol.PermisosDisponibles = permisosDisponibles
-                    .GroupBy(p => p.IdPermiso)
-                    .Select(g => g.First())
-                    .OrderBy(p => p.Modulo)
-                    .ThenBy(p => p.NombrePermiso)
-                    .ToList();
-
-                rol.PermisosAsignados = rol.PermisosAsignados
-                    .GroupBy(p => p.IdPermiso)
-                    .Select(g => g.First())
-                    .OrderBy(p => p.Modulo)
-                    .ThenBy(p => p.NombrePermiso)
-                    .ToList();
-            }
-
-            return roles.Values.OrderBy(r => r.NombreRol).ToList();
+            rol.PermisosDisponibles = rol.PermisosDisponibles
+                .GroupBy(x => x.IdPermiso)
+                .Select(g => g.First())
+                .OrderBy(x => x.Codigo)
+                .ToList();
         }
 
-        public async Task GuardarPermisosRolAsync(GuardarPermisosRolDTO dto)
+        return roles.Values.OrderBy(x => x.NombreRol).ToList();
+    }
+
+    public async Task GuardarPermisosRolAsync(GuardarPermisosRolDTO dto)
+    {
+        if (dto.IdRol <= 0)
         {
-            using var conn = _dbContext.CrearConexion();
-            await conn.OpenAsync();
-
-            using var tx = conn.BeginTransaction();
-            try
-            {
-                var cmdDelete = conn.CreateCommand();
-                cmdDelete.Transaction = tx;
-                cmdDelete.CommandType = CommandType.StoredProcedure;
-                cmdDelete.CommandText = "SP_ELIMINAR_PERMISOS_DE_ROL";
-                cmdDelete.Parameters.AddWithValue("@IdRol", dto.IdRol);
-                await cmdDelete.ExecuteNonQueryAsync();
-
-                if (dto.IdsPermisos != null)
-                {
-                    foreach (var idPermiso in dto.IdsPermisos.Distinct())
-                    {
-                        var cmdInsert = conn.CreateCommand();
-                        cmdInsert.Transaction = tx;
-                        cmdInsert.CommandType = CommandType.StoredProcedure;
-                        cmdInsert.CommandText = "SP_ASIGNAR_PERMISO_A_ROL";
-                        cmdInsert.Parameters.AddWithValue("@IdRol", dto.IdRol);
-                        cmdInsert.Parameters.AddWithValue("@IdPermiso", idPermiso);
-                        await cmdInsert.ExecuteNonQueryAsync();
-                    }
-                }
-
-                tx.Commit();
-            }
-            catch
-            {
-                tx.Rollback();
-                throw;
-            }
+            throw new ArgumentException("Debe indicar un rol válido.", nameof(dto.IdRol));
         }
+
+        const string sqlDelete = "DELETE FROM dbo.RolesPermisos WHERE IdRol = @IdRol;";
+        const string sqlInsert = @"
+INSERT INTO dbo.RolesPermisos (IdRol, IdPermiso)
+SELECT @IdRol, p.IdPermiso
+FROM dbo.Permisos p
+WHERE p.Codigo = @CodigoPermiso;";
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var tx = connection.BeginTransaction();
+
+        try
+        {
+            using (var deleteCommand = new SqlCommand(sqlDelete, connection, tx))
+            {
+                deleteCommand.Parameters.AddWithValue("@IdRol", dto.IdRol);
+                await deleteCommand.ExecuteNonQueryAsync();
+            }
+
+            foreach (var codigoPermiso in dto.CodigosPermiso.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                using var insertCommand = new SqlCommand(sqlInsert, connection, tx);
+                insertCommand.Parameters.AddWithValue("@IdRol", dto.IdRol);
+                insertCommand.Parameters.AddWithValue("@CodigoPermiso", codigoPermiso);
+                await insertCommand.ExecuteNonQueryAsync();
+            }
+
+            await tx.CommitAsync();
+        }
+        catch
+        {
+            await tx.RollbackAsync();
+            throw;
+        }
+    }
+
+    public async Task<List<PSA.EntidadesDTO.DTOs.Usuarios.RolDTO>> ObtenerRolesAsync()
+    {
+        const string sql = @"
+SELECT IdRol, Nombre, Descripcion
+FROM dbo.Roles
+WHERE Estado = 'Activo'
+ORDER BY Nombre;";
+
+        var roles = new List<PSA.EntidadesDTO.DTOs.Usuarios.RolDTO>();
+
+        using var connection = _connectionFactory.CreateConnection();
+        using var command = new SqlCommand(sql, connection);
+
+        await connection.OpenAsync();
+        using var reader = await command.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            roles.Add(new PSA.EntidadesDTO.DTOs.Usuarios.RolDTO
+            {
+                Id = reader.GetInt32(reader.GetOrdinal("IdRol")),
+                Nombre = reader["Nombre"]?.ToString() ?? string.Empty,
+                Descripcion = reader["Descripcion"] == DBNull.Value ? null : reader["Descripcion"]?.ToString()
+            });
+        }
+
+        return roles;
     }
 }

--- a/PSA.DataAccess/DAO/UsuarioDAO.cs
+++ b/PSA.DataAccess/DAO/UsuarioDAO.cs
@@ -1,5 +1,7 @@
 using Microsoft.Data.SqlClient;
+using System.Text;
 using PSA.EntidadesDTO.Entidades;
+using PSA.EntidadesDTO.DTOs.Administracion;
 using PSA.EntidadesDTO.DTOs.Usuarios;
 
 using PSA.DataAccess;
@@ -213,6 +215,159 @@ namespace PSA.DataAccess.DAO
             {
                 throw new InvalidOperationException("No se pudo asignar el rol al usuario indicado.");
             }
+        }
+
+        public async Task<List<UsuarioAdminListadoDTO>> ObtenerUsuariosAdminAsync(int? idRol = null)
+        {
+            var sql = new StringBuilder(@"
+SELECT
+    u.IdUsuario,
+    u.NombreCompleto,
+    u.Email,
+    u.IdRol,
+    r.Nombre AS NombreRol,
+    u.Estado,
+    u.FechaCreacion,
+    u.UltimoAcceso,
+    (SELECT COUNT(1) FROM dbo.Fincas f WHERE f.IdPropietario = u.IdUsuario) AS CantidadFincas,
+    (SELECT COUNT(1)
+     FROM dbo.EvaluacionesTecnicas e
+     INNER JOIN dbo.Fincas f ON f.IdFinca = e.IdFinca
+     WHERE f.IdPropietario = u.IdUsuario
+       AND e.EstadoEvaluacion IN ('Pendiente', 'En Proceso')) AS CantidadEvaluacionesActivas
+FROM dbo.Usuarios u
+INNER JOIN dbo.Roles r ON r.IdRol = u.IdRol");
+
+            if (idRol.HasValue)
+            {
+                sql.Append(" WHERE u.IdRol = @IdRol");
+            }
+
+            sql.Append(" ORDER BY u.Estado, u.NombreCompleto;");
+
+            var resultado = new List<UsuarioAdminListadoDTO>();
+
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(sql.ToString(), connection);
+            if (idRol.HasValue)
+            {
+                command.Parameters.AddWithValue("@IdRol", idRol.Value);
+            }
+
+            await connection.OpenAsync();
+            using var reader = await command.ExecuteReaderAsync();
+
+            while (await reader.ReadAsync())
+            {
+                resultado.Add(new UsuarioAdminListadoDTO
+                {
+                    IdUsuario = reader.GetInt32(reader.GetOrdinal("IdUsuario")),
+                    NombreCompleto = reader["NombreCompleto"]?.ToString() ?? string.Empty,
+                    Email = reader["Email"]?.ToString() ?? string.Empty,
+                    IdRol = reader.GetInt32(reader.GetOrdinal("IdRol")),
+                    NombreRol = reader["NombreRol"]?.ToString() ?? string.Empty,
+                    Estado = reader["Estado"]?.ToString() ?? string.Empty,
+                    FechaCreacion = reader.GetDateTime(reader.GetOrdinal("FechaCreacion")),
+                    UltimoAcceso = reader["UltimoAcceso"] == DBNull.Value ? null : reader.GetDateTime(reader.GetOrdinal("UltimoAcceso")),
+                    CantidadFincas = reader.GetInt32(reader.GetOrdinal("CantidadFincas")),
+                    CantidadEvaluacionesActivas = reader.GetInt32(reader.GetOrdinal("CantidadEvaluacionesActivas"))
+                });
+            }
+
+            return resultado;
+        }
+
+        public async Task<UsuarioAdminEdicionDTO?> ObtenerUsuarioAdminPorIdAsync(int idUsuario)
+        {
+            const string sql = @"
+SELECT
+    IdUsuario,
+    NombreCompleto,
+    Email,
+    IdRol,
+    Estado
+FROM dbo.Usuarios
+WHERE IdUsuario = @IdUsuario;";
+
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+
+            await connection.OpenAsync();
+            using var reader = await command.ExecuteReaderAsync();
+
+            if (!await reader.ReadAsync())
+            {
+                return null;
+            }
+
+            return new UsuarioAdminEdicionDTO
+            {
+                IdUsuario = reader.GetInt32(reader.GetOrdinal("IdUsuario")),
+                NombreCompleto = reader["NombreCompleto"]?.ToString() ?? string.Empty,
+                Email = reader["Email"]?.ToString() ?? string.Empty,
+                IdRol = reader.GetInt32(reader.GetOrdinal("IdRol")),
+                Estado = reader["Estado"]?.ToString() ?? "Activo"
+            };
+        }
+
+        public async Task<int> ActualizarUsuarioAdminAsync(UsuarioAdminEdicionDTO dto, string? nuevoPasswordHash = null)
+        {
+            const string sql = @"
+UPDATE dbo.Usuarios
+SET
+    NombreCompleto = @NombreCompleto,
+    Email = @Email,
+    IdRol = @IdRol,
+    Estado = @Estado,
+    PasswordHash = COALESCE(@PasswordHash, PasswordHash)
+WHERE IdUsuario = @IdUsuario;";
+
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(sql, connection);
+
+            command.Parameters.AddWithValue("@IdUsuario", dto.IdUsuario);
+            command.Parameters.AddWithValue("@NombreCompleto", dto.NombreCompleto.Trim());
+            command.Parameters.AddWithValue("@Email", dto.Email.Trim());
+            command.Parameters.AddWithValue("@IdRol", dto.IdRol);
+            command.Parameters.AddWithValue("@Estado", dto.Estado.Trim());
+            command.Parameters.AddWithValue("@PasswordHash", (object?)nuevoPasswordHash ?? DBNull.Value);
+
+            await connection.OpenAsync();
+            return await command.ExecuteNonQueryAsync();
+        }
+
+        public async Task<int> EliminarUsuarioAdminAsync(int idUsuario)
+        {
+            const string sql = @"
+UPDATE dbo.Usuarios
+SET Estado = 'Inactivo'
+WHERE IdUsuario = @IdUsuario;";
+
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+
+            await connection.OpenAsync();
+            return await command.ExecuteNonQueryAsync();
+        }
+
+        public async Task<int> ReasignarClientesAIngenieroAsync(int idPropietario, int idIngenieroDestino)
+        {
+            const string sql = @"
+UPDATE e
+SET e.IdIngeniero = @IdIngenieroDestino
+FROM dbo.EvaluacionesTecnicas e
+INNER JOIN dbo.Fincas f ON f.IdFinca = e.IdFinca
+WHERE f.IdPropietario = @IdPropietario;";
+
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+            command.Parameters.AddWithValue("@IdIngenieroDestino", idIngenieroDestino);
+
+            await connection.OpenAsync();
+            return await command.ExecuteNonQueryAsync();
         }
     }
 }

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -18,6 +18,9 @@
 		<Compile Include="DAO\FincaDAO.cs" />
 		<Compile Include="DAO\DashboardDAO.cs" />
 		<Compile Include="DAO\AuditoriaLogDAO.cs" />
+		<Compile Include="DAO\RolPermisoDAO.cs" />
+		<Compile Include="DAO\ConfiguracionPagoDAO.cs" />
+		<Compile Include="DAO\CuentaBancariaDAO.cs" />
 		<Compile Include="DAO\EvaluacionTecnicaDAO.cs" />
 		<Compile Include="DAO\RecuperacionContrasenaDAO.cs" />
 		<Compile Include="DAO\ReportesDAO.cs" />

--- a/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
+++ b/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
@@ -14,6 +14,7 @@
     <Compile Include="Base\IAuditable.cs" />
     <Compile Include="Base\IBaseEntity.cs" />
     <Compile Include="DTOs\Auditoria\AuditoriaLogDTO.cs" />
+    <Compile Include="DTOs\Administracion\AdministracionDTOs.cs" />
     <Compile Include="DTOs\Dashboard\ResumenDashboardAdministradorDTO.cs" />
     <Compile Include="DTOs\Evaluaciones\EvaluacionEvidenciaDTO.cs" />
     <Compile Include="DTOs\Evaluaciones\EvaluacionFlujoDTOs.cs" />

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -18,6 +18,7 @@
     <Compile Include="Controllers\FincasController.cs" />
     <Compile Include="Controllers\HealthController.cs" />
     <Compile Include="Controllers\LandingController.cs" />
+    <Compile Include="Controllers\AdministracionController.cs" />
     <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Controllers\PerfilController.cs" />
     <Compile Include="Controllers\Middleware\ExceptionMiddleware.cs" />

--- a/PSA.WebApp/Controllers/AdministracionController.cs
+++ b/PSA.WebApp/Controllers/AdministracionController.cs
@@ -1,10 +1,13 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using PSA.EntidadesDTO.DTOs.Administracion;
+using PSA.EntidadesDTO.DTOs.Usuarios;
 using PSA.WebApp.Models;
 using PSA.WebApp.Services;
 
 namespace PSA.WebApp.Controllers
 {
+    [Authorize(Roles = "1")]
     public class AdministracionController : Controller
     {
         private readonly HttpClientService _httpClientService;

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -80,7 +80,7 @@ namespace PSA.WebApp.Controllers
 
                 if (idFinca > 0 && idUsuario > 0)
                 {
-                    var evidenciaSubida = await SubirEvidenciasAsync(client, idFinca, idUsuario, model.Evidencias);
+                    var evidenciaSubida = await SubirEvidenciasAsync(client, idFinca, idUsuario, model.Evidencias ?? new List<IFormFile>());
                     if (!evidenciaSubida)
                     {
                         TempData["MensajeError"] = "La evaluación se guardó, pero no fue posible cargar la evidencia adjunta.";

--- a/PSA.WebApp/Models/AdministracionViewModels.cs
+++ b/PSA.WebApp/Models/AdministracionViewModels.cs
@@ -12,6 +12,7 @@ namespace PSA.WebApp.Models
     {
         public UsuarioAdminEdicionDTO Usuario { get; set; } = new();
         public List<RolDTO> Roles { get; set; } = new();
+        public bool EsEdicion => Usuario?.IdUsuario > 0;
         public string TituloFormulario { get; set; } = string.Empty;
         public string TextoAccion { get; set; } = string.Empty;
     }
@@ -26,6 +27,7 @@ namespace PSA.WebApp.Models
     public class RolesPermisosViewModel
     {
         public List<RolPermisoDTO> Roles { get; set; } = new();
+        public List<PermisoDTO> PermisosDisponibles { get; set; } = new();
     }
 
     public class ParametrosPagoViewModel

--- a/PSA.WebApp/PSA.WebApp.csproj
+++ b/PSA.WebApp/PSA.WebApp.csproj
@@ -21,11 +21,13 @@
     <Compile Include="Controllers\PagosController.cs" />
     <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Models\DashboardViewModels.cs" />
+    <Compile Include="Models\AdministracionViewModels.cs" />
     <Compile Include="Models\MiPerfilViewModel.cs" />
     <Compile Include="Models\EvaluacionesViewModels.cs" />
     <Compile Include="Models\ReportesViewModels.cs" />
     <Compile Include="Models\RecuperarContrasenaViewModel.cs" />
     <Compile Include="Models\RestablecerContrasenaViewModel.cs" />
+    <Compile Include="Services\HttpClientService.cs" />
     <Compile Include="Program.cs" />
     <ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
   </ItemGroup>

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
+using PSA.WebApp.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -32,6 +33,8 @@ if (builder.Environment.IsDevelopment())
         ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
     });
 }
+
+builder.Services.AddScoped<HttpClientService>();
 
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie(options =>

--- a/PSA.WebApp/Services/HttpClientService.cs
+++ b/PSA.WebApp/Services/HttpClientService.cs
@@ -1,0 +1,96 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace PSA.WebApp.Services;
+
+public class HttpClientService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public HttpClientService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<T?> GetAsync<T>(string endpoint)
+    {
+        var client = _httpClientFactory.CreateClient("AuthApi");
+        var response = await client.GetAsync(endpoint);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return default;
+        }
+
+        return await response.Content.ReadFromJsonAsync<T>(JsonOptions);
+    }
+
+    public async Task<TResponse?> PostAsync<TRequest, TResponse>(string endpoint, TRequest data)
+    {
+        var client = _httpClientFactory.CreateClient("AuthApi");
+        var response = await client.PostAsJsonAsync(endpoint, data, JsonOptions);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return default;
+        }
+
+        if (typeof(TResponse) == typeof(bool))
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (bool.TryParse(body, out var parsed))
+            {
+                return (TResponse)(object)parsed;
+            }
+        }
+
+        return await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions);
+    }
+
+    public async Task<TResponse?> PutAsync<TRequest, TResponse>(string endpoint, TRequest data)
+    {
+        var client = _httpClientFactory.CreateClient("AuthApi");
+        var content = new StringContent(JsonSerializer.Serialize(data, JsonOptions), Encoding.UTF8, "application/json");
+        var response = await client.PutAsync(endpoint, content);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return default;
+        }
+
+        if (typeof(TResponse) == typeof(bool))
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (bool.TryParse(body, out var parsed))
+            {
+                return (TResponse)(object)parsed;
+            }
+        }
+
+        return await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions);
+    }
+
+    public async Task<TResponse?> DeleteAsync<TResponse>(string endpoint)
+    {
+        var client = _httpClientFactory.CreateClient("AuthApi");
+        var response = await client.DeleteAsync(endpoint);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return default;
+        }
+
+        if (typeof(TResponse) == typeof(bool))
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (bool.TryParse(body, out var parsed))
+            {
+                return (TResponse)(object)parsed;
+            }
+        }
+
+        return await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions);
+    }
+}

--- a/PSA.WebApp/Views/Administracion/AuditoriaLogs.cshtml
+++ b/PSA.WebApp/Views/Administracion/AuditoriaLogs.cshtml
@@ -1,24 +1,78 @@
+@model PSA.WebApp.Models.AuditoriaLogsViewModel
 @{
-    ViewData["Title"] = "Auditoría y logs";
+    ViewData["Title"] = "Auditoría";
 }
 <section class="seccion-pagina">
     <div class="cabecera-pagina">
         <div>
-            <span class="eyebrow">Trazabilidad</span>
-            <h2>Auditoría y logs</h2>
-            <p>Base visual para consultar eventos y acciones críticas.</p>
+            <span class="eyebrow">Administración</span>
+            <h2>Auditoría del sistema</h2>
+            <p>Monitoree accesos y cambios críticos del sistema por módulo y fecha.</p>
         </div>
-        <a class="boton-secundario" asp-controller="Reportes" asp-action="Index">Ver reportes</a>
     </div>
 
+    <section class="tarjeta-panel mb-3">
+        <form method="get" asp-action="AuditoriaLogs" class="row g-3 align-items-end">
+            <div class="col-md-3">
+                <label asp-for="Filtro.Modulo" class="form-label">Módulo</label>
+                <input asp-for="Filtro.Modulo" name="modulo" class="form-control" />
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Filtro.Accion" class="form-label">Acción</label>
+                <input asp-for="Filtro.Accion" name="accion" class="form-control" />
+            </div>
+            <div class="col-md-2">
+                <label asp-for="Filtro.FechaDesde" class="form-label">Desde</label>
+                <input asp-for="Filtro.FechaDesde" name="fechaDesde" type="date" class="form-control" />
+            </div>
+            <div class="col-md-2">
+                <label asp-for="Filtro.FechaHasta" class="form-label">Hasta</label>
+                <input asp-for="Filtro.FechaHasta" name="fechaHasta" type="date" class="form-control" />
+            </div>
+            <div class="col-md-2">
+                <label asp-for="Filtro.MaximoRegistros" class="form-label">Máx. registros</label>
+                <input asp-for="Filtro.MaximoRegistros" name="maximoRegistros" class="form-control" min="1" max="500" />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="boton-primario">Filtrar auditoría</button>
+            </div>
+        </form>
+    </section>
+
     <section class="tarjeta-panel">
-        <ul class="lista-timeline">
-            <li><a asp-controller="Administracion" asp-action="ParametrosPago">26/03/2026 08:20 - Usuario Dennis Cruz modificó parámetros de pago.</a></li>
-            <li><a asp-controller="Administracion" asp-action="ValidacionCuentasBancarias">26/03/2026 09:05 - Cuenta bancaria de Laura Mora enviada a validación.</a></li>
-            <li><a asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">26/03/2026 10:12 - Evaluación técnica de Río Verde marcada como finalizada.</a></li>
-        </ul>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Fecha</th>
+                        <th>Módulo</th>
+                        <th>Acción</th>
+                        <th>Usuario</th>
+                        <th>Detalle</th>
+                        <th>IP</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if (Model.Eventos.Count == 0)
+                    {
+                        <tr><td colspan="6" class="text-center text-muted">No hay eventos con el filtro actual.</td></tr>
+                    }
+                    else
+                    {
+                        @foreach (var evento in Model.Eventos)
+                        {
+                            <tr>
+                                <td>@evento.FechaAccion.ToString("yyyy-MM-dd HH:mm")</td>
+                                <td>@evento.Modulo</td>
+                                <td>@evento.Accion</td>
+                                <td>@(evento.NombreUsuario ?? "Sistema")</td>
+                                <td>@evento.Detalle</td>
+                                <td>@evento.IpOrigen</td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
     </section>
 </section>
-@section Scripts{
-    <script src="~/js/auditoria.js" asp-append-version="true"></script>
-}

--- a/PSA.WebApp/Views/Administracion/FormularioUsuario.cshtml
+++ b/PSA.WebApp/Views/Administracion/FormularioUsuario.cshtml
@@ -35,7 +35,7 @@
                     </div>
                     <div class="col-md-4">
                         <label asp-for="Usuario.IdRol" class="form-label">Rol</label>
-                        <select asp-for="Usuario.IdRol" class="form-select" asp-items="@(new SelectList(Model.Roles, "IdRol", "Nombre"))">
+                        <select asp-for="Usuario.IdRol" class="form-select" asp-items="@(new SelectList(Model.Roles, "Id", "Nombre"))">
                             <option value="">Seleccione...</option>
                         </select>
                         <span asp-validation-for="Usuario.IdRol" class="text-danger"></span>

--- a/PSA.WebApp/Views/Administracion/GestionUsuarios.cshtml
+++ b/PSA.WebApp/Views/Administracion/GestionUsuarios.cshtml
@@ -1,3 +1,4 @@
+@model PSA.WebApp.Models.GestionUsuariosViewModel
 @{
     ViewData["Title"] = "Gestión de usuarios";
 }
@@ -6,9 +7,12 @@
         <div>
             <span class="eyebrow">Administración</span>
             <h2>Gestión de usuarios</h2>
-            <p>Base para administración de usuarios, roles y estados.</p>
+            <p>Gestione usuarios, roles y estados desde dentro de la aplicación.</p>
         </div>
-        <a class="boton-primario" asp-controller="Autenticacion" asp-action="RegistroUsuario">Crear usuario</a>
+        <div class="d-flex gap-2">
+            <a class="boton-secundario" asp-controller="Administracion" asp-action="ReasignarCliente">Reasignar cliente</a>
+            <a class="boton-primario" asp-controller="Administracion" asp-action="CrearUsuario">Crear usuario</a>
+        </div>
     </div>
 
     <section class="tarjeta-panel">
@@ -20,24 +24,42 @@
                         <th>Correo</th>
                         <th>Rol</th>
                         <th>Estado</th>
-                        <th>Acción</th>
+                        <th>Último acceso</th>
+                        <th>Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td>Dennis Cruz</td>
-                        <td>dennis@psa.cr</td>
-                        <td>Administrador</td>
-                        <td><span class="badge-estado badge-exito">Activo</span></td>
-                        <td><a class="boton-link" asp-controller="Administracion" asp-action="ParametrosPago">Ver permisos</a></td>
-                    </tr>
-                    <tr>
-                        <td>Laura Mora</td>
-                        <td>laura@psa.cr</td>
-                        <td>Dueño</td>
-                        <td><span class="badge-estado badge-pendiente">Pendiente</span></td>
-                        <td><a class="boton-link" asp-controller="Administracion" asp-action="ValidacionCuentasBancarias">Validar cuenta</a></td>
-                    </tr>
+                    @if (Model.Usuarios.Count == 0)
+                    {
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">No hay usuarios disponibles.</td>
+                        </tr>
+                    }
+                    else
+                    {
+                        @foreach (var usuario in Model.Usuarios)
+                        {
+                            var activo = string.Equals(usuario.Estado, "Activo", System.StringComparison.OrdinalIgnoreCase);
+                            <tr>
+                                <td>@usuario.NombreCompleto</td>
+                                <td>@usuario.Email</td>
+                                <td>@usuario.NombreRol</td>
+                                <td>
+                                    <span class="badge-estado @(activo ? "badge-exito" : "badge-pendiente")">@usuario.Estado</span>
+                                </td>
+                                <td>@(usuario.UltimoAcceso?.ToString("yyyy-MM-dd HH:mm") ?? "Sin registro")</td>
+                                <td>
+                                    <div class="d-flex flex-wrap gap-2">
+                                        <a class="boton-link" asp-action="EditarUsuario" asp-route-id="@usuario.IdUsuario">Editar</a>
+                                        <form asp-action="EliminarUsuario" asp-route-id="@usuario.IdUsuario" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit" class="boton-link border-0 bg-transparent p-0">@(activo ? "Inactivar" : "Activar / Inactivar")</button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    }
                 </tbody>
             </table>
         </div>

--- a/PSA.WebApp/Views/Administracion/ParametrosPago.cshtml
+++ b/PSA.WebApp/Views/Administracion/ParametrosPago.cshtml
@@ -1,34 +1,140 @@
+@model PSA.WebApp.Models.ParametrosPagoViewModel
 @{
-    ViewData["Title"] = "Parámetros de pago";
+    ViewData["Title"] = "Configuración de pagos";
 }
 <section class="seccion-pagina">
     <div class="cabecera-pagina">
         <div>
-            <span class="eyebrow">Configuración versionada</span>
-            <h2>Parámetros de pago</h2>
-            <p>Base para precio por hectárea, porcentajes y topes de ajuste.</p>
+            <span class="eyebrow">Administración</span>
+            <h2>Configuración de pagos</h2>
+            <p>Ajuste precio base por hectárea, porcentajes, topes y vigencias.</p>
         </div>
-        <a class="boton-secundario" asp-controller="Pagos" asp-action="PlanesPago">Ir a planes de pago</a>
     </div>
 
-    <form class="formulario-base formulario-modulo" id="formularioParametrosPago" method="get" asp-controller="Administracion" asp-action="AuditoriaLogs">
-        <div class="grid-tres-columnas">
-            <div class="campo-formulario">
-                <label for="precioBase">Precio base por hectárea</label>
-                <input id="precioBase" type="number" step="0.01" value="12000" />
+    @if (Model.ConfiguracionActual != null)
+    {
+        <section class="tarjeta-panel mb-3">
+            <h5>Configuración vigente</h5>
+            <div class="row g-3 mt-1">
+                <div class="col-md-3"><strong>Versión:</strong> @Model.ConfiguracionActual.NombreVersion</div>
+                <div class="col-md-3"><strong>Precio base:</strong> @Model.ConfiguracionActual.PrecioBasePorHectarea.ToString("N2")</div>
+                <div class="col-md-3"><strong>Tope ajuste %:</strong> @Model.ConfiguracionActual.TopePorcentajeAjuste.ToString("N2")</div>
+                <div class="col-md-3"><strong>Desde:</strong> @Model.ConfiguracionActual.FechaVigenciaDesde.ToString("yyyy-MM-dd")</div>
             </div>
-            <div class="campo-formulario">
-                <label for="ajustePorcentaje">Ajuste porcentual</label>
-                <input id="ajustePorcentaje" type="number" step="0.01" value="5" />
-            </div>
-            <div class="campo-formulario">
-                <label for="topeAjuste">Tope de ajuste</label>
-                <input id="topeAjuste" type="number" step="0.01" value="15" />
-            </div>
-        </div>
+        </section>
+    }
 
-        <div class="fila-acciones-formulario">
-            <button type="submit" class="boton-primario">Guardar parámetros</button>
+    <section class="tarjeta-panel">
+        <h5>Nueva configuración</h5>
+        <form asp-action="GuardarConfiguracionPago" method="post" class="mt-3">
+            @Html.AntiForgeryToken()
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger"></div>
+
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label asp-for="NuevaConfiguracion.NombreVersion" class="form-label"></label>
+                    <input asp-for="NuevaConfiguracion.NombreVersion" class="form-control" />
+                    <span asp-validation-for="NuevaConfiguracion.NombreVersion" class="text-danger"></span>
+                </div>
+                <div class="col-md-4">
+                    <label asp-for="NuevaConfiguracion.PrecioBasePorHectarea" class="form-label"></label>
+                    <input asp-for="NuevaConfiguracion.PrecioBasePorHectarea" class="form-control" />
+                    <span asp-validation-for="NuevaConfiguracion.PrecioBasePorHectarea" class="text-danger"></span>
+                </div>
+                <div class="col-md-4">
+                    <label asp-for="NuevaConfiguracion.TopePorcentajeAjuste" class="form-label"></label>
+                    <input asp-for="NuevaConfiguracion.TopePorcentajeAjuste" class="form-control" />
+                    <span asp-validation-for="NuevaConfiguracion.TopePorcentajeAjuste" class="text-danger"></span>
+                </div>
+                <div class="col-md-4">
+                    <label asp-for="NuevaConfiguracion.FechaVigenciaDesde" class="form-label"></label>
+                    <input asp-for="NuevaConfiguracion.FechaVigenciaDesde" type="date" class="form-control" />
+                    <span asp-validation-for="NuevaConfiguracion.FechaVigenciaDesde" class="text-danger"></span>
+                </div>
+                <div class="col-md-4">
+                    <label asp-for="NuevaConfiguracion.FechaVigenciaHasta" class="form-label"></label>
+                    <input asp-for="NuevaConfiguracion.FechaVigenciaHasta" type="date" class="form-control" />
+                </div>
+                <div class="col-md-4 d-flex align-items-end">
+                    <div class="form-check">
+                        <input asp-for="NuevaConfiguracion.Activa" class="form-check-input" />
+                        <label asp-for="NuevaConfiguracion.Activa" class="form-check-label">Marcar como activa</label>
+                    </div>
+                </div>
+            </div>
+
+            <h6 class="mt-4">Porcentajes de ajuste por parámetro</h6>
+            <div class="tabla-responsive">
+                <table class="tabla-base">
+                    <thead>
+                        <tr>
+                            <th>Tipo factor</th>
+                            <th>Valor factor</th>
+                            <th>% ajuste</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for (var i = 0; i < Model.NuevaConfiguracion.Ajustes.Count; i++)
+                        {
+                            <tr>
+                                <td>
+                                    <input asp-for="NuevaConfiguracion.Ajustes[i].TipoFactor" class="form-control" readonly />
+                                </td>
+                                <td>
+                                    <input asp-for="NuevaConfiguracion.Ajustes[i].ValorFactor" class="form-control" readonly />
+                                </td>
+                                <td>
+                                    <input asp-for="NuevaConfiguracion.Ajustes[i].PorcentajeAjuste" class="form-control" />
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="fila-acciones-formulario mt-3">
+                <button type="submit" class="boton-primario">Guardar configuración</button>
+            </div>
+        </form>
+    </section>
+
+    <section class="tarjeta-panel mt-3">
+        <h5>Historial de configuraciones</h5>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Versión</th>
+                        <th>Precio base</th>
+                        <th>Tope %</th>
+                        <th>Vigencia desde</th>
+                        <th>Estado</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if (Model.Historial.Count == 0)
+                    {
+                        <tr><td colspan="5" class="text-center text-muted">Sin configuraciones registradas.</td></tr>
+                    }
+                    else
+                    {
+                        @foreach (var item in Model.Historial)
+                        {
+                            <tr>
+                                <td>@item.NombreVersion</td>
+                                <td>@item.PrecioBasePorHectarea.ToString("N2")</td>
+                                <td>@item.TopePorcentajeAjuste.ToString("N2")</td>
+                                <td>@item.FechaVigenciaDesde.ToString("yyyy-MM-dd")</td>
+                                <td>@(item.Activa ? "Activa" : "Inactiva")</td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
         </div>
-    </form>
+    </section>
 </section>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/PSA.WebApp/Views/Administracion/ReasignarCliente.cshtml
+++ b/PSA.WebApp/Views/Administracion/ReasignarCliente.cshtml
@@ -1,5 +1,5 @@
 @model PSA.EntidadesDTO.DTOs.Administracion.ReasignacionClienteDTO
-@using PSA.EntidadesDTO.DTOs.Usuarios
+@using PSA.EntidadesDTO.DTOs.Administracion
 @{
     ViewData["Title"] = "Reasignar cliente";
     var propietarios = ViewBag.Propietarios as List<UsuarioAdminListadoDTO> ?? new();

--- a/PSA.WebApp/Views/Administracion/RolesPermisos.cshtml
+++ b/PSA.WebApp/Views/Administracion/RolesPermisos.cshtml
@@ -30,10 +30,11 @@
                         @foreach (var permiso in Model.PermisosDisponibles)
                         {
                             var checkedPermiso = rol.CodigosPermisoAsignados.Contains(permiso.Codigo);
+                            var controlId = $"permiso_{rol.IdRol}_{permiso.IdPermiso}";
                             <div class="col">
                                 <div class="form-check border rounded p-3 h-100">
-                                    <input class="form-check-input" type="checkbox" name="CodigosPermiso" value="@permiso.Codigo" id="permiso_@rol.IdRol_@permiso.IdPermiso" @(checkedPermiso ? "checked" : string.Empty) />
-                                    <label class="form-check-label ms-1" for="permiso_@rol.IdRol_@permiso.IdPermiso">
+                                    <input class="form-check-input" type="checkbox" name="CodigosPermiso" value="@permiso.Codigo" id="@controlId" @(checkedPermiso ? "checked" : string.Empty) />
+                                    <label class="form-check-label ms-1" for="@controlId">
                                         <strong>@permiso.Nombre</strong><br />
                                         <span class="text-muted small">@permiso.Descripcion</span>
                                     </label>

--- a/PSA.WebApp/Views/Administracion/RolesPermisosSimple.cshtml
+++ b/PSA.WebApp/Views/Administracion/RolesPermisosSimple.cshtml
@@ -30,10 +30,11 @@
                         @foreach (var permiso in rol.PermisosDisponibles)
                         {
                             var checkedPermiso = rol.CodigosPermisoAsignados.Contains(permiso.Codigo);
+                            var controlId = $"permiso_{rol.IdRol}_{permiso.IdPermiso}";
                             <div class="col">
                                 <div class="form-check border rounded p-3 h-100">
-                                    <input class="form-check-input" type="checkbox" name="CodigosPermiso" value="@permiso.Codigo" checked="@(checkedPermiso ? "checked" : null)" id="permiso_@rol.IdRol_@permiso.IdPermiso" />
-                                    <label class="form-check-label ms-1" for="permiso_@rol.IdRol_@permiso.IdPermiso">
+                                    <input class="form-check-input" type="checkbox" name="CodigosPermiso" value="@permiso.Codigo" checked="@(checkedPermiso ? "checked" : null)" id="@controlId" />
+                                    <label class="form-check-label ms-1" for="@controlId">
                                         <strong>@permiso.Nombre</strong><br />
                                         <span class="text-muted small">@permiso.Descripcion</span>
                                     </label>

--- a/PSA.WebApp/Views/Administracion/ValidacionCuentasBancarias.cshtml
+++ b/PSA.WebApp/Views/Administracion/ValidacionCuentasBancarias.cshtml
@@ -1,12 +1,13 @@
+@model PSA.WebApp.Models.ValidacionCuentasBancariasViewModel
 @{
     ViewData["Title"] = "Validación bancaria";
 }
 <section class="seccion-pagina">
     <div class="cabecera-pagina">
         <div>
-            <span class="eyebrow">Revisión administrativa</span>
+            <span class="eyebrow">Administración</span>
             <h2>Validación de cuentas bancarias</h2>
-            <p>Base para aprobar o rechazar cuentas asociadas a propietarios.</p>
+            <p>Apruebe o rechace cuentas pendientes de validación.</p>
         </div>
         <a class="boton-secundario" asp-controller="Administracion" asp-action="GestionUsuarios">Volver a usuarios</a>
     </div>
@@ -24,13 +25,40 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td>Laura Mora</td>
-                        <td>Banco Nacional</td>
-                        <td>CR12-3456-7890</td>
-                        <td><span class="badge-estado badge-pendiente">Pendiente</span></td>
-                        <td><a class="boton-link" asp-controller="Administracion" asp-action="AuditoriaLogs">Registrar revisión</a></td>
-                    </tr>
+                    @if (Model.CuentasPendientes.Count == 0)
+                    {
+                        <tr><td colspan="5" class="text-center text-muted">No hay cuentas pendientes de validación.</td></tr>
+                    }
+                    else
+                    {
+                        @foreach (var cuenta in Model.CuentasPendientes)
+                        {
+                            <tr>
+                                <td>@cuenta.NombreUsuario</td>
+                                <td>@cuenta.Banco</td>
+                                <td>@cuenta.NumeroCuenta</td>
+                                <td><span class="badge-estado badge-pendiente">@cuenta.EstadoValidacion</span></td>
+                                <td>
+                                    <div class="d-flex flex-wrap gap-2">
+                                        <form asp-action="ValidarCuentaBancaria" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="IdCuentaBancaria" value="@cuenta.IdCuentaBancaria" />
+                                            <input type="hidden" name="Aprobada" value="true" />
+                                            <input type="hidden" name="IdAdministrador" value="1" />
+                                            <button type="submit" class="boton-link border-0 bg-transparent p-0">Aprobar</button>
+                                        </form>
+                                        <form asp-action="ValidarCuentaBancaria" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="IdCuentaBancaria" value="@cuenta.IdCuentaBancaria" />
+                                            <input type="hidden" name="Aprobada" value="false" />
+                                            <input type="hidden" name="IdAdministrador" value="1" />
+                                            <button type="submit" class="boton-link border-0 bg-transparent p-0 text-danger">Rechazar</button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    }
                 </tbody>
             </table>
         </div>

--- a/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
+++ b/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
@@ -1,6 +1,8 @@
 @using System.Security.Claims
 @{
     var moduloActivo = (ViewBag.ModuloActivo as string ?? string.Empty).ToLowerInvariant();
+    var controllerActual = (ViewContext.RouteData.Values["controller"]?.ToString() ?? string.Empty).ToLowerInvariant();
+    var accionActual = (ViewContext.RouteData.Values["action"]?.ToString() ?? string.Empty).ToLowerInvariant();
     var rolClaim = User.FindFirstValue(ClaimTypes.Role);
     var rolActivo = rolClaim switch
     {
@@ -34,14 +36,14 @@
         }
         else if (rolActivo == "administrador")
         {
-            <a class="item-menu @(moduloActivo == "dashboard" ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Administrador">Inicio</a>
-            <a class="item-menu @(moduloActivo == "administracion" ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="GestionUsuarios">Usuarios</a>
-            <a class="item-menu item-menu--proximamente" href="#" data-omitir-trobber-global="true" aria-disabled="true">Roles y permisos</a>
-            <a class="item-menu item-menu--proximamente" href="#" data-omitir-trobber-global="true" aria-disabled="true">Fincas</a>
-            <a class="item-menu item-menu--proximamente" href="#" data-omitir-trobber-global="true" aria-disabled="true">Evaluaciones</a>
-            <a class="item-menu @(moduloActivo == "pagos" ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="PlanesPago">Configuración de pagos</a>
-            <a class="item-menu @(moduloActivo == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
-            <a class="item-menu @(moduloActivo == "administracion" ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="AuditoriaLogs">Auditoría</a>
+            <a class="item-menu @((controllerActual == "dashboard" && accionActual == "administrador") ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Administrador">Inicio</a>
+            <a class="item-menu @((controllerActual == "administracion" && (accionActual == "gestionusuarios" || accionActual == "crearusuario" || accionActual == "editarusuario" || accionActual == "reasignarcliente")) ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="GestionUsuarios">Usuarios</a>
+            <a class="item-menu @((controllerActual == "administracion" && accionActual == "rolespermisos") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="RolesPermisos">Roles y permisos</a>
+            <a class="item-menu @((controllerActual == "reportes" && accionActual == "adminfincasestado") ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="AdminFincasEstado">Fincas</a>
+            <a class="item-menu @((controllerActual == "reportes" && accionActual == "adminevaluaciones") ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="AdminEvaluaciones">Evaluaciones</a>
+            <a class="item-menu @((controllerActual == "administracion" && accionActual == "parametrospago") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="ParametrosPago">Configuración de pagos</a>
+            <a class="item-menu @(moduloActivo == "reportes" || controllerActual == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
+            <a class="item-menu @((controllerActual == "administracion" && accionActual == "auditorialogs") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="AuditoriaLogs">Auditoría</a>
             <a class="item-menu item-menu--proximamente" href="#" data-omitir-trobber-global="true" aria-disabled="true">Notificaciones</a>
             <a class="item-menu @(moduloActivo == "mi-perfil" ? "activo" : string.Empty)" asp-controller="MiPerfil" asp-action="Index">Mi perfil</a>
         }


### PR DESCRIPTION
### Motivation
- Provide full administrative functionality including user management, role/permission management, payment configuration versioning, bank account validation and audit event browsing. 
- Replace legacy DB helpers/stored-proc usages with unified `IDbConnectionFactory`-based DAOs and inline SQL for new admin flows.
- Expose admin APIs and integrate them into the WebApp UI with dedicated views and a lightweight HTTP client wrapper.

### Description
- Added `AdministracionManager` exposing user CRUD, role/permission operations, payment configuration management, bank account validation and audit event listing with audit logging calls to `AuditoriaLogDAO`.
- Reworked/implemented DAOs to use `IDbConnectionFactory`: `AuditoriaLogDAO` (`RegistrarEventoAsync`, `ObtenerEventosAsync`), `ConfiguracionPagoDAO` (create/get current/get history and `MapConfiguracion`), `CuentaBancariaDAO` (list pending and `ValidarCuentaAsync`), `RolPermisoDAO` (list roles with permissions, save role permissions, list basic roles) and `UsuarioDAO` (admin listing, get-by-id, update, deactivate, reassign clients and helpers for admin flows).
- WebApp changes: added `HttpClientService` and registered it in `Program.cs`, applied `[Authorize(Roles = "1")]` to `AdministracionController`, added/updated admin views (`GestionUsuarios`, `FormularioUsuario`, `RolesPermisos`, `ParametrosPago`, `AuditoriaLogs`, `ValidacionCuentasBancarias`, `ReasignarCliente`) and view models, improved sidebar active-route logic, fixed form field bindings and file upload handling in `EvaluacionesController`.
- Project files updated to include new/modified sources in `PSA.DataAccess`, `PSA.EntidadesDTO`, `PSA.WebAPI`, and `PSA.WebApp` csproj files.

### Testing
- Built the solution with `dotnet build` to validate compile-time changes and project file updates, which completed successfully.
- No automated unit/integration tests were added as part of this change and no test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e242044e28832d9dbd188c37628873)