### PR TITLE
Support flexible Roles 'Estado'/'Activo' columns and enhance admin seed script

### DIFF
--- a/PSA.DataAccess/DAO/RolPermisoDAO.cs
+++ b/PSA.DataAccess/DAO/RolPermisoDAO.cs
@@ -13,13 +13,15 @@ public class RolPermisoDAO(IDbConnectionFactory connectionFactory)
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
+        var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
+        var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
+        var expresionActivo = ObtenerExpresionActivo("r", metadataEstado, metadataActivo);
         var sql = $@"
 SELECT
     r.IdRol,
     r.Nombre AS NombreRol,
     r.Descripcion AS DescripcionRol,
-    {(tieneEstado ? "CAST(CASE WHEN r.Estado = 'Activo' THEN 1 ELSE 0 END AS bit)" : "CAST(1 AS bit)")} AS Activo,
+    {expresionActivo} AS Activo,
     p.Codigo AS CodigoPermisoAsignado,
     p.IdPermiso,
     p.Nombre,
@@ -149,11 +151,6 @@ WHERE p.Codigo = @CodigoPermiso;";
             await tx.RollbackAsync();
             throw;
         }
-        catch
-        {
-            await tx.RollbackAsync();
-            throw;
-        }
     }
 
     public async Task<List<PermisoDTO>> ObtenerPermisosAsync()
@@ -183,15 +180,11 @@ SELECT p.IdPermiso, p.Codigo, p.Nombre, p.Descripcion
 FROM dbo.Permisos p
 ORDER BY p.Codigo;";
 
-        using (var command = new SqlCommand(sql, connection))
-        using (var reader = await command.ExecuteReaderAsync())
+        using var fallbackCommand = new SqlCommand(sql, connection);
+        using var fallbackReader = await fallbackCommand.ExecuteReaderAsync();
+        while (await fallbackReader.ReadAsync())
         {
-            while (await reader.ReadAsync())
-            {
-                permisos.Add(MapPermiso(reader));
-            }
-
-            await tx.CommitAsync();
+            permisos.Add(MapPermiso(fallbackReader));
         }
 
         return permisos;
@@ -202,11 +195,13 @@ ORDER BY p.Codigo;";
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
+        var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
+        var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
+        var expresionActivo = ObtenerExpresionActivo("dbo.Roles", metadataEstado, metadataActivo);
         var sql = $@"
 SELECT IdRol, Nombre, Descripcion
 FROM dbo.Roles
-{(tieneEstado ? "WHERE Estado = 'Activo'" : string.Empty)}
+WHERE {expresionActivo} = CAST(1 AS bit)
 ORDER BY Nombre;";
 
         var roles = new List<RolDTO>();
@@ -238,37 +233,69 @@ ORDER BY Nombre;";
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
+        var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
+        var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
+
+        var columnas = new List<string> { "Nombre", "Descripcion" };
+        var valores = new List<string> { "@Nombre", "@Descripcion" };
+
+        var usaEstado = metadataEstado.Exists;
+        var usaActivo = !usaEstado && metadataActivo.Exists;
+        if (usaEstado)
+        {
+            columnas.Add("Estado");
+            valores.Add("@Estado");
+        }
+        else if (usaActivo)
+        {
+            columnas.Add("Activo");
+            valores.Add("@Activo");
+        }
+
         var sql = $@"
-INSERT INTO dbo.Roles (Nombre, Descripcion{(tieneEstado ? ", Estado" : string.Empty)})
-VALUES (@Nombre, @Descripcion{(tieneEstado ? ", @Estado" : string.Empty)});
+INSERT INTO dbo.Roles ({string.Join(", ", columnas)})
+VALUES ({string.Join(", ", valores)});
 SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@Nombre", dto.Nombre.Trim());
         command.Parameters.AddWithValue("@Descripcion", (object?)dto.Descripcion?.Trim() ?? DBNull.Value);
-        if (tieneEstado)
+        if (usaEstado)
         {
-            command.Parameters.AddWithValue("@Estado", dto.Activo ? "Activo" : "Inactivo");
+            command.Parameters.AddWithValue("@Estado", ConvertirEstadoParametro(metadataEstado, dto.Activo));
+        }
+        else if (usaActivo)
+        {
+            command.Parameters.AddWithValue("@Activo", dto.Activo);
         }
 
         var result = await command.ExecuteScalarAsync();
         return Convert.ToInt32(result ?? 0);
     }
 
-    private static async Task<bool> ExisteColumnaEnRolesAsync(SqlConnection connection, string nombreColumna)
+    private static async Task<(bool Exists, string? SqlType)> ObtenerMetadataColumnaAsync(
+        SqlConnection connection,
+        string nombreTabla,
+        string nombreColumna)
     {
         const string sql = @"
-SELECT COUNT(1)
-FROM INFORMATION_SCHEMA.COLUMNS
-WHERE TABLE_SCHEMA = 'dbo'
-  AND TABLE_NAME = 'Roles'
-  AND COLUMN_NAME = @NombreColumna;";
+SELECT TOP 1 c.DATA_TYPE
+FROM INFORMATION_SCHEMA.COLUMNS c
+WHERE c.TABLE_SCHEMA = 'dbo'
+  AND c.TABLE_NAME = @NombreTabla
+  AND c.COLUMN_NAME = @NombreColumna;";
 
         using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@NombreTabla", nombreTabla);
         command.Parameters.AddWithValue("@NombreColumna", nombreColumna);
+
         var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0) > 0;
+        if (result is null || result is DBNull)
+        {
+            return (false, null);
+        }
+
+        return (true, result.ToString());
     }
 
     private static async Task<bool> ExisteStoredProcedureAsync(SqlConnection connection, string nombreProcedimiento)
@@ -296,138 +323,34 @@ WHERE schema_id = SCHEMA_ID('dbo')
         };
     }
 
-    public async Task<List<PermisoDTO>> ObtenerPermisosAsync()
+    private static string ObtenerExpresionActivo(
+        string aliasTabla,
+        (bool Exists, string? SqlType) metadataEstado,
+        (bool Exists, string? SqlType) metadataActivo)
     {
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
-
-        var permisos = new List<PermisoDTO>();
-
-        if (await ExisteStoredProcedureAsync(connection, "usp_Admin_ObtenerPermisos"))
+        if (metadataEstado.Exists)
         {
-            using var sp = new SqlCommand("dbo.usp_Admin_ObtenerPermisos", connection)
+            if (EsTipoBooleano(metadataEstado.SqlType))
             {
-                CommandType = System.Data.CommandType.StoredProcedure
-            };
-            using var reader = await sp.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-            {
-                permisos.Add(MapPermiso(reader));
+                return $"CAST(ISNULL({aliasTabla}.Estado, 0) AS bit)";
             }
 
-            return permisos;
+            return $"CAST(CASE WHEN {aliasTabla}.Estado = 'Activo' THEN 1 ELSE 0 END AS bit)";
         }
 
-        const string sql = @"
-SELECT p.IdPermiso, p.Codigo, p.Nombre, p.Descripcion
-FROM dbo.Permisos p
-ORDER BY p.Codigo;";
-
-        using var command = new SqlCommand(sql, connection);
-        using var dataReader = await command.ExecuteReaderAsync();
-        while (await dataReader.ReadAsync())
+        if (metadataActivo.Exists)
         {
-            permisos.Add(MapPermiso(dataReader));
+            return $"CAST(ISNULL({aliasTabla}.Activo, 1) AS bit)";
         }
 
-        return permisos;
+        return "CAST(1 AS bit)";
     }
 
-    public async Task<List<RolDTO>> ObtenerRolesAsync()
-    {
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
+    private static object ConvertirEstadoParametro((bool Exists, string? SqlType) metadataEstado, bool activo)
+        => EsTipoBooleano(metadataEstado.SqlType)
+            ? activo
+            : activo ? "Activo" : "Inactivo";
 
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
-        var sql = $@"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
-{(tieneEstado ? "WHERE Estado = 'Activo'" : string.Empty)}
-ORDER BY Nombre;";
-
-        var roles = new List<RolDTO>();
-        using var command = new SqlCommand(sql, connection);
-        using var reader = await command.ExecuteReaderAsync();
-
-        while (await reader.ReadAsync())
-        {
-            roles.Add(new RolDTO
-            {
-                Id = reader.GetInt32(reader.GetOrdinal("IdRol")),
-                Nombre = reader["Nombre"]?.ToString() ?? string.Empty,
-                Descripcion = reader["Descripcion"] == DBNull.Value ? null : reader["Descripcion"]?.ToString()
-            });
-        }
-
-        return roles;
-    }
-
-    public async Task<int> CrearRolAsync(CrearRolDTO dto)
-    {
-        ArgumentNullException.ThrowIfNull(dto);
-        if (string.IsNullOrWhiteSpace(dto.Nombre))
-        {
-            throw new ArgumentException("El nombre del rol es obligatorio.", nameof(dto.Nombre));
-        }
-
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
-
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
-        var sql = $@"
-INSERT INTO dbo.Roles (Nombre, Descripcion{(tieneEstado ? ", Estado" : string.Empty)})
-VALUES (@Nombre, @Descripcion{(tieneEstado ? ", @Estado" : string.Empty)});
-SELECT CAST(SCOPE_IDENTITY() AS int);";
-
-        using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@Nombre", dto.Nombre.Trim());
-        command.Parameters.AddWithValue("@Descripcion", (object?)dto.Descripcion?.Trim() ?? DBNull.Value);
-        if (tieneEstado)
-        {
-            command.Parameters.AddWithValue("@Estado", dto.Activo ? "Activo" : "Inactivo");
-        }
-
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0);
-    }
-
-    private static async Task<bool> ExisteColumnaEnRolesAsync(SqlConnection connection, string nombreColumna)
-    {
-        const string sql = @"
-SELECT COUNT(1)
-FROM INFORMATION_SCHEMA.COLUMNS
-WHERE TABLE_SCHEMA = 'dbo'
-  AND TABLE_NAME = 'Roles'
-  AND COLUMN_NAME = @NombreColumna;";
-
-        using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@NombreColumna", nombreColumna);
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0) > 0;
-    }
-
-    private static async Task<bool> ExisteStoredProcedureAsync(SqlConnection connection, string nombreProcedimiento)
-    {
-        const string sql = @"
-SELECT COUNT(1)
-FROM sys.procedures
-WHERE schema_id = SCHEMA_ID('dbo')
-  AND name = @NombreProcedimiento;";
-
-        using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@NombreProcedimiento", nombreProcedimiento);
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0) > 0;
-    }
-
-    private static PermisoDTO MapPermiso(SqlDataReader reader)
-    {
-        return new PermisoDTO
-        {
-            IdPermiso = reader.GetInt32(reader.GetOrdinal("IdPermiso")),
-            Codigo = reader["Codigo"]?.ToString() ?? string.Empty,
-            Nombre = reader["Nombre"]?.ToString() ?? string.Empty,
-            Descripcion = reader["Descripcion"] == DBNull.Value ? null : reader["Descripcion"]?.ToString()
-        };
-    }
+    private static bool EsTipoBooleano(string? sqlType)
+        => string.Equals(sqlType, "bit", StringComparison.OrdinalIgnoreCase);
 }

--- a/scripts/sql/20260417_admin_config_pagos_y_roles_seed.sql
+++ b/scripts/sql/20260417_admin_config_pagos_y_roles_seed.sql
@@ -1,6 +1,6 @@
 /*
     Script:
-    - Garantiza una sola configuración de pago activa
+    - Garantiza una sola configuración de pago activa (columna Activa BIT)
     - Crea catálogo mínimo de permisos administrativos
     - Crea roles base si no existen
 */
@@ -9,23 +9,31 @@ SET ANSI_NULLS ON;
 SET QUOTED_IDENTIFIER ON;
 GO
 
-/* 1) Restricción de una sola configuración activa */
-IF COL_LENGTH('dbo.ConfiguracionesPago', 'Estado') IS NOT NULL
+/* 1) Restricción de una sola configuración activa (según esquema real) */
+IF OBJECT_ID('dbo.ConfiguracionesPago', 'U') IS NOT NULL
+   AND COL_LENGTH('dbo.ConfiguracionesPago', 'Activa') IS NOT NULL
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM sys.indexes
-        WHERE object_id = OBJECT_ID('dbo.ConfiguracionesPago')
-          AND name = 'UX_ConfiguracionesPago_EstadoActiva')
-    BEGIN
-        CREATE UNIQUE INDEX UX_ConfiguracionesPago_EstadoActiva
-            ON dbo.ConfiguracionesPago(Estado)
-            WHERE Estado = 'Activa';
-    END
-END
-GO
+    /* 1.1) Si existen múltiples activas, conservar solo la más reciente */
+    ;WITH ConfiguracionesActivas AS
+    (
+        SELECT
+            cp.IdConfiguracionPago,
+            ROW_NUMBER() OVER (
+                ORDER BY
+                    ISNULL(cp.Version, 0) DESC,
+                    cp.IdConfiguracionPago DESC
+            ) AS Orden
+        FROM dbo.ConfiguracionesPago cp
+        WHERE cp.Activa = 1
+    )
+    UPDATE cp
+    SET Activa = 0
+    FROM dbo.ConfiguracionesPago cp
+    INNER JOIN ConfiguracionesActivas ca
+        ON ca.IdConfiguracionPago = cp.IdConfiguracionPago
+    WHERE ca.Orden > 1;
 
-IF COL_LENGTH('dbo.ConfiguracionesPago', 'Activa') IS NOT NULL
-BEGIN
+    /* 1.2) Índice filtrado para impedir más de una activa */
     IF NOT EXISTS (
         SELECT 1 FROM sys.indexes
         WHERE object_id = OBJECT_ID('dbo.ConfiguracionesPago')
@@ -35,23 +43,79 @@ BEGIN
             ON dbo.ConfiguracionesPago(Activa)
             WHERE Activa = 1;
     END
+
+    /* 1.3) Seed mínimo de configuración de pago si la tabla está vacía */
+    IF NOT EXISTS (SELECT 1 FROM dbo.ConfiguracionesPago)
+    BEGIN
+        DECLARE @IdUsuarioCreador INT;
+        SELECT TOP 1 @IdUsuarioCreador = u.IdUsuario
+        FROM dbo.Usuarios u
+        ORDER BY u.IdUsuario;
+
+        IF @IdUsuarioCreador IS NOT NULL
+        BEGIN
+            INSERT INTO dbo.ConfiguracionesPago
+            (
+                Version,
+                NombreVersion,
+                PrecioBasePorHectarea,
+                TopePorcentajeAjuste,
+                FechaVigenciaDesde,
+                FechaVigenciaHasta,
+                Activa,
+                CreadoPor
+            )
+            VALUES
+            (
+                1,
+                'Configuración Base',
+                25000.00,
+                30.00,
+                CAST(GETDATE() AS date),
+                NULL,
+                1,
+                @IdUsuarioCreador
+            );
+        END
+    END
 END
 GO
 
 /* 2) Roles base */
 IF OBJECT_ID('dbo.Roles', 'U') IS NOT NULL
 BEGIN
+    DECLARE @RolesTieneEstado BIT = CASE WHEN COL_LENGTH('dbo.Roles', 'Estado') IS NOT NULL THEN 1 ELSE 0 END;
+    DECLARE @RolesTieneActivo BIT = CASE WHEN COL_LENGTH('dbo.Roles', 'Activo') IS NOT NULL THEN 1 ELSE 0 END;
+
     IF NOT EXISTS (SELECT 1 FROM dbo.Roles WHERE Nombre = 'Administrador')
-        INSERT INTO dbo.Roles (Nombre, Descripcion, Estado)
-        VALUES ('Administrador', 'Acceso total al sistema', 'Activo');
+    BEGIN
+        IF @RolesTieneEstado = 1
+            INSERT INTO dbo.Roles (Nombre, Descripcion, Estado) VALUES ('Administrador', 'Acceso total al sistema', 'Activo');
+        ELSE IF @RolesTieneActivo = 1
+            INSERT INTO dbo.Roles (Nombre, Descripcion, Activo) VALUES ('Administrador', 'Acceso total al sistema', 1);
+        ELSE
+            INSERT INTO dbo.Roles (Nombre, Descripcion) VALUES ('Administrador', 'Acceso total al sistema');
+    END
 
     IF NOT EXISTS (SELECT 1 FROM dbo.Roles WHERE Nombre = 'Ingeniero')
-        INSERT INTO dbo.Roles (Nombre, Descripcion, Estado)
-        VALUES ('Ingeniero', 'Operación técnica de campo', 'Activo');
+    BEGIN
+        IF @RolesTieneEstado = 1
+            INSERT INTO dbo.Roles (Nombre, Descripcion, Estado) VALUES ('Ingeniero', 'Operación técnica de campo', 'Activo');
+        ELSE IF @RolesTieneActivo = 1
+            INSERT INTO dbo.Roles (Nombre, Descripcion, Activo) VALUES ('Ingeniero', 'Operación técnica de campo', 1);
+        ELSE
+            INSERT INTO dbo.Roles (Nombre, Descripcion) VALUES ('Ingeniero', 'Operación técnica de campo');
+    END
 
     IF NOT EXISTS (SELECT 1 FROM dbo.Roles WHERE Nombre = 'Propietario')
-        INSERT INTO dbo.Roles (Nombre, Descripcion, Estado)
-        VALUES ('Propietario', 'Consulta y gestión de sus fincas', 'Activo');
+    BEGIN
+        IF @RolesTieneEstado = 1
+            INSERT INTO dbo.Roles (Nombre, Descripcion, Estado) VALUES ('Propietario', 'Consulta y gestión de sus fincas', 'Activo');
+        ELSE IF @RolesTieneActivo = 1
+            INSERT INTO dbo.Roles (Nombre, Descripcion, Activo) VALUES ('Propietario', 'Consulta y gestión de sus fincas', 1);
+        ELSE
+            INSERT INTO dbo.Roles (Nombre, Descripcion) VALUES ('Propietario', 'Consulta y gestión de sus fincas');
+    END
 END
 GO
 
@@ -84,34 +148,52 @@ BEGIN
 END
 GO
 
-/* 4) Asignación inicial para Administrador */
+/* 4) Asignación inicial por rol */
 IF OBJECT_ID('dbo.RolesPermisos', 'U') IS NOT NULL
    AND OBJECT_ID('dbo.Roles', 'U') IS NOT NULL
    AND OBJECT_ID('dbo.Permisos', 'U') IS NOT NULL
 BEGIN
-    DECLARE @IdRolAdmin int;
-    SELECT TOP 1 @IdRolAdmin = IdRol FROM dbo.Roles WHERE Nombre = 'Administrador';
+    DECLARE @Asignaciones TABLE
+    (
+        NombreRol NVARCHAR(50) NOT NULL,
+        CodigoPermiso NVARCHAR(100) NOT NULL
+    );
 
-    IF @IdRolAdmin IS NOT NULL
-    BEGIN
-        INSERT INTO dbo.RolesPermisos (IdRol, IdPermiso)
-        SELECT @IdRolAdmin, p.IdPermiso
-        FROM dbo.Permisos p
-        WHERE p.Codigo IN (
-            'ADMIN_USUARIOS_VER',
-            'ADMIN_USUARIOS_CREAR',
-            'ADMIN_USUARIOS_EDITAR',
-            'ADMIN_USUARIOS_ELIMINAR',
-            'ADMIN_CLIENTES_REASIGNAR',
-            'ADMIN_PAGOS_CONFIGURAR',
-            'ADMIN_CUENTAS_VALIDAR',
-            'ADMIN_AUDITORIA_CONSULTAR'
-        )
-        AND NOT EXISTS (
-            SELECT 1 FROM dbo.RolesPermisos rp
-            WHERE rp.IdRol = @IdRolAdmin
-              AND rp.IdPermiso = p.IdPermiso
-        );
-    END
+    /* Administrador: todos los permisos */
+    INSERT INTO @Asignaciones (NombreRol, CodigoPermiso)
+    VALUES
+        ('Administrador', 'ADMIN_USUARIOS_VER'),
+        ('Administrador', 'ADMIN_USUARIOS_CREAR'),
+        ('Administrador', 'ADMIN_USUARIOS_EDITAR'),
+        ('Administrador', 'ADMIN_USUARIOS_ELIMINAR'),
+        ('Administrador', 'ADMIN_CLIENTES_REASIGNAR'),
+        ('Administrador', 'ADMIN_PAGOS_CONFIGURAR'),
+        ('Administrador', 'ADMIN_CUENTAS_VALIDAR'),
+        ('Administrador', 'ADMIN_AUDITORIA_CONSULTAR');
+
+    /* Ingeniero: lectura de usuarios y consulta de auditoría */
+    INSERT INTO @Asignaciones (NombreRol, CodigoPermiso)
+    VALUES
+        ('Ingeniero', 'ADMIN_USUARIOS_VER'),
+        ('Ingeniero', 'ADMIN_AUDITORIA_CONSULTAR');
+
+    /* Propietario: lectura de usuarios (mínimo para poblar pantalla) */
+    INSERT INTO @Asignaciones (NombreRol, CodigoPermiso)
+    VALUES
+        ('Propietario', 'ADMIN_USUARIOS_VER');
+
+    INSERT INTO dbo.RolesPermisos (IdRol, IdPermiso)
+    SELECT r.IdRol, p.IdPermiso
+    FROM @Asignaciones a
+    INNER JOIN dbo.Roles r
+        ON r.Nombre = a.NombreRol
+    INNER JOIN dbo.Permisos p
+        ON p.Codigo = a.CodigoPermiso
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM dbo.RolesPermisos rp
+        WHERE rp.IdRol = r.IdRol
+          AND rp.IdPermiso = p.IdPermiso
+    );
 END
 GO


### PR DESCRIPTION
### Motivation
- Make role-related data access resilient to schema variations where `Roles` may expose either a textual `Estado` column or a boolean `Activo` column or neither. 
- Improve database seed script to enforce a single active payment configuration using the actual `Activa` bit column and to provide idempotent role and permission seeding and assignments.

### Description
- Refactored `RolPermisoDAO` to detect column metadata via `ObtenerMetadataColumnaAsync` and build an `Activo` expression with `ObtenerExpresionActivo`, allowing queries to work whether `Estado` (string) or `Activo` (bit) exist or neither does. 
- Added helpers `ConvertirEstadoParametro` and `EsTipoBooleano` to normalize parameter values when inserting roles depending on the detected column type, and simplified SQL generation for `CrearRolAsync` to only include relevant columns. 
- Removed duplicated/incorrect catch block and consolidated code paths in `ObtenerPermisosAsync`, switching to a clear fallback query when the stored procedure is not present. 
- Enhanced seed script `scripts/sql/20260417_admin_config_pagos_y_roles_seed.sql` to: create a filtered unique index on `ConfiguracionesPago.Activa`, collapse multiple active rows keeping the most recent, seed a base configuration if empty, insert base roles conditionally based on whether `Roles` has `Estado` or `Activo`, and idempotently assign permissions per role using a table variable. 

### Testing
- Built the solution successfully after the changes. 
- Ran the existing automated unit test suite and checks against the modified assemblies, and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27c6329b4832da19b03e40044728a)