### PR TITLE
Corregir duplicados en RolPermisoDAO que rompían la compilación

### DIFF
--- a/PSA.DataAccess/DAO/RolPermisoDAO.cs
+++ b/PSA.DataAccess/DAO/RolPermisoDAO.cs
@@ -149,11 +149,6 @@ WHERE p.Codigo = @CodigoPermiso;";
             await tx.RollbackAsync();
             throw;
         }
-        catch
-        {
-            await tx.RollbackAsync();
-            throw;
-        }
     }
 
     public async Task<List<PermisoDTO>> ObtenerPermisosAsync()
@@ -183,15 +178,11 @@ SELECT p.IdPermiso, p.Codigo, p.Nombre, p.Descripcion
 FROM dbo.Permisos p
 ORDER BY p.Codigo;";
 
-        using (var command = new SqlCommand(sql, connection))
-        using (var reader = await command.ExecuteReaderAsync())
+        using var fallbackCommand = new SqlCommand(sql, connection);
+        using var fallbackReader = await fallbackCommand.ExecuteReaderAsync();
+        while (await fallbackReader.ReadAsync())
         {
-            while (await reader.ReadAsync())
-            {
-                permisos.Add(MapPermiso(reader));
-            }
-
-            await tx.CommitAsync();
+            permisos.Add(MapPermiso(fallbackReader));
         }
 
         return permisos;
@@ -211,141 +202,6 @@ ORDER BY Nombre;";
 
         var roles = new List<RolDTO>();
 
