### PR TITLE
Fix RolPermisoDAO merge conflict and add model binding for CrearRol

### DIFF
--- a/PSA.DataAccess/DAO/RolPermisoDAO.cs
+++ b/PSA.DataAccess/DAO/RolPermisoDAO.cs
@@ -178,20 +178,14 @@ ORDER BY p.Codigo;";
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-<<<<<<< HEAD
         var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
         var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
         var expresionActivo = ObtenerExpresionActivo("dbo.Roles", metadataEstado, metadataActivo);
         var sql = $@"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
-WHERE {expresionActivo} = CAST(1 AS bit)
-=======
-        const string sql = @"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
->>>>>>> origin/codex/fix-compilation-errors-in-rolpermisodao-ipmjam
-ORDER BY Nombre;";
+	SELECT IdRol, Nombre, Descripcion
+	FROM dbo.Roles
+	WHERE {expresionActivo} = CAST(1 AS bit)
+	ORDER BY Nombre;";
 
         var roles = new List<RolDTO>();
 

--- a/PSA.WebApp/Controllers/AdministracionController.cs
+++ b/PSA.WebApp/Controllers/AdministracionController.cs
@@ -172,7 +172,7 @@ namespace PSA.WebApp.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> CrearRol(CrearRolDTO model)
+        public async Task<IActionResult> CrearRol([Bind(Prefix = "NuevoRol")] CrearRolDTO model)
         {
             if (!ModelState.IsValid)
             {


### PR DESCRIPTION
### Motivation
- Remove leftover merge-conflict artifacts in `PSA.DataAccess/DAO/RolPermisoDAO.cs` that caused compilation errors and ensure active-role filtering is applied correctly. 
- Ensure the `CrearRol` POST action in `PSA.WebApp/Controllers/AdministracionController.cs` binds the nested `NuevoRol` form data to the action parameter.

### Description
- Resolved merge conflict in `RolPermisoDAO.cs` by removing conflict markers and reinstating the `sql` string that uses `expresionActivo` with `WHERE {expresionActivo} = CAST(1 AS bit)` and `ORDER BY Nombre;`.
- Added `[Bind(Prefix = "NuevoRol")]` to the `CrearRol` action method parameter to correctly bind the posted nested `CrearRolDTO` model.
- Kept existing reader/result mapping logic unchanged while restoring valid compilable code.

### Testing
- Ran `dotnet build` for the solution and the build completed successfully.
- Executed `dotnet test` for the test projects and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c76b9b3c832d8af509069f54ad5b)