### PR TITLE
Resolve merge conflict and fix compilation in RolPermisoDAO.ObtenerRolesAsync

### DIFF
--- a/PSA.DataAccess/DAO/RolPermisoDAO.cs
+++ b/PSA.DataAccess/DAO/RolPermisoDAO.cs
@@ -178,20 +178,14 @@ ORDER BY p.Codigo;";
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-<<<<<<< HEAD
         var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
         var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
         var expresionActivo = ObtenerExpresionActivo("dbo.Roles", metadataEstado, metadataActivo);
         var sql = $@"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
-WHERE {expresionActivo} = CAST(1 AS bit)
-=======
-        const string sql = @"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
->>>>>>> origin/codex/fix-compilation-errors-in-rolpermisodao-ipmjam
-ORDER BY Nombre;";
+	SELECT IdRol, Nombre, Descripcion
+	FROM dbo.Roles
+	WHERE {expresionActivo} = CAST(1 AS bit)
+	ORDER BY Nombre;";
 
         var roles = new List<RolDTO>();
 


### PR DESCRIPTION
### Motivation

- Remove leftover merge conflict markers and restore a compilable implementation of `ObtenerRolesAsync` that applies the dynamic active-column filter. 
- Ensure the `Roles` query uses the metadata-driven active expression so role selection respects the database schema changes.

### Description

- Eliminated merge conflict markers and reintroduced metadata retrieval with `ObtenerMetadataColumnaAsync` for the `Roles` table. 
- Replaced the invalid `const string` query with an interpolated `var sql = $@"...{expresionActivo}..."` so the computed `expresionActivo` can be injected into the SQL. 
- Restored the `SELECT IdRol, Nombre, Descripcion` query with the `WHERE {expresionActivo} = CAST(1 AS bit)` filter and `ORDER BY Nombre`, and preserved the reader-to-`RolDTO` mapping.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c76b9b3c832d8af509069f54ad5b)