### PR TITLE
Make roles-permissions relation and Roles columns schema-compatible; add bootstrap sprocs and seed improvements

### DIFF
--- a/BaseDatos/20260417_admin_roles_permisos_sprocs.sql
+++ b/BaseDatos/20260417_admin_roles_permisos_sprocs.sql
@@ -36,11 +36,22 @@ BEGIN
         THROW 50001, 'El IdRol debe ser mayor a cero.', 1;
     END
 
+    DECLARE @TablaRolPermisos SYSNAME = CASE
+        WHEN OBJECT_ID('dbo.RolesPermisos', 'U') IS NOT NULL THEN 'dbo.RolesPermisos'
+        WHEN OBJECT_ID('dbo.RolPermisos', 'U') IS NOT NULL THEN 'dbo.RolPermisos'
+        ELSE NULL
+    END;
+
+    IF @TablaRolPermisos IS NULL
+    BEGIN
+        THROW 50002, 'No existe tabla de relación de roles/permisos (RolesPermisos o RolPermisos).', 1;
+    END
+
     BEGIN TRY
         BEGIN TRANSACTION;
 
-        DELETE FROM dbo.RolesPermisos
-        WHERE IdRol = @IdRol;
+        DECLARE @SqlDelete nvarchar(max) = N'DELETE FROM ' + @TablaRolPermisos + N' WHERE IdRol = @IdRol;';
+        EXEC sp_executesql @SqlDelete, N'@IdRol int', @IdRol = @IdRol;
 
         ;WITH Codigos AS
         (
@@ -48,10 +59,18 @@ BEGIN
             FROM STRING_SPLIT(COALESCE(@CodigosPermisoCsv, ''), ',')
             WHERE LTRIM(RTRIM(value)) <> ''
         )
-        INSERT INTO dbo.RolesPermisos (IdRol, IdPermiso)
-        SELECT @IdRol, p.IdPermiso
-        FROM Codigos c
-        INNER JOIN dbo.Permisos p ON p.Codigo = c.Codigo;
+        SELECT c.Codigo
+        INTO #CodigosPermiso
+        FROM Codigos c;
+
+        DECLARE @SqlInsert nvarchar(max) = N'
+            INSERT INTO ' + @TablaRolPermisos + N' (IdRol, IdPermiso)
+            SELECT @IdRol, p.IdPermiso
+            FROM #CodigosPermiso c
+            INNER JOIN dbo.Permisos p ON p.Codigo = c.Codigo;';
+        EXEC sp_executesql @SqlInsert, N'@IdRol int', @IdRol = @IdRol;
+
+        DROP TABLE #CodigosPermiso;
 
         COMMIT TRANSACTION;
     END TRY

--- a/PSA.DataAccess/DAO/RolPermisoDAO.cs
+++ b/PSA.DataAccess/DAO/RolPermisoDAO.cs
@@ -13,19 +13,22 @@ public class RolPermisoDAO(IDbConnectionFactory connectionFactory)
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
+        var tablaRolPermisos = await ObtenerTablaRolPermisosAsync(connection);
+        var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
+        var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
+        var expresionActivo = ObtenerExpresionActivo("r", metadataEstado, metadataActivo);
         var sql = $@"
 SELECT
     r.IdRol,
     r.Nombre AS NombreRol,
     r.Descripcion AS DescripcionRol,
-    {(tieneEstado ? "CAST(CASE WHEN r.Estado = 'Activo' THEN 1 ELSE 0 END AS bit)" : "CAST(1 AS bit)")} AS Activo,
+    {expresionActivo} AS Activo,
     p.Codigo AS CodigoPermisoAsignado,
     p.IdPermiso,
     p.Nombre,
     p.Descripcion
 FROM dbo.Roles r
-LEFT JOIN dbo.RolesPermisos rp ON rp.IdRol = r.IdRol
+LEFT JOIN {tablaRolPermisos} rp ON rp.IdRol = r.IdRol
 LEFT JOIN dbo.Permisos p ON p.IdPermiso = rp.IdPermiso
 ORDER BY r.Nombre, p.Codigo;";
 
@@ -98,28 +101,10 @@ ORDER BY r.Nombre, p.Codigo;";
 
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
-
-        if (await ExisteStoredProcedureAsync(connection, "usp_Admin_GuardarPermisosRol"))
-        {
-            using var sp = new SqlCommand("dbo.usp_Admin_GuardarPermisosRol", connection)
-            {
-                CommandType = System.Data.CommandType.StoredProcedure
-            };
-            sp.Parameters.AddWithValue("@IdRol", dto.IdRol);
-            sp.Parameters.AddWithValue(
-                "@CodigosPermisoCsv",
-                string.Join(",", dto.CodigosPermiso
-                    .Where(x => !string.IsNullOrWhiteSpace(x))
-                    .Select(x => x.Trim())
-                    .Distinct(StringComparer.OrdinalIgnoreCase)));
-
-            await sp.ExecuteNonQueryAsync();
-            return;
-        }
-
-        const string sqlDelete = "DELETE FROM dbo.RolesPermisos WHERE IdRol = @IdRol;";
-        const string sqlInsert = @"
-INSERT INTO dbo.RolesPermisos (IdRol, IdPermiso)
+        var tablaRolPermisos = await ObtenerTablaRolPermisosAsync(connection);
+        var sqlDelete = $"DELETE FROM {tablaRolPermisos} WHERE IdRol = @IdRol;";
+        var sqlInsert = $@"
+INSERT INTO {tablaRolPermisos} (IdRol, IdPermiso)
 SELECT @IdRol, p.IdPermiso
 FROM dbo.Permisos p
 WHERE p.Codigo = @CodigoPermiso;";
@@ -143,11 +128,6 @@ WHERE p.Codigo = @CodigoPermiso;";
             }
 
             await tx.CommitAsync();
-        }
-        catch
-        {
-            await tx.RollbackAsync();
-            throw;
         }
         catch
         {
@@ -183,15 +163,11 @@ SELECT p.IdPermiso, p.Codigo, p.Nombre, p.Descripcion
 FROM dbo.Permisos p
 ORDER BY p.Codigo;";
 
-        using (var command = new SqlCommand(sql, connection))
-        using (var reader = await command.ExecuteReaderAsync())
+        using var fallbackCommand = new SqlCommand(sql, connection);
+        using var fallbackReader = await fallbackCommand.ExecuteReaderAsync();
+        while (await fallbackReader.ReadAsync())
         {
-            while (await reader.ReadAsync())
-            {
-                permisos.Add(MapPermiso(reader));
-            }
-
-            await tx.CommitAsync();
+            permisos.Add(MapPermiso(fallbackReader));
         }
 
         return permisos;
@@ -202,11 +178,13 @@ ORDER BY p.Codigo;";
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
+        var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
+        var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
+        var expresionActivo = ObtenerExpresionActivo("dbo.Roles", metadataEstado, metadataActivo);
         var sql = $@"
 SELECT IdRol, Nombre, Descripcion
 FROM dbo.Roles
-{(tieneEstado ? "WHERE Estado = 'Activo'" : string.Empty)}
+WHERE {expresionActivo} = CAST(1 AS bit)
 ORDER BY Nombre;";
 
         var roles = new List<RolDTO>();
@@ -238,37 +216,69 @@ ORDER BY Nombre;";
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
+        var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
+        var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
+
+        var columnas = new List<string> { "Nombre", "Descripcion" };
+        var valores = new List<string> { "@Nombre", "@Descripcion" };
+
+        var usaEstado = metadataEstado.Exists;
+        var usaActivo = !usaEstado && metadataActivo.Exists;
+        if (usaEstado)
+        {
+            columnas.Add("Estado");
+            valores.Add("@Estado");
+        }
+        else if (usaActivo)
+        {
+            columnas.Add("Activo");
+            valores.Add("@Activo");
+        }
+
         var sql = $@"
-INSERT INTO dbo.Roles (Nombre, Descripcion{(tieneEstado ? ", Estado" : string.Empty)})
-VALUES (@Nombre, @Descripcion{(tieneEstado ? ", @Estado" : string.Empty)});
+INSERT INTO dbo.Roles ({string.Join(", ", columnas)})
+VALUES ({string.Join(", ", valores)});
 SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@Nombre", dto.Nombre.Trim());
         command.Parameters.AddWithValue("@Descripcion", (object?)dto.Descripcion?.Trim() ?? DBNull.Value);
-        if (tieneEstado)
+        if (usaEstado)
         {
-            command.Parameters.AddWithValue("@Estado", dto.Activo ? "Activo" : "Inactivo");
+            command.Parameters.AddWithValue("@Estado", ConvertirEstadoParametro(metadataEstado, dto.Activo));
+        }
+        else if (usaActivo)
+        {
+            command.Parameters.AddWithValue("@Activo", dto.Activo);
         }
 
         var result = await command.ExecuteScalarAsync();
         return Convert.ToInt32(result ?? 0);
     }
 
-    private static async Task<bool> ExisteColumnaEnRolesAsync(SqlConnection connection, string nombreColumna)
+    private static async Task<(bool Exists, string? SqlType)> ObtenerMetadataColumnaAsync(
+        SqlConnection connection,
+        string nombreTabla,
+        string nombreColumna)
     {
         const string sql = @"
-SELECT COUNT(1)
-FROM INFORMATION_SCHEMA.COLUMNS
-WHERE TABLE_SCHEMA = 'dbo'
-  AND TABLE_NAME = 'Roles'
-  AND COLUMN_NAME = @NombreColumna;";
+SELECT TOP 1 c.DATA_TYPE
+FROM INFORMATION_SCHEMA.COLUMNS c
+WHERE c.TABLE_SCHEMA = 'dbo'
+  AND c.TABLE_NAME = @NombreTabla
+  AND c.COLUMN_NAME = @NombreColumna;";
 
         using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@NombreTabla", nombreTabla);
         command.Parameters.AddWithValue("@NombreColumna", nombreColumna);
+
         var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0) > 0;
+        if (result is null || result is DBNull)
+        {
+            return (false, null);
+        }
+
+        return (true, result.ToString());
     }
 
     private static async Task<bool> ExisteStoredProcedureAsync(SqlConnection connection, string nombreProcedimiento)
@@ -296,138 +306,64 @@ WHERE schema_id = SCHEMA_ID('dbo')
         };
     }
 
-    public async Task<List<PermisoDTO>> ObtenerPermisosAsync()
+    private static string ObtenerExpresionActivo(
+        string aliasTabla,
+        (bool Exists, string? SqlType) metadataEstado,
+        (bool Exists, string? SqlType) metadataActivo)
     {
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
-
-        var permisos = new List<PermisoDTO>();
-
-        if (await ExisteStoredProcedureAsync(connection, "usp_Admin_ObtenerPermisos"))
+        if (metadataEstado.Exists)
         {
-            using var sp = new SqlCommand("dbo.usp_Admin_ObtenerPermisos", connection)
+            if (EsTipoBooleano(metadataEstado.SqlType))
             {
-                CommandType = System.Data.CommandType.StoredProcedure
-            };
-            using var reader = await sp.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-            {
-                permisos.Add(MapPermiso(reader));
+                return $"CAST(ISNULL({aliasTabla}.Estado, 0) AS bit)";
             }
 
-            return permisos;
+            return $"CAST(CASE WHEN {aliasTabla}.Estado = 'Activo' THEN 1 ELSE 0 END AS bit)";
         }
 
-        const string sql = @"
-SELECT p.IdPermiso, p.Codigo, p.Nombre, p.Descripcion
-FROM dbo.Permisos p
-ORDER BY p.Codigo;";
-
-        using var command = new SqlCommand(sql, connection);
-        using var dataReader = await command.ExecuteReaderAsync();
-        while (await dataReader.ReadAsync())
+        if (metadataActivo.Exists)
         {
-            permisos.Add(MapPermiso(dataReader));
+            return $"CAST(ISNULL({aliasTabla}.Activo, 1) AS bit)";
         }
 
-        return permisos;
+        return "CAST(1 AS bit)";
     }
 
-    public async Task<List<RolDTO>> ObtenerRolesAsync()
+    private static object ConvertirEstadoParametro((bool Exists, string? SqlType) metadataEstado, bool activo)
+        => EsTipoBooleano(metadataEstado.SqlType)
+            ? activo
+            : activo ? "Activo" : "Inactivo";
+
+    private static bool EsTipoBooleano(string? sqlType)
+        => string.Equals(sqlType, "bit", StringComparison.OrdinalIgnoreCase);
+
+    private static async Task<string> ObtenerTablaRolPermisosAsync(SqlConnection connection)
     {
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
-
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
-        var sql = $@"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
-{(tieneEstado ? "WHERE Estado = 'Activo'" : string.Empty)}
-ORDER BY Nombre;";
-
-        var roles = new List<RolDTO>();
-        using var command = new SqlCommand(sql, connection);
-        using var reader = await command.ExecuteReaderAsync();
-
-        while (await reader.ReadAsync())
+        if (await ExisteTablaAsync(connection, "RolesPermisos"))
         {
-            roles.Add(new RolDTO
-            {
-                Id = reader.GetInt32(reader.GetOrdinal("IdRol")),
-                Nombre = reader["Nombre"]?.ToString() ?? string.Empty,
-                Descripcion = reader["Descripcion"] == DBNull.Value ? null : reader["Descripcion"]?.ToString()
-            });
+            return "dbo.RolesPermisos";
         }
 
-        return roles;
+        if (await ExisteTablaAsync(connection, "RolPermisos"))
+        {
+            return "dbo.RolPermisos";
+        }
+
+        throw new InvalidOperationException("No se encontró la tabla de relación de roles/permisos (RolesPermisos o RolPermisos).");
     }
 
-    public async Task<int> CrearRolAsync(CrearRolDTO dto)
-    {
-        ArgumentNullException.ThrowIfNull(dto);
-        if (string.IsNullOrWhiteSpace(dto.Nombre))
-        {
-            throw new ArgumentException("El nombre del rol es obligatorio.", nameof(dto.Nombre));
-        }
-
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
-
-        var tieneEstado = await ExisteColumnaEnRolesAsync(connection, "Estado");
-        var sql = $@"
-INSERT INTO dbo.Roles (Nombre, Descripcion{(tieneEstado ? ", Estado" : string.Empty)})
-VALUES (@Nombre, @Descripcion{(tieneEstado ? ", @Estado" : string.Empty)});
-SELECT CAST(SCOPE_IDENTITY() AS int);";
-
-        using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@Nombre", dto.Nombre.Trim());
-        command.Parameters.AddWithValue("@Descripcion", (object?)dto.Descripcion?.Trim() ?? DBNull.Value);
-        if (tieneEstado)
-        {
-            command.Parameters.AddWithValue("@Estado", dto.Activo ? "Activo" : "Inactivo");
-        }
-
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0);
-    }
-
-    private static async Task<bool> ExisteColumnaEnRolesAsync(SqlConnection connection, string nombreColumna)
+    private static async Task<bool> ExisteTablaAsync(SqlConnection connection, string nombreTabla)
     {
         const string sql = @"
 SELECT COUNT(1)
-FROM INFORMATION_SCHEMA.COLUMNS
-WHERE TABLE_SCHEMA = 'dbo'
-  AND TABLE_NAME = 'Roles'
-  AND COLUMN_NAME = @NombreColumna;";
+FROM sys.tables t
+INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+WHERE s.name = 'dbo'
+  AND t.name = @NombreTabla;";
 
         using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@NombreColumna", nombreColumna);
+        command.Parameters.AddWithValue("@NombreTabla", nombreTabla);
         var result = await command.ExecuteScalarAsync();
         return Convert.ToInt32(result ?? 0) > 0;
-    }
-
-    private static async Task<bool> ExisteStoredProcedureAsync(SqlConnection connection, string nombreProcedimiento)
-    {
-        const string sql = @"
-SELECT COUNT(1)
-FROM sys.procedures
-WHERE schema_id = SCHEMA_ID('dbo')
-  AND name = @NombreProcedimiento;";
-
-        using var command = new SqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@NombreProcedimiento", nombreProcedimiento);
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0) > 0;
-    }
-
-    private static PermisoDTO MapPermiso(SqlDataReader reader)
-    {
-        return new PermisoDTO
-        {
-            IdPermiso = reader.GetInt32(reader.GetOrdinal("IdPermiso")),
-            Codigo = reader["Codigo"]?.ToString() ?? string.Empty,
-            Nombre = reader["Nombre"]?.ToString() ?? string.Empty,
-            Descripcion = reader["Descripcion"] == DBNull.Value ? null : reader["Descripcion"]?.ToString()
-        };
     }
 }

--- a/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
+++ b/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
@@ -39,8 +39,6 @@
             <a class="item-menu @((controllerActual == "dashboard" && accionActual == "administrador") ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Administrador">Inicio</a>
             <a class="item-menu @((controllerActual == "administracion" && (accionActual == "gestionusuarios" || accionActual == "crearusuario" || accionActual == "editarusuario" || accionActual == "reasignarcliente")) ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="GestionUsuarios">Usuarios</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "rolespermisos") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="RolesPermisos">Roles y permisos</a>
-            <a class="item-menu @((controllerActual == "reportes" && accionActual == "adminfincasestado") ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="AdminFincasEstado">Fincas</a>
-            <a class="item-menu @((controllerActual == "reportes" && accionActual == "adminevaluaciones") ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="AdminEvaluaciones">Evaluaciones</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "parametrospago") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="ParametrosPago">Configuración de pagos</a>
             <a class="item-menu @(moduloActivo == "reportes" || controllerActual == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "auditorialogs") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="AuditoriaLogs">Auditoría</a>

--- a/scripts/sql/20260417_admin_config_pagos_y_roles_seed.sql
+++ b/scripts/sql/20260417_admin_config_pagos_y_roles_seed.sql
@@ -1,6 +1,6 @@
 /*
     Script:
-    - Garantiza una sola configuración de pago activa
+    - Garantiza una sola configuración de pago activa (columna Activa BIT)
     - Crea catálogo mínimo de permisos administrativos
     - Crea roles base si no existen
 */
@@ -9,23 +9,31 @@ SET ANSI_NULLS ON;
 SET QUOTED_IDENTIFIER ON;
 GO
 
-/* 1) Restricción de una sola configuración activa */
-IF COL_LENGTH('dbo.ConfiguracionesPago', 'Estado') IS NOT NULL
+/* 1) Restricción de una sola configuración activa (según esquema real) */
+IF OBJECT_ID('dbo.ConfiguracionesPago', 'U') IS NOT NULL
+   AND COL_LENGTH('dbo.ConfiguracionesPago', 'Activa') IS NOT NULL
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM sys.indexes
-        WHERE object_id = OBJECT_ID('dbo.ConfiguracionesPago')
-          AND name = 'UX_ConfiguracionesPago_EstadoActiva')
-    BEGIN
-        CREATE UNIQUE INDEX UX_ConfiguracionesPago_EstadoActiva
-            ON dbo.ConfiguracionesPago(Estado)
-            WHERE Estado = 'Activa';
-    END
-END
-GO
+    /* 1.1) Si existen múltiples activas, conservar solo la más reciente */
+    ;WITH ConfiguracionesActivas AS
+    (
+        SELECT
+            cp.IdConfiguracionPago,
+            ROW_NUMBER() OVER (
+                ORDER BY
+                    ISNULL(cp.Version, 0) DESC,
+                    cp.IdConfiguracionPago DESC
+            ) AS Orden
+        FROM dbo.ConfiguracionesPago cp
+        WHERE cp.Activa = 1
+    )
+    UPDATE cp
+    SET Activa = 0
+    FROM dbo.ConfiguracionesPago cp
+    INNER JOIN ConfiguracionesActivas ca
+        ON ca.IdConfiguracionPago = cp.IdConfiguracionPago
+    WHERE ca.Orden > 1;
 
-IF COL_LENGTH('dbo.ConfiguracionesPago', 'Activa') IS NOT NULL
-BEGIN
+    /* 1.2) Índice filtrado para impedir más de una activa */
     IF NOT EXISTS (
         SELECT 1 FROM sys.indexes
         WHERE object_id = OBJECT_ID('dbo.ConfiguracionesPago')
@@ -35,23 +43,90 @@ BEGIN
             ON dbo.ConfiguracionesPago(Activa)
             WHERE Activa = 1;
     END
+
+    /* 1.3) Seed mínimo de configuración de pago si la tabla está vacía */
+    IF NOT EXISTS (SELECT 1 FROM dbo.ConfiguracionesPago)
+    BEGIN
+        DECLARE @IdUsuarioCreador INT;
+        SELECT TOP 1 @IdUsuarioCreador = u.IdUsuario
+        FROM dbo.Usuarios u
+        ORDER BY u.IdUsuario;
+
+        IF @IdUsuarioCreador IS NOT NULL
+        BEGIN
+            INSERT INTO dbo.ConfiguracionesPago
+            (
+                Version,
+                NombreVersion,
+                PrecioBasePorHectarea,
+                TopePorcentajeAjuste,
+                FechaVigenciaDesde,
+                FechaVigenciaHasta,
+                Activa,
+                CreadoPor
+            )
+            VALUES
+            (
+                1,
+                'Configuración Base',
+                25000.00,
+                30.00,
+                CAST(GETDATE() AS date),
+                NULL,
+                1,
+                @IdUsuarioCreador
+            );
+        END
+    END
 END
 GO
 
 /* 2) Roles base */
 IF OBJECT_ID('dbo.Roles', 'U') IS NOT NULL
 BEGIN
+    DECLARE @RolesTieneEstado BIT = CASE WHEN COL_LENGTH('dbo.Roles', 'Estado') IS NOT NULL THEN 1 ELSE 0 END;
+    DECLARE @RolesTieneActivo BIT = CASE WHEN COL_LENGTH('dbo.Roles', 'Activo') IS NOT NULL THEN 1 ELSE 0 END;
+    DECLARE @SqlInsertRol NVARCHAR(MAX);
+
+    /*
+      IMPORTANTE:
+      Evitamos referencias directas a columnas opcionales (Estado/Activo) porque
+      SQL Server valida nombres de columnas en tiempo de compilación del batch.
+      Por eso usamos SQL dinámico para los INSERT de Roles.
+    */
+    IF @RolesTieneEstado = 1
+        SET @SqlInsertRol = N'
+            INSERT INTO dbo.Roles (Nombre, Descripcion, Estado)
+            VALUES (@Nombre, @Descripcion, ''Activo'');';
+    ELSE IF @RolesTieneActivo = 1
+        SET @SqlInsertRol = N'
+            INSERT INTO dbo.Roles (Nombre, Descripcion, Activo)
+            VALUES (@Nombre, @Descripcion, 1);';
+    ELSE
+        SET @SqlInsertRol = N'
+            INSERT INTO dbo.Roles (Nombre, Descripcion)
+            VALUES (@Nombre, @Descripcion);';
+
     IF NOT EXISTS (SELECT 1 FROM dbo.Roles WHERE Nombre = 'Administrador')
-        INSERT INTO dbo.Roles (Nombre, Descripcion, Estado)
-        VALUES ('Administrador', 'Acceso total al sistema', 'Activo');
+        EXEC sp_executesql
+            @SqlInsertRol,
+            N'@Nombre VARCHAR(50), @Descripcion VARCHAR(150)',
+            @Nombre = 'Administrador',
+            @Descripcion = 'Acceso total al sistema';
 
     IF NOT EXISTS (SELECT 1 FROM dbo.Roles WHERE Nombre = 'Ingeniero')
-        INSERT INTO dbo.Roles (Nombre, Descripcion, Estado)
-        VALUES ('Ingeniero', 'Operación técnica de campo', 'Activo');
+        EXEC sp_executesql
+            @SqlInsertRol,
+            N'@Nombre VARCHAR(50), @Descripcion VARCHAR(150)',
+            @Nombre = 'Ingeniero',
+            @Descripcion = 'Operación técnica de campo';
 
     IF NOT EXISTS (SELECT 1 FROM dbo.Roles WHERE Nombre = 'Propietario')
-        INSERT INTO dbo.Roles (Nombre, Descripcion, Estado)
-        VALUES ('Propietario', 'Consulta y gestión de sus fincas', 'Activo');
+        EXEC sp_executesql
+            @SqlInsertRol,
+            N'@Nombre VARCHAR(50), @Descripcion VARCHAR(150)',
+            @Nombre = 'Propietario',
+            @Descripcion = 'Consulta y gestión de sus fincas';
 END
 GO
 
@@ -84,34 +159,71 @@ BEGIN
 END
 GO
 
-/* 4) Asignación inicial para Administrador */
-IF OBJECT_ID('dbo.RolesPermisos', 'U') IS NOT NULL
-   AND OBJECT_ID('dbo.Roles', 'U') IS NOT NULL
+/* 4) Asignación inicial por rol */
+IF OBJECT_ID('dbo.Roles', 'U') IS NOT NULL
    AND OBJECT_ID('dbo.Permisos', 'U') IS NOT NULL
 BEGIN
-    DECLARE @IdRolAdmin int;
-    SELECT TOP 1 @IdRolAdmin = IdRol FROM dbo.Roles WHERE Nombre = 'Administrador';
+    DECLARE @TablaRolPermisos SYSNAME = CASE
+        WHEN OBJECT_ID('dbo.RolesPermisos', 'U') IS NOT NULL THEN 'dbo.RolesPermisos'
+        WHEN OBJECT_ID('dbo.RolPermisos', 'U') IS NOT NULL THEN 'dbo.RolPermisos'
+        ELSE NULL
+    END;
 
-    IF @IdRolAdmin IS NOT NULL
+    IF @TablaRolPermisos IS NULL
     BEGIN
-        INSERT INTO dbo.RolesPermisos (IdRol, IdPermiso)
-        SELECT @IdRolAdmin, p.IdPermiso
-        FROM dbo.Permisos p
-        WHERE p.Codigo IN (
-            'ADMIN_USUARIOS_VER',
-            'ADMIN_USUARIOS_CREAR',
-            'ADMIN_USUARIOS_EDITAR',
-            'ADMIN_USUARIOS_ELIMINAR',
-            'ADMIN_CLIENTES_REASIGNAR',
-            'ADMIN_PAGOS_CONFIGURAR',
-            'ADMIN_CUENTAS_VALIDAR',
-            'ADMIN_AUDITORIA_CONSULTAR'
-        )
-        AND NOT EXISTS (
-            SELECT 1 FROM dbo.RolesPermisos rp
-            WHERE rp.IdRol = @IdRolAdmin
-              AND rp.IdPermiso = p.IdPermiso
-        );
+        PRINT 'No existe tabla de relación de roles/permisos (RolesPermisos o RolPermisos).';
+        RETURN;
     END
+
+    IF OBJECT_ID('tempdb..#Asignaciones') IS NOT NULL
+        DROP TABLE #Asignaciones;
+
+    CREATE TABLE #Asignaciones
+    (
+        NombreRol NVARCHAR(50) NOT NULL,
+        CodigoPermiso NVARCHAR(100) NOT NULL
+    );
+
+    /* Administrador: todos los permisos */
+    INSERT INTO #Asignaciones (NombreRol, CodigoPermiso)
+    VALUES
+        ('Administrador', 'ADMIN_USUARIOS_VER'),
+        ('Administrador', 'ADMIN_USUARIOS_CREAR'),
+        ('Administrador', 'ADMIN_USUARIOS_EDITAR'),
+        ('Administrador', 'ADMIN_USUARIOS_ELIMINAR'),
+        ('Administrador', 'ADMIN_CLIENTES_REASIGNAR'),
+        ('Administrador', 'ADMIN_PAGOS_CONFIGURAR'),
+        ('Administrador', 'ADMIN_CUENTAS_VALIDAR'),
+        ('Administrador', 'ADMIN_AUDITORIA_CONSULTAR');
+
+    /* Ingeniero: lectura de usuarios y consulta de auditoría */
+    INSERT INTO #Asignaciones (NombreRol, CodigoPermiso)
+    VALUES
+        ('Ingeniero', 'ADMIN_USUARIOS_VER'),
+        ('Ingeniero', 'ADMIN_AUDITORIA_CONSULTAR');
+
+    /* Propietario: lectura de usuarios (mínimo para poblar pantalla) */
+    INSERT INTO #Asignaciones (NombreRol, CodigoPermiso)
+    VALUES
+        ('Propietario', 'ADMIN_USUARIOS_VER');
+
+    DECLARE @SqlAsignacion NVARCHAR(MAX) = N'
+        INSERT INTO ' + @TablaRolPermisos + N' (IdRol, IdPermiso)
+        SELECT r.IdRol, p.IdPermiso
+        FROM #Asignaciones a
+        INNER JOIN dbo.Roles r
+            ON r.Nombre = a.NombreRol
+        INNER JOIN dbo.Permisos p
+            ON p.Codigo = a.CodigoPermiso
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM ' + @TablaRolPermisos + N' rp
+            WHERE rp.IdRol = r.IdRol
+              AND rp.IdPermiso = p.IdPermiso
+        );';
+
+    EXEC sp_executesql @SqlAsignacion;
+
+    DROP TABLE #Asignaciones;
 END
 GO

--- a/scripts/sql/20260417_admin_roles_permisos_bootstrap.sql
+++ b/scripts/sql/20260417_admin_roles_permisos_bootstrap.sql
@@ -1,0 +1,92 @@
+/*
+    Script de compatibilidad para módulo de Administración (Roles y permisos)
+    Ejecutar antes de iniciar la app en ambientes existentes.
+*/
+
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+/* 1) Stored procedure: catálogo de permisos */
+CREATE OR ALTER PROCEDURE dbo.usp_Admin_ObtenerPermisos
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        p.IdPermiso,
+        p.Codigo,
+        p.Nombre,
+        p.Descripcion
+    FROM dbo.Permisos p
+    ORDER BY p.Codigo;
+END;
+GO
+
+/* 2) Stored procedure: guardar permisos por rol (compatible RolPermisos/RolesPermisos) */
+CREATE OR ALTER PROCEDURE dbo.usp_Admin_GuardarPermisosRol
+    @IdRol INT,
+    @CodigosPermisoCsv NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @IdRol IS NULL OR @IdRol <= 0
+    BEGIN
+        RAISERROR('Debe indicar un IdRol válido.', 16, 1);
+        RETURN;
+    END;
+
+    IF OBJECT_ID('dbo.Permisos', 'U') IS NULL
+    BEGIN
+        RAISERROR('No existe la tabla dbo.Permisos.', 16, 1);
+        RETURN;
+    END;
+
+    DECLARE @TablaRolPermisos SYSNAME = CASE
+        WHEN OBJECT_ID('dbo.RolesPermisos', 'U') IS NOT NULL THEN 'dbo.RolesPermisos'
+        WHEN OBJECT_ID('dbo.RolPermisos', 'U') IS NOT NULL THEN 'dbo.RolPermisos'
+        ELSE NULL
+    END;
+
+    IF @TablaRolPermisos IS NULL
+    BEGIN
+        RAISERROR('No existe tabla de relación de roles/permisos (RolesPermisos o RolPermisos).', 16, 1);
+        RETURN;
+    END;
+
+    BEGIN TRY
+        BEGIN TRANSACTION;
+
+        DECLARE @SqlDelete NVARCHAR(MAX) = N'DELETE FROM ' + @TablaRolPermisos + N' WHERE IdRol = @IdRol;';
+        EXEC sp_executesql @SqlDelete, N'@IdRol INT', @IdRol = @IdRol;
+
+        IF OBJECT_ID('tempdb..#CodigosPermiso') IS NOT NULL
+            DROP TABLE #CodigosPermiso;
+
+        CREATE TABLE #CodigosPermiso (Codigo NVARCHAR(100) NOT NULL PRIMARY KEY);
+
+        IF @CodigosPermisoCsv IS NOT NULL AND LEN(LTRIM(RTRIM(@CodigosPermisoCsv))) > 0
+        BEGIN
+            INSERT INTO #CodigosPermiso (Codigo)
+            SELECT DISTINCT LTRIM(RTRIM(value))
+            FROM STRING_SPLIT(@CodigosPermisoCsv, ',')
+            WHERE LTRIM(RTRIM(value)) <> '';
+
+            DECLARE @SqlInsert NVARCHAR(MAX) = N'
+                INSERT INTO ' + @TablaRolPermisos + N' (IdRol, IdPermiso)
+                SELECT @IdRol, p.IdPermiso
+                FROM #CodigosPermiso c
+                INNER JOIN dbo.Permisos p ON p.Codigo = c.Codigo;';
+
+            EXEC sp_executesql @SqlInsert, N'@IdRol INT', @IdRol = @IdRol;
+        END;
+
+        COMMIT TRANSACTION;
+    END TRY
+    BEGIN CATCH
+        IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION;
+        THROW;
+    END CATCH;
+END;
+GO

--- a/scripts/sql/20260417_admin_roles_permisos_sprocs.sql
+++ b/scripts/sql/20260417_admin_roles_permisos_sprocs.sql
@@ -36,11 +36,22 @@ BEGIN
         THROW 50001, 'El IdRol debe ser mayor a cero.', 1;
     END
 
+    DECLARE @TablaRolPermisos SYSNAME = CASE
+        WHEN OBJECT_ID('dbo.RolesPermisos', 'U') IS NOT NULL THEN 'dbo.RolesPermisos'
+        WHEN OBJECT_ID('dbo.RolPermisos', 'U') IS NOT NULL THEN 'dbo.RolPermisos'
+        ELSE NULL
+    END;
+
+    IF @TablaRolPermisos IS NULL
+    BEGIN
+        THROW 50002, 'No existe tabla de relación de roles/permisos (RolesPermisos o RolPermisos).', 1;
+    END
+
     BEGIN TRY
         BEGIN TRANSACTION;
 
-        DELETE FROM dbo.RolesPermisos
-        WHERE IdRol = @IdRol;
+        DECLARE @SqlDelete nvarchar(max) = N'DELETE FROM ' + @TablaRolPermisos + N' WHERE IdRol = @IdRol;';
+        EXEC sp_executesql @SqlDelete, N'@IdRol int', @IdRol = @IdRol;
 
         ;WITH Codigos AS
         (
@@ -48,10 +59,18 @@ BEGIN
             FROM STRING_SPLIT(COALESCE(@CodigosPermisoCsv, ''), ',')
             WHERE LTRIM(RTRIM(value)) <> ''
         )
-        INSERT INTO dbo.RolesPermisos (IdRol, IdPermiso)
-        SELECT @IdRol, p.IdPermiso
-        FROM Codigos c
-        INNER JOIN dbo.Permisos p ON p.Codigo = c.Codigo;
+        SELECT c.Codigo
+        INTO #CodigosPermiso
+        FROM Codigos c;
+
+        DECLARE @SqlInsert nvarchar(max) = N'
+            INSERT INTO ' + @TablaRolPermisos + N' (IdRol, IdPermiso)
+            SELECT @IdRol, p.IdPermiso
+            FROM #CodigosPermiso c
+            INNER JOIN dbo.Permisos p ON p.Codigo = c.Codigo;';
+        EXEC sp_executesql @SqlInsert, N'@IdRol int', @IdRol = @IdRol;
+
+        DROP TABLE #CodigosPermiso;
 
         COMMIT TRANSACTION;
     END TRY


### PR DESCRIPTION
### Motivation
- Support databases with different schema variants (table named `RolesPermisos` or `RolPermisos`, and optional `Estado`/`Activo` columns in `Roles`) so the admin module works across existing environments. 
- Ensure a safe, idempotent seed that enforces a single active payment configuration and inserts base roles and permissions without breaking on schema differences. 

### Description
- Update stored procedure `dbo.usp_Admin_GuardarPermisosRol` to detect the roles-permissions table dynamically and use dynamic SQL and a temp table for inserting permissions, making it compatible with either `dbo.RolesPermisos` or `dbo.RolPermisos`.
- Add `scripts/sql/20260417_admin_roles_permisos_bootstrap.sql` providing compatibility stored procedures (`usp_Admin_ObtenerPermisos`, `usp_Admin_GuardarPermisosRol`) for environments that need them before app startup.
- Enhance seed script `scripts/sql/20260417_admin_config_pagos_y_roles_seed.sql` to: ensure only one active `ConfiguracionesPago` row (using filtered unique index and cleaning duplicates), create a minimal payment configuration if table is empty, insert base roles using dynamic SQL depending on whether `Roles` has `Estado` or `Activo`, insert base permissions, and assign initial permissions per role using a temp table and dynamic target table detection.
- Modify `BaseDatos/..._sprocs.sql` to mirror the updated stored procedure behavior (dynamic target table and temp-table based insert).
- Refactor `PSA.DataAccess/DAO/RolPermisoDAO.cs` to detect the roles-permissions table and `Roles` column metadata at runtime, build the `Activo` expression depending on whether `Estado` (string) or `Activo` (bit) exists, use dynamic table names for delete/insert in `GuardarPermisosRolAsync`, and centralize helpers: `ObtenerMetadataColumnaAsync`, `ObtenerExpresionActivo`, `ConvertirEstadoParametro`, `EsTipoBooleano`, `ObtenerTablaRolPermisosAsync`, and `ExisteTablaAsync`.
- Tidy up permission retrieval and fallback logic in `ObtenerPermisosAsync` and remove older schema assumptions.
- Minor UI change in `_BarraLateral.cshtml` to simplify administrator menu (removed two specific report links in favor of consolidated `Reportes` entry).

### Testing
- Performed `dotnet build` on the solution to validate compile-time changes and refactor, which completed successfully.
- Ran unit/integration test suite with `dotnet test` (data-access related tests that mock DB interactions), and all tests passed.
- Validated SQL scripts locally against a copy of the database schema variations (with and without `Estado`/`Activo`, and with both `RolesPermisos` and `RolPermisos`) to confirm stored procedures and seed logic run without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27c6329b4832da19b03e40044728a)