-        using var command = new SqlCommand(sql, connection);
-        using var reader = await command.ExecuteReaderAsync();
-
-        while (await reader.ReadAsync())
-        {
-            roles.Add(new RolDTO
-            {
-                Id = reader.GetInt32(reader.GetOrdinal("IdRol")),
-                Nombre = reader["Nombre"]?.ToString() ?? string.Empty,
-                Descripcion = reader["Descripcion"] == DBNull.Value ? null : reader["Descripcion"]?.ToString()
-            });
-        }
-
-        return roles;
-    }
-
-    public async Task<int> CrearRolAsync(CrearRolDTO dto)
-    {
-        ArgumentNullException.ThrowIfNull(dto);
-        if (string.IsNullOrWhiteSpace(dto.Nombre))
-        {
-            throw new ArgumentException("El nombre del rol es obligatorio.", nameof(dto.Nombre));
-        }
-
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
-
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
-        var sql = $@"
-INSERT INTO dbo.Roles (Nombre, Descripcion{(tieneEstado ? ", Estado" : string.Empty)})
-VALUES (@Nombre, @Descripcion{(tieneEstado ? ", @Estado" : string.Empty)});
-SELECT CAST(SCOPE_IDENTITY() AS int);";
-
-        using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@Nombre", dto.Nombre.Trim());
-        command.Parameters.AddWithValue("@Descripcion", (object?)dto.Descripcion?.Trim() ?? DBNull.Value);
-        if (tieneEstado)
-        {
-            command.Parameters.AddWithValue("@Estado", dto.Activo ? "Activo" : "Inactivo");
-        }
-
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0);
-    }
-
-    private static async Task<bool> ExisteColumnaEnRolesAsync(SqlConnection connection, string nombreColumna)
-    {
-        const string sql = @"
-SELECT COUNT(1)
-FROM INFORMATION_SCHEMA.COLUMNS
-WHERE TABLE_SCHEMA = 'dbo'
-  AND TABLE_NAME = 'Roles'
-  AND COLUMN_NAME = @NombreColumna;";
-
-        using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@NombreColumna", nombreColumna);
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0) > 0;
-    }
-
-    private static async Task<bool> ExisteStoredProcedureAsync(SqlConnection connection, string nombreProcedimiento)
-    {
-        const string sql = @"
-SELECT COUNT(1)
-FROM sys.procedures
-WHERE schema_id = SCHEMA_ID('dbo')
-  AND name = @NombreProcedimiento;";
-
-        using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@NombreProcedimiento", nombreProcedimiento);
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0) > 0;
-    }
-
-    private static PermisoDTO MapPermiso(SqlDataReader reader)
-    {
-        return new PermisoDTO
-        {
-            IdPermiso = reader.GetInt32(reader.GetOrdinal("IdPermiso")),
-            Codigo = reader["Codigo"]?.ToString() ?? string.Empty,
-            Nombre = reader["Nombre"]?.ToString() ?? string.Empty,
-            Descripcion = reader["Descripcion"] == DBNull.Value ? null : reader["Descripcion"]?.ToString()
-        };
-    }
-
-    public async Task<List<PermisoDTO>> ObtenerPermisosAsync()
-    {
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
-
-        var permisos = new List<PermisoDTO>();
-
-        if (await ExisteStoredProcedureAsync(connection, "usp_Admin_ObtenerPermisos"))
-        {
-            using var sp = new SqlCommand("dbo.usp_Admin_ObtenerPermisos", connection)
-            {
-                CommandType = System.Data.CommandType.StoredProcedure
-            };
-            using var reader = await sp.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-            {
-                permisos.Add(MapPermiso(reader));
-            }
-
-            return permisos;
-        }
-
-        const string sql = @"
-SELECT p.IdPermiso, p.Codigo, p.Nombre, p.Descripcion
-FROM dbo.Permisos p
-ORDER BY p.Codigo;";
-
-        using var command = new SqlCommand(sql, connection);
-        using var dataReader = await command.ExecuteReaderAsync();
-        while (await dataReader.ReadAsync())
-        {
-            permisos.Add(MapPermiso(dataReader));
-        }
-
-        return permisos;
-    }
-
-    public async Task<List<RolDTO>> ObtenerRolesAsync()
-    {
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
-
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
-        var sql = $@"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
-{(tieneEstado ? "WHERE Estado = 'Activo'" : string.Empty)}
-ORDER BY Nombre;";
-
-        var roles = new List<RolDTO>();
         using var command = new SqlCommand(sql, connection);
         using var reader = await command.ExecuteReaderAsync();
 


### PR DESCRIPTION
### Motivation
- La solución no compilaba por errores `CS0111` en `PSA.DataAccess/DAO/RolPermisoDAO.cs` debido a métodos definidos dos veces (`ObtenerPermisosAsync`, `ObtenerRolesAsync`, `CrearRolAsync`, `ExisteColumnaEnRolesAsync`, `ExisteStoredProcedureAsync`, `MapPermiso`).
- Estos fallos en cascada producían `CS0006`/`RAZORSDK1007` en proyectos consumidores porque la biblioteca de datos no generaba su ensamblado de referencia.

### Description
- Eliminadas las definiciones duplicadas de los métodos `ObtenerPermisosAsync`, `ObtenerRolesAsync`, `CrearRolAsync`, `ExisteColumnaEnRolesAsync`, `ExisteStoredProcedureAsync` y `MapPermiso` para dejar una única implementación de cada uno.
- Quitado un `catch` duplicado en `GuardarPermisosRolAsync` para dejar un único manejo de rollback/throw válido.
- Corregido el flujo de fallback en `ObtenerPermisosAsync` reemplazando el uso incorrecto de `reader`/`tx` por un `fallbackCommand`/`fallbackReader` y eliminando la llamada a `tx.CommitAsync()` fuera de cualquier transacción.
- Limpieza menor de código para evitar ambigüedades y asegurar que solo exista una versión de cada helper y método público.

### Testing
- Intenté ejecutar `dotnet build psa-costa-rica.slnx` en este entorno, pero falló porque la CLI de .NET no está instalada (`/bin/bash: dotnet: command not found`).
- No se ejecutaron pruebas automatizadas adicionales en este entorno debido a la falta del SDK; se recomienda compilar en la máquina de desarrollo con `dotnet` instalado para verificar que los `CS0111` y los `CS0006` resultantes desaparezcan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27c6329b4832da19b03e40044728a)