### PR TITLE
Add payments module: plan generation, bank account workflows, DB/SP/DAO/Views

### DIFF
--- a/BaseDatos/01_creacion_bd_y_tablas.sql
+++ b/BaseDatos/01_creacion_bd_y_tablas.sql
@@ -41,6 +41,9 @@ IF OBJECT_ID(N'dbo.CatalogoFincaValores', N'U') IS NOT NULL DROP TABLE dbo.Catal
 IF OBJECT_ID(N'dbo.TransaccionesPago', N'U') IS NOT NULL DROP TABLE dbo.TransaccionesPago;
 IF OBJECT_ID(N'dbo.CuotasPago', N'U') IS NOT NULL DROP TABLE dbo.CuotasPago;
 IF OBJECT_ID(N'dbo.PlanesPago', N'U') IS NOT NULL DROP TABLE dbo.PlanesPago;
+IF OBJECT_ID(N'dbo.RolesPermisos', N'U') IS NOT NULL DROP TABLE dbo.RolesPermisos;
+IF OBJECT_ID(N'dbo.RolPermisos', N'U') IS NOT NULL DROP TABLE dbo.RolPermisos;
+IF OBJECT_ID(N'dbo.Permisos', N'U') IS NOT NULL DROP TABLE dbo.Permisos;
 IF OBJECT_ID(N'dbo.ConfiguracionPagoDetalle', N'U') IS NOT NULL DROP TABLE dbo.ConfiguracionPagoDetalle;
 IF OBJECT_ID(N'dbo.ConfiguracionesPago', N'U') IS NOT NULL DROP TABLE dbo.ConfiguracionesPago;
 IF OBJECT_ID(N'dbo.CuentasBancarias', N'U') IS NOT NULL DROP TABLE dbo.CuentasBancarias;
@@ -83,7 +86,22 @@ CREATE TABLE dbo.Roles
 GO
 
 /* =========================================
-   2. Usuarios
+   2. Permisos
+   ========================================= */
+CREATE TABLE dbo.Permisos
+(
+    IdPermiso       INT IDENTITY(1,1) NOT NULL,
+    Codigo          NVARCHAR(100) NOT NULL,
+    Nombre          NVARCHAR(150) NOT NULL,
+    Descripcion     NVARCHAR(300) NULL,
+    Activo          BIT NOT NULL CONSTRAINT DF_Permisos_Activo DEFAULT (1),
+    CONSTRAINT PK_Permisos PRIMARY KEY (IdPermiso),
+    CONSTRAINT UQ_Permisos_Codigo UNIQUE (Codigo)
+);
+GO
+
+/* =========================================
+   3. Usuarios
    ========================================= */
 CREATE TABLE dbo.Usuarios
 (
@@ -107,7 +125,20 @@ ALTER COLUMN PasswordHash NVARCHAR(500) NULL;
 GO
 
 /* =========================================
-   3. TokensRecuperacion
+   4. RolesPermisos
+   ========================================= */
+CREATE TABLE dbo.RolesPermisos
+(
+    IdRol           INT NOT NULL,
+    IdPermiso       INT NOT NULL,
+    CONSTRAINT PK_RolesPermisos PRIMARY KEY (IdRol, IdPermiso),
+    CONSTRAINT FK_RolesPermisos_Roles FOREIGN KEY (IdRol) REFERENCES dbo.Roles(IdRol),
+    CONSTRAINT FK_RolesPermisos_Permisos FOREIGN KEY (IdPermiso) REFERENCES dbo.Permisos(IdPermiso)
+);
+GO
+
+/* =========================================
+   5. TokensRecuperacion
    ========================================= */
 CREATE TABLE dbo.TokensRecuperacion
 (
@@ -274,7 +305,7 @@ CREATE TABLE dbo.PlanesPago
     IdFinca                     INT NOT NULL,
     IdEvaluacion                INT NOT NULL,
     IdConfiguracionPago         INT NOT NULL,
-    IdCuentaBancaria            INT NOT NULL,
+    IdCuentaBancaria            INT NULL,
     Anio                        INT NOT NULL,
     MontoBaseMensual            DECIMAL(10,2) NOT NULL,
     PorcentajeAjusteTotal       DECIMAL(5,2) NOT NULL,
@@ -293,7 +324,37 @@ CREATE TABLE dbo.PlanesPago
 GO
 
 /* =========================================
-   10. CuotasPago
+   10. PlanesPagoDetalleCalculo
+   ========================================= */
+CREATE TABLE dbo.PlanesPagoDetalleCalculo
+(
+    IdDetalleCalculo            INT IDENTITY(1,1) NOT NULL,
+    IdPlanPago                  INT NOT NULL,
+    HectareasAprobadas          DECIMAL(12,2) NOT NULL,
+    PrecioBasePorHectarea       DECIMAL(10,2) NOT NULL,
+    PorcentajeVegetacion        DECIMAL(5,2) NOT NULL,
+    PorcentajeHidrico           DECIMAL(5,2) NOT NULL,
+    PorcentajeNacientes         DECIMAL(5,2) NOT NULL,
+    PorcentajePendiente         DECIMAL(5,2) NOT NULL,
+    PorcentajeTotalAntesTope    DECIMAL(5,2) NOT NULL,
+    PorcentajeTopeAplicado      DECIMAL(5,2) NOT NULL,
+    PorcentajeTotalAplicado     DECIMAL(5,2) NOT NULL,
+    MontoBaseMensual            DECIMAL(10,2) NOT NULL,
+    MontoAjusteMensual          DECIMAL(10,2) NOT NULL,
+    MontoFinalMensual           DECIMAL(10,2) NOT NULL,
+    VegetacionFinal             VARCHAR(100) NOT NULL,
+    TieneRecursosHidricosFinal  BIT NOT NULL,
+    CantidadNacientesFinal      INT NOT NULL,
+    PendienteFinal              VARCHAR(50) NOT NULL,
+    FechaCalculo                DATETIME2 NOT NULL CONSTRAINT DF_PlanesPagoDetalleCalculo_FechaCalculo DEFAULT (SYSDATETIME()),
+    CONSTRAINT PK_PlanesPagoDetalleCalculo PRIMARY KEY (IdDetalleCalculo),
+    CONSTRAINT FK_PlanesPagoDetalleCalculo_PlanesPago FOREIGN KEY (IdPlanPago) REFERENCES dbo.PlanesPago(IdPlanPago),
+    CONSTRAINT UQ_PlanesPagoDetalleCalculo_IdPlanPago UNIQUE (IdPlanPago)
+);
+GO
+
+/* =========================================
+   11. CuotasPago
    ========================================= */
 CREATE TABLE dbo.CuotasPago
 (
@@ -315,7 +376,7 @@ CREATE TABLE dbo.CuotasPago
 GO
 
 /* =========================================
-   11. TransaccionesPago (opcional para MVP)
+   12. TransaccionesPago (opcional para MVP)
    ========================================= */
 CREATE TABLE dbo.TransaccionesPago
 (
@@ -334,7 +395,7 @@ CREATE TABLE dbo.TransaccionesPago
 GO
 
 /* =========================================
-   12. AuditoriaLog
+   13. AuditoriaLog
    ========================================= */
 CREATE TABLE dbo.AuditoriaLog
 (
@@ -355,7 +416,7 @@ CREATE TABLE dbo.AuditoriaLog
 GO
 
 /* =========================================
-   13. FincaEvidencias
+   14. FincaEvidencias
    ========================================= */
 CREATE TABLE dbo.FincaEvidencias
 (

--- a/BaseDatos/04_creacion_stored_procedures.sql
+++ b/BaseDatos/04_creacion_stored_procedures.sql
@@ -821,3 +821,463 @@ BEGIN
     SELECT @@ROWCOUNT AS FilasAfectadas;
 END;
 GO
+
+/* =========================================
+   Pagos - Simulación/generación de plan e historial del dueño
+   ========================================= */
+CREATE OR ALTER PROCEDURE dbo.SP_Pagos_GenerarPlanPago
+    @IdFinca INT,
+    @Anio INT,
+    @Simular BIT = 0,
+    @Silencioso BIT = 0
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @IdFinca <= 0
+    BEGIN
+        IF @Silencioso = 1 RETURN;
+        THROW 57001, 'La finca es obligatoria para generar el plan.', 1;
+    END
+
+    IF @Anio < YEAR(SYSDATETIME())
+    BEGIN
+        IF @Silencioso = 1 RETURN;
+        THROW 57002, 'El año del plan debe ser actual o futuro.', 1;
+    END
+
+    DECLARE
+        @IdEvaluacion INT,
+        @IdPropietario INT,
+        @IdConfiguracionPago INT,
+        @IdCuentaBancaria INT,
+        @HectareasAprobadas DECIMAL(12,2),
+        @VegetacionFinal VARCHAR(100),
+        @TieneRecursosHidricosFinal BIT,
+        @CantidadNacientesFinal INT,
+        @PendienteFinal VARCHAR(50),
+        @PrecioBasePorHectarea DECIMAL(10,2),
+        @TopePorcentajeAjuste DECIMAL(5,2),
+        @PorcentajeVegetacion DECIMAL(5,2) = 0,
+        @PorcentajeHidrico DECIMAL(5,2) = 0,
+        @PorcentajeNacientes DECIMAL(5,2) = 0,
+        @PorcentajePendiente DECIMAL(5,2) = 0,
+        @PorcentajePorNaciente DECIMAL(5,2) = 0,
+        @PorcentajeTotalAntesTope DECIMAL(8,2) = 0,
+        @PorcentajeTotalAplicado DECIMAL(8,2) = 0,
+        @MontoBaseMensual DECIMAL(12,2) = 0,
+        @MontoAjusteMensual DECIMAL(12,2) = 0,
+        @MontoFinalMensual DECIMAL(12,2) = 0,
+        @IdPlanPago INT = NULL,
+        @Mes INT = 1;
+
+    SELECT TOP 1
+        @IdPropietario = f.IdPropietario,
+        @IdEvaluacion = e.IdEvaluacion,
+        @HectareasAprobadas = COALESCE(e.HectareasAjustadas, f.Hectareas),
+        @VegetacionFinal = COALESCE(NULLIF(e.VegetacionAjustada, ''), f.Vegetacion),
+        @TieneRecursosHidricosFinal = COALESCE(e.RecursosHidricosAjustado, f.TieneRecursosHidricos),
+        @CantidadNacientesFinal = COALESCE(f.CantidadNacientes, 0),
+        @PendienteFinal = COALESCE(NULLIF(e.PendienteAjustada, ''), f.Pendiente)
+    FROM dbo.Fincas f
+    INNER JOIN dbo.EvaluacionesTecnicas e ON e.IdFinca = f.IdFinca
+    WHERE f.IdFinca = @IdFinca
+      AND f.EstadoFinca = 'Aprobada'
+      AND e.DecisionTecnica = 'Califica'
+      AND e.EstadoEvaluacion = 'Evaluada – Califica'
+    ORDER BY e.IdEvaluacion DESC;
+
+    IF @IdEvaluacion IS NULL
+    BEGIN
+        IF @Silencioso = 1 RETURN;
+        THROW 57003, 'La finca debe estar aprobada y calificada para generar plan de pago.', 1;
+    END
+
+    SELECT TOP 1
+        @IdCuentaBancaria = cb.IdCuentaBancaria
+    FROM dbo.CuentasBancarias cb
+    WHERE cb.IdUsuario = @IdPropietario
+      AND cb.EstadoValidacion = 'Validada'
+      AND cb.Activa = 1
+    ORDER BY cb.FechaRegistro DESC, cb.IdCuentaBancaria DESC;
+
+    SELECT TOP 1
+        @IdConfiguracionPago = cp.IdConfiguracionPago,
+        @PrecioBasePorHectarea = cp.PrecioBasePorHectarea,
+        @TopePorcentajeAjuste = cp.TopePorcentajeAjuste
+    FROM dbo.ConfiguracionesPago cp
+    WHERE cp.Activa = 1
+      AND cp.FechaVigenciaDesde <= DATEFROMPARTS(@Anio, 1, 1)
+      AND (cp.FechaVigenciaHasta IS NULL OR cp.FechaVigenciaHasta >= DATEFROMPARTS(@Anio, 1, 1))
+    ORDER BY cp.FechaVigenciaDesde DESC, cp.IdConfiguracionPago DESC;
+
+    IF @IdConfiguracionPago IS NULL
+    BEGIN
+        IF @Silencioso = 1 RETURN;
+        THROW 57005, 'No existe configuración de pago activa para el año solicitado.', 1;
+    END
+
+    SELECT @PorcentajeVegetacion = COALESCE(d.PorcentajeAjuste, 0)
+    FROM dbo.ConfiguracionPagoDetalle d
+    WHERE d.IdConfiguracionPago = @IdConfiguracionPago
+      AND d.TipoFactor = 'Vegetacion'
+      AND d.ValorFactor = @VegetacionFinal;
+
+    SELECT @PorcentajeHidrico = CASE WHEN @TieneRecursosHidricosFinal = 1 THEN COALESCE(d.PorcentajeAjuste, 0) ELSE 0 END
+    FROM dbo.ConfiguracionPagoDetalle d
+    WHERE d.IdConfiguracionPago = @IdConfiguracionPago
+      AND d.TipoFactor = 'RecursosHidricos'
+      AND d.ValorFactor = 'Si';
+
+    SELECT @PorcentajePorNaciente = COALESCE(d.PorcentajeAjuste, 0)
+    FROM dbo.ConfiguracionPagoDetalle d
+    WHERE d.IdConfiguracionPago = @IdConfiguracionPago
+      AND d.TipoFactor = 'RecursosHidricos'
+      AND d.ValorFactor = 'Naciente';
+
+    SELECT @PorcentajePendiente = COALESCE(d.PorcentajeAjuste, 0)
+    FROM dbo.ConfiguracionPagoDetalle d
+    WHERE d.IdConfiguracionPago = @IdConfiguracionPago
+      AND d.TipoFactor = 'Pendiente'
+      AND d.ValorFactor = @PendienteFinal;
+
+    SET @PorcentajeNacientes = COALESCE(@CantidadNacientesFinal, 0) * COALESCE(@PorcentajePorNaciente, 0);
+    SET @PorcentajeTotalAntesTope = COALESCE(@PorcentajeVegetacion, 0) + COALESCE(@PorcentajeHidrico, 0) + COALESCE(@PorcentajeNacientes, 0) + COALESCE(@PorcentajePendiente, 0);
+    SET @PorcentajeTotalAplicado = CASE WHEN @PorcentajeTotalAntesTope > @TopePorcentajeAjuste THEN @TopePorcentajeAjuste ELSE @PorcentajeTotalAntesTope END;
+
+    SET @MontoBaseMensual = ROUND(COALESCE(@HectareasAprobadas, 0) * COALESCE(@PrecioBasePorHectarea, 0), 2);
+    SET @MontoAjusteMensual = ROUND(@MontoBaseMensual * (@PorcentajeTotalAplicado / 100.0), 2);
+    SET @MontoFinalMensual = ROUND(@MontoBaseMensual + @MontoAjusteMensual, 2);
+
+    IF @Simular = 0
+    BEGIN
+        SELECT TOP 1
+            @IdPlanPago = p.IdPlanPago
+        FROM dbo.PlanesPago p
+        WHERE p.IdFinca = @IdFinca
+          AND p.Anio = @Anio
+          AND p.EstadoPlan = 'Activo'
+        ORDER BY p.IdPlanPago DESC;
+
+        IF @IdPlanPago IS NULL
+        BEGIN
+            INSERT INTO dbo.PlanesPago
+            (
+                IdFinca,
+                IdEvaluacion,
+                IdConfiguracionPago,
+                IdCuentaBancaria,
+                Anio,
+                MontoBaseMensual,
+                PorcentajeAjusteTotal,
+                MontoMensualCalculado,
+                EstadoPlan
+            )
+            VALUES
+            (
+                @IdFinca,
+                @IdEvaluacion,
+                @IdConfiguracionPago,
+                @IdCuentaBancaria,
+                @Anio,
+                @MontoBaseMensual,
+                @PorcentajeTotalAplicado,
+                @MontoFinalMensual,
+                'Activo'
+            );
+
+            SET @IdPlanPago = CAST(SCOPE_IDENTITY() AS INT);
+        END
+        ELSE
+        BEGIN
+            UPDATE dbo.PlanesPago
+            SET IdEvaluacion = @IdEvaluacion,
+                IdConfiguracionPago = @IdConfiguracionPago,
+                IdCuentaBancaria = @IdCuentaBancaria,
+                MontoBaseMensual = @MontoBaseMensual,
+                PorcentajeAjusteTotal = @PorcentajeTotalAplicado,
+                MontoMensualCalculado = @MontoFinalMensual
+            WHERE IdPlanPago = @IdPlanPago;
+        END
+
+        IF EXISTS (SELECT 1 FROM dbo.PlanesPagoDetalleCalculo WHERE IdPlanPago = @IdPlanPago)
+        BEGIN
+            UPDATE dbo.PlanesPagoDetalleCalculo
+            SET HectareasAprobadas = @HectareasAprobadas,
+                PrecioBasePorHectarea = @PrecioBasePorHectarea,
+                PorcentajeVegetacion = @PorcentajeVegetacion,
+                PorcentajeHidrico = @PorcentajeHidrico,
+                PorcentajeNacientes = @PorcentajeNacientes,
+                PorcentajePendiente = @PorcentajePendiente,
+                PorcentajeTotalAntesTope = @PorcentajeTotalAntesTope,
+                PorcentajeTopeAplicado = @TopePorcentajeAjuste,
+                PorcentajeTotalAplicado = @PorcentajeTotalAplicado,
+                MontoBaseMensual = @MontoBaseMensual,
+                MontoAjusteMensual = @MontoAjusteMensual,
+                MontoFinalMensual = @MontoFinalMensual,
+                VegetacionFinal = @VegetacionFinal,
+                TieneRecursosHidricosFinal = @TieneRecursosHidricosFinal,
+                CantidadNacientesFinal = @CantidadNacientesFinal,
+                PendienteFinal = @PendienteFinal
+            WHERE IdPlanPago = @IdPlanPago;
+        END
+        ELSE
+        BEGIN
+            INSERT INTO dbo.PlanesPagoDetalleCalculo
+            (
+                IdPlanPago,
+                HectareasAprobadas,
+                PrecioBasePorHectarea,
+                PorcentajeVegetacion,
+                PorcentajeHidrico,
+                PorcentajeNacientes,
+                PorcentajePendiente,
+                PorcentajeTotalAntesTope,
+                PorcentajeTopeAplicado,
+                PorcentajeTotalAplicado,
+                MontoBaseMensual,
+                MontoAjusteMensual,
+                MontoFinalMensual,
+                VegetacionFinal,
+                TieneRecursosHidricosFinal,
+                CantidadNacientesFinal,
+                PendienteFinal
+            )
+            VALUES
+            (
+                @IdPlanPago,
+                @HectareasAprobadas,
+                @PrecioBasePorHectarea,
+                @PorcentajeVegetacion,
+                @PorcentajeHidrico,
+                @PorcentajeNacientes,
+                @PorcentajePendiente,
+                @PorcentajeTotalAntesTope,
+                @TopePorcentajeAjuste,
+                @PorcentajeTotalAplicado,
+                @MontoBaseMensual,
+                @MontoAjusteMensual,
+                @MontoFinalMensual,
+                @VegetacionFinal,
+                @TieneRecursosHidricosFinal,
+                @CantidadNacientesFinal,
+                @PendienteFinal
+            );
+        END
+
+        DELETE FROM dbo.CuotasPago WHERE IdPlanPago = @IdPlanPago;
+
+        WHILE @Mes <= 12
+        BEGIN
+            INSERT INTO dbo.CuotasPago
+            (
+                IdPlanPago,
+                Mes,
+                FechaProgramada,
+                MontoProgramado,
+                MontoPendiente,
+                EstadoCuota
+            )
+            VALUES
+            (
+                @IdPlanPago,
+                @Mes,
+                DATEFROMPARTS(@Anio, @Mes, 1),
+                @MontoFinalMensual,
+                @MontoFinalMensual,
+                'Programada'
+            );
+
+            SET @Mes = @Mes + 1;
+        END
+    END
+
+    SELECT
+        ISNULL(@IdPlanPago, 0) AS IdPlanPago,
+        @IdFinca AS IdFinca,
+        f.NombreFinca,
+        @Anio AS Anio,
+        @IdConfiguracionPago AS IdConfiguracionPago,
+        @IdCuentaBancaria AS IdCuentaBancaria,
+        @MontoBaseMensual AS MontoBaseMensual,
+        @PorcentajeTotalAplicado AS PorcentajeAjusteTotal,
+        @MontoFinalMensual AS MontoMensualCalculado,
+        CAST(CASE WHEN @Simular = 1 THEN 'Simulado' ELSE 'Activo' END AS VARCHAR(20)) AS EstadoPlan,
+        SYSDATETIME() AS FechaGeneracion,
+        @HectareasAprobadas AS HectareasAprobadas,
+        @PrecioBasePorHectarea AS PrecioBasePorHectarea,
+        @PorcentajeVegetacion AS PorcentajeVegetacion,
+        @PorcentajeHidrico AS PorcentajeHidrico,
+        @PorcentajeNacientes AS PorcentajeNacientes,
+        @PorcentajePendiente AS PorcentajePendiente,
+        @PorcentajeTotalAntesTope AS PorcentajeTotalAntesTope,
+        @TopePorcentajeAjuste AS PorcentajeTopeAplicado,
+        @PorcentajeTotalAplicado AS PorcentajeTotalAplicado,
+        @MontoAjusteMensual AS MontoAjusteMensual,
+        @MontoFinalMensual AS MontoFinalMensual,
+        @VegetacionFinal AS VegetacionFinal,
+        @TieneRecursosHidricosFinal AS TieneRecursosHidricosFinal,
+        @CantidadNacientesFinal AS CantidadNacientesFinal,
+        @PendienteFinal AS PendienteFinal
+    FROM dbo.Fincas f
+    WHERE f.IdFinca = @IdFinca;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Pagos_ObtenerHistorialDueno
+    @IdPropietario INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        pp.IdPlanPago,
+        cp.IdCuotaPago,
+        pp.IdFinca,
+        f.NombreFinca,
+        pp.Anio,
+        cp.Mes,
+        cp.FechaProgramada,
+        cp.MontoProgramado,
+        cp.MontoPendiente,
+        cp.EstadoCuota,
+        cp.FechaPago
+    FROM dbo.PlanesPago pp
+    INNER JOIN dbo.CuotasPago cp ON cp.IdPlanPago = pp.IdPlanPago
+    INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+    WHERE f.IdPropietario = @IdPropietario
+    ORDER BY pp.Anio DESC, cp.Mes DESC, cp.IdCuotaPago DESC;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Pagos_ObtenerPlanesDueno
+    @IdPropietario INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        pp.IdPlanPago,
+        pp.IdFinca,
+        f.NombreFinca,
+        pp.Anio,
+        pp.MontoMensualCalculado,
+        CAST(pp.MontoMensualCalculado * 12 AS DECIMAL(12,2)) AS MontoAnualEstimado,
+        pp.EstadoPlan,
+        pp.IdCuentaBancaria
+    FROM dbo.PlanesPago pp
+    INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+    WHERE f.IdPropietario = @IdPropietario
+    ORDER BY pp.Anio DESC, pp.IdPlanPago DESC;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Pagos_ObtenerCuentasBancariasDueno
+    @IdUsuario INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        cb.IdCuentaBancaria,
+        cb.Banco,
+        cb.NumeroCuenta,
+        cb.TipoCuenta,
+        cb.Titular,
+        cb.EstadoValidacion,
+        cb.Activa,
+        cb.FechaRegistro
+    FROM dbo.CuentasBancarias cb
+    WHERE cb.IdUsuario = @IdUsuario
+    ORDER BY cb.FechaRegistro DESC, cb.IdCuentaBancaria DESC;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Pagos_RegistrarCuentaBancariaDueno
+    @IdUsuario INT,
+    @Banco VARCHAR(100),
+    @NumeroCuenta VARCHAR(50),
+    @TipoCuenta VARCHAR(30),
+    @Titular VARCHAR(150)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @IdUsuario <= 0
+        THROW 57006, 'Debe indicar un usuario válido.', 1;
+
+    IF LTRIM(RTRIM(ISNULL(@Banco, ''))) = ''
+        THROW 57007, 'Debe indicar el banco.', 1;
+
+    IF LTRIM(RTRIM(ISNULL(@NumeroCuenta, ''))) = ''
+        THROW 57008, 'Debe indicar el número de cuenta.', 1;
+
+    IF LTRIM(RTRIM(ISNULL(@TipoCuenta, ''))) = ''
+        THROW 57009, 'Debe indicar el tipo de cuenta.', 1;
+
+    IF LTRIM(RTRIM(ISNULL(@Titular, ''))) = ''
+        THROW 57010, 'Debe indicar el titular de la cuenta.', 1;
+
+    INSERT INTO dbo.CuentasBancarias
+    (
+        IdUsuario,
+        Banco,
+        NumeroCuenta,
+        TipoCuenta,
+        Titular,
+        EstadoValidacion,
+        Activa
+    )
+    VALUES
+    (
+        @IdUsuario,
+        @Banco,
+        @NumeroCuenta,
+        @TipoCuenta,
+        @Titular,
+        'Pendiente',
+        0
+    );
+
+    SELECT CAST(SCOPE_IDENTITY() AS INT) AS IdCuentaBancaria;
+END;
+GO
+
+CREATE OR ALTER PROCEDURE dbo.SP_Pagos_AsociarCuentaPlan
+    @IdPlanPago INT,
+    @IdUsuario INT,
+    @IdCuentaBancaria INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @IdPlanPago <= 0
+        THROW 57011, 'Debe indicar un plan de pago válido.', 1;
+
+    IF @IdUsuario <= 0
+        THROW 57012, 'Debe indicar un usuario válido.', 1;
+
+    IF @IdCuentaBancaria <= 0
+        THROW 57013, 'Debe indicar una cuenta bancaria válida.', 1;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM dbo.CuentasBancarias cb
+        WHERE cb.IdCuentaBancaria = @IdCuentaBancaria
+          AND cb.IdUsuario = @IdUsuario
+          AND cb.EstadoValidacion = 'Validada'
+          AND cb.Activa = 1
+    )
+        THROW 57014, 'La cuenta bancaria no pertenece al dueño o no está validada/activa.', 1;
+
+    UPDATE pp
+    SET pp.IdCuentaBancaria = @IdCuentaBancaria
+    FROM dbo.PlanesPago pp
+    INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+    WHERE pp.IdPlanPago = @IdPlanPago
+      AND pp.EstadoPlan = 'Activo'
+      AND f.IdPropietario = @IdUsuario;
+
+    SELECT @@ROWCOUNT AS FilasAfectadas;
+END;
+GO

--- a/BaseDatos/05_creacion_triggers.sql
+++ b/BaseDatos/05_creacion_triggers.sql
@@ -41,6 +41,126 @@ BEGIN
 END;
 GO
 
+CREATE OR ALTER TRIGGER dbo.TR_EvaluacionesTecnicas_GenerarPlanPago
+ON dbo.EvaluacionesTecnicas
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @IdFinca INT;
+    DECLARE @Anio INT = YEAR(SYSDATETIME()) + 1;
+
+    DECLARE cursorFincas CURSOR LOCAL FAST_FORWARD FOR
+        SELECT DISTINCT i.IdFinca
+        FROM inserted i
+        INNER JOIN deleted d ON d.IdEvaluacion = i.IdEvaluacion
+        INNER JOIN dbo.Fincas f ON f.IdFinca = i.IdFinca
+        WHERE i.EstadoEvaluacion = 'Evaluada – Califica'
+          AND i.DecisionTecnica = 'Califica'
+          AND (d.EstadoEvaluacion <> i.EstadoEvaluacion OR ISNULL(d.DecisionTecnica, '') <> ISNULL(i.DecisionTecnica, ''))
+          AND EXISTS (
+              SELECT 1
+              FROM dbo.ConfiguracionesPago cp
+              WHERE cp.FechaVigenciaDesde <= DATEFROMPARTS(YEAR(SYSDATETIME()) + 1, 1, 1)
+                AND (cp.FechaVigenciaHasta IS NULL OR cp.FechaVigenciaHasta >= DATEFROMPARTS(YEAR(SYSDATETIME()) + 1, 1, 1))
+          );
+
+    OPEN cursorFincas;
+    FETCH NEXT FROM cursorFincas INTO @IdFinca;
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        BEGIN TRY
+            IF OBJECT_ID('dbo.SP_Pagos_GenerarPlanPago', 'P') IS NOT NULL
+            BEGIN
+                EXEC sys.sp_executesql
+                    N'EXEC dbo.SP_Pagos_GenerarPlanPago @IdFinca = @IdFinca, @Anio = @Anio, @Simular = 0;',
+                    N'@IdFinca INT, @Anio INT',
+                    @IdFinca = @IdFinca,
+                    @Anio = @Anio;
+            END
+            ELSE
+            BEGIN
+                PRINT CONCAT('TR_EvaluacionesTecnicas_GenerarPlanPago omitido para finca ', @IdFinca, ': SP_Pagos_GenerarPlanPago no existe.');
+            END
+        END TRY
+        BEGIN CATCH
+            -- Si falta cuenta validada o configuración activa, no se cae la transacción principal.
+            PRINT CONCAT('TR_EvaluacionesTecnicas_GenerarPlanPago omitido para finca ', @IdFinca, ': ', ERROR_MESSAGE());
+        END CATCH;
+
+        FETCH NEXT FROM cursorFincas INTO @IdFinca;
+    END
+
+    CLOSE cursorFincas;
+    DEALLOCATE cursorFincas;
+END;
+GO
+
+CREATE OR ALTER TRIGGER dbo.TR_CuentasBancarias_GenerarPlanPagoPendiente
+ON dbo.CuentasBancarias
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @IdFinca INT;
+    DECLARE @Anio INT = YEAR(SYSDATETIME()) + 1;
+
+    DECLARE cursorFincas CURSOR LOCAL FAST_FORWARD FOR
+        SELECT DISTINCT f.IdFinca
+        FROM inserted i
+        INNER JOIN deleted d ON d.IdCuentaBancaria = i.IdCuentaBancaria
+        INNER JOIN dbo.Fincas f ON f.IdPropietario = i.IdUsuario
+        WHERE i.EstadoValidacion = 'Validada'
+          AND ISNULL(d.EstadoValidacion, '') <> 'Validada'
+          AND f.EstadoFinca = 'Aprobada'
+          AND EXISTS (
+              SELECT 1
+              FROM dbo.EvaluacionesTecnicas e
+              WHERE e.IdFinca = f.IdFinca
+                AND e.EstadoEvaluacion = 'Evaluada – Califica'
+                AND e.DecisionTecnica = 'Califica'
+          )
+          AND EXISTS (
+              SELECT 1
+              FROM dbo.ConfiguracionesPago cp
+              WHERE cp.FechaVigenciaDesde <= DATEFROMPARTS(YEAR(SYSDATETIME()) + 1, 1, 1)
+                AND (cp.FechaVigenciaHasta IS NULL OR cp.FechaVigenciaHasta >= DATEFROMPARTS(YEAR(SYSDATETIME()) + 1, 1, 1))
+          );
+
+    OPEN cursorFincas;
+    FETCH NEXT FROM cursorFincas INTO @IdFinca;
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        BEGIN TRY
+            IF OBJECT_ID('dbo.SP_Pagos_GenerarPlanPago', 'P') IS NOT NULL
+            BEGIN
+                EXEC sys.sp_executesql
+                    N'EXEC dbo.SP_Pagos_GenerarPlanPago @IdFinca = @IdFinca, @Anio = @Anio, @Simular = 0;',
+                    N'@IdFinca INT, @Anio INT',
+                    @IdFinca = @IdFinca,
+                    @Anio = @Anio;
+            END
+            ELSE
+            BEGIN
+                PRINT CONCAT('TR_CuentasBancarias_GenerarPlanPagoPendiente omitido para finca ', @IdFinca, ': SP_Pagos_GenerarPlanPago no existe.');
+            END
+        END TRY
+        BEGIN CATCH
+            PRINT CONCAT('TR_CuentasBancarias_GenerarPlanPagoPendiente omitido para finca ', @IdFinca, ': ', ERROR_MESSAGE());
+        END CATCH;
+
+        FETCH NEXT FROM cursorFincas INTO @IdFinca;
+    END
+
+    CLOSE cursorFincas;
+    DEALLOCATE cursorFincas;
+END;
+GO
+
 CREATE OR ALTER TRIGGER dbo.TR_Fincas_Auditoria
 ON dbo.Fincas
 AFTER INSERT, UPDATE, DELETE

--- a/BaseDatos/06_admin_roles_permisos_sprocs.sql
+++ b/BaseDatos/06_admin_roles_permisos_sprocs.sql
@@ -9,18 +9,64 @@ SET ANSI_NULLS ON;
 SET QUOTED_IDENTIFIER ON;
 GO
 
+/*
+    Bootstrap incremental:
+    En algunos ambientes la BD fue creada sin catálogo de permisos.
+    Este bloque evita que falle el script 06 y deja la base lista para script 07.
+*/
+IF OBJECT_ID('dbo.Permisos', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.Permisos
+    (
+        IdPermiso     INT IDENTITY(1,1) NOT NULL,
+        Codigo        NVARCHAR(100) NOT NULL,
+        Nombre        NVARCHAR(150) NOT NULL,
+        Descripcion   NVARCHAR(300) NULL,
+        Activo        BIT NOT NULL CONSTRAINT DF_Permisos_Activo DEFAULT (1),
+        CONSTRAINT PK_Permisos PRIMARY KEY (IdPermiso),
+        CONSTRAINT UQ_Permisos_Codigo UNIQUE (Codigo)
+    );
+END
+GO
+
+IF OBJECT_ID('dbo.RolesPermisos', 'U') IS NULL
+   AND OBJECT_ID('dbo.RolPermisos', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.RolesPermisos
+    (
+        IdRol       INT NOT NULL,
+        IdPermiso   INT NOT NULL,
+        CONSTRAINT PK_RolesPermisos PRIMARY KEY (IdRol, IdPermiso),
+        CONSTRAINT FK_RolesPermisos_Roles FOREIGN KEY (IdRol) REFERENCES dbo.Roles(IdRol),
+        CONSTRAINT FK_RolesPermisos_Permisos FOREIGN KEY (IdPermiso) REFERENCES dbo.Permisos(IdPermiso)
+    );
+END
+GO
+
 CREATE OR ALTER PROCEDURE dbo.usp_Admin_ObtenerPermisos
 AS
 BEGIN
     SET NOCOUNT ON;
 
-    SELECT
-        p.IdPermiso,
-        p.Codigo,
-        p.Nombre,
-        p.Descripcion
-    FROM dbo.Permisos p
-    ORDER BY p.Codigo;
+    IF OBJECT_ID('dbo.Permisos', 'U') IS NULL
+    BEGIN
+        SELECT
+            CAST(NULL AS INT) AS IdPermiso,
+            CAST(NULL AS NVARCHAR(100)) AS Codigo,
+            CAST(NULL AS NVARCHAR(150)) AS Nombre,
+            CAST(NULL AS NVARCHAR(300)) AS Descripcion
+        WHERE 1 = 0;
+        RETURN;
+    END
+
+    EXEC sys.sp_executesql N'
+        SELECT
+            p.IdPermiso,
+            p.Codigo,
+            p.Nombre,
+            p.Descripcion
+        FROM dbo.Permisos p
+        ORDER BY p.Codigo;';
 END;
 GO
 

--- a/PSA.AppCore/Managers/AdministracionManager.cs
+++ b/PSA.AppCore/Managers/AdministracionManager.cs
@@ -210,7 +210,7 @@ public class AdministracionManager
             modulo: "Administracion",
             tablaAfectada: "CuentasBancarias",
             accion: "VALIDAR_CUENTA_BANCARIA",
-            detalle: $"Cuenta {model.IdCuentaBancaria} validada con resultado: {(model.Aprobada ? "Aprobada" : "Rechazada")}",
+            detalle: $"Cuenta {model.IdCuentaBancaria} validada con resultado: {(model.Aprobada ? "Validada" : "Rechazada")}",
             idRegistroAfectado: model.IdCuentaBancaria,
             ipOrigen: ip);
     }

--- a/PSA.AppCore/Managers/PagosManager.cs
+++ b/PSA.AppCore/Managers/PagosManager.cs
@@ -1,0 +1,101 @@
+using PSA.DataAccess.DAO;
+using PSA.EntidadesDTO.DTOs.Pagos;
+
+namespace PSA.AppCore.Managers;
+
+public class PagosManager(PlanPagoDAO planPagoDao, AuditoriaLogDAO auditoriaLogDao)
+{
+    private readonly PlanPagoDAO _planPagoDao = planPagoDao;
+    private readonly AuditoriaLogDAO _auditoriaLogDao = auditoriaLogDao;
+
+    public async Task<PlanPagoDTO?> GenerarPlanPagoAsync(GenerarPlanPagoRequestDTO request, int idUsuario, string? ip)
+    {
+        if (request.IdFinca <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar una finca válida.");
+        }
+
+        if (request.Anio < DateTime.UtcNow.Year)
+        {
+            throw new InvalidOperationException("El año del plan no puede ser anterior al año actual.");
+        }
+
+        var plan = await _planPagoDao.GenerarPlanPagoAsync(request);
+        if (plan != null && !request.Simular)
+        {
+            await _auditoriaLogDao.RegistrarEventoAsync(
+                idUsuario: idUsuario,
+                modulo: "Pagos",
+                tablaAfectada: "PlanesPago",
+                accion: "GENERAR_PLAN_PAGO",
+                detalle: $"Plan {plan.IdPlanPago} generado para finca {plan.IdFinca} año {plan.Anio}.",
+                idRegistroAfectado: plan.IdPlanPago,
+                ipOrigen: ip);
+        }
+
+        return plan;
+    }
+
+    public Task<List<CuotaPlanPagoDTO>> ObtenerHistorialDuenoAsync(int idPropietario)
+    {
+        if (idPropietario <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un propietario válido.");
+        }
+
+        return _planPagoDao.ObtenerHistorialCuotasDuenoAsync(idPropietario);
+    }
+
+    public Task<List<PlanPagoResumenDTO>> ObtenerPlanesDuenoAsync(int idPropietario)
+    {
+        if (idPropietario <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un propietario válido.");
+        }
+
+        return _planPagoDao.ObtenerPlanesDuenoAsync(idPropietario);
+    }
+
+    public Task<List<CuentaBancariaDuenoDTO>> ObtenerCuentasBancariasDuenoAsync(int idUsuario)
+    {
+        if (idUsuario <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un usuario válido.");
+        }
+
+        return _planPagoDao.ObtenerCuentasBancariasDuenoAsync(idUsuario);
+    }
+
+    public Task<int> RegistrarCuentaBancariaDuenoAsync(RegistrarCuentaBancariaDTO dto)
+    {
+        if (dto.IdUsuario <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un usuario válido.");
+        }
+
+        if (string.IsNullOrWhiteSpace(dto.Banco)
+            || string.IsNullOrWhiteSpace(dto.NumeroCuenta)
+            || string.IsNullOrWhiteSpace(dto.TipoCuenta)
+            || string.IsNullOrWhiteSpace(dto.Titular))
+        {
+            throw new InvalidOperationException("Debe completar todos los datos de la cuenta bancaria.");
+        }
+
+        return _planPagoDao.RegistrarCuentaBancariaDuenoAsync(dto);
+    }
+
+    public Task<bool> AsociarCuentaPlanAsync(int idPlanPago, AsociarCuentaPlanDTO dto)
+    {
+        if (idPlanPago <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un plan válido.");
+        }
+
+        if (dto.IdUsuario <= 0 || dto.IdCuentaBancaria <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar usuario y cuenta bancaria válidos.");
+        }
+
+        return _planPagoDao.AsociarCuentaPlanAsync(idPlanPago, dto.IdUsuario, dto.IdCuentaBancaria);
+    }
+}

--- a/PSA.DataAccess/DAO/CuentaBancariaDAO.cs
+++ b/PSA.DataAccess/DAO/CuentaBancariaDAO.cs
@@ -15,7 +15,28 @@ public class CuentaBancariaDAO
 
     public async Task<List<CuentaBancariaPendienteDTO>> ObtenerPendientesValidacionAsync()
     {
-        const string sql = @"
+        var resultado = new List<CuentaBancariaPendienteDTO>();
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        var columnas = await ObtenerColumnasCuentaBancariaAsync(connection);
+        var expresionEstadoCuenta = columnas.Contains("Activa", StringComparer.OrdinalIgnoreCase)
+            ? "CASE WHEN cb.Activa = 1 THEN 'Activa' ELSE 'Inactiva' END AS EstadoCuenta"
+            : columnas.Contains("Estado", StringComparer.OrdinalIgnoreCase)
+                ? "cb.Estado AS EstadoCuenta"
+                : "'Desconocida' AS EstadoCuenta";
+        var expresionFecha = columnas.Contains("FechaRegistro", StringComparer.OrdinalIgnoreCase)
+            ? "cb.FechaRegistro AS FechaReferencia"
+            : columnas.Contains("FechaCreacion", StringComparer.OrdinalIgnoreCase)
+                ? "cb.FechaCreacion AS FechaReferencia"
+                : "SYSUTCDATETIME() AS FechaReferencia";
+        var ordenFecha = columnas.Contains("FechaRegistro", StringComparer.OrdinalIgnoreCase)
+            ? "cb.FechaRegistro DESC"
+            : columnas.Contains("FechaCreacion", StringComparer.OrdinalIgnoreCase)
+                ? "cb.FechaCreacion DESC"
+                : "cb.IdCuentaBancaria DESC";
+        var sql = $@"
 SELECT
     cb.IdCuentaBancaria,
     cb.IdUsuario,
@@ -27,18 +48,14 @@ SELECT
     cb.Titular,
     cb.EstadoValidacion,
     cb.ObservacionesValidacion,
-    cb.Estado AS EstadoCuenta,
-    cb.FechaCreacion
+    {expresionEstadoCuenta},
+    {expresionFecha}
 FROM dbo.CuentasBancarias cb
 INNER JOIN dbo.Usuarios u ON u.IdUsuario = cb.IdUsuario
-ORDER BY cb.FechaCreacion DESC;";
+WHERE cb.EstadoValidacion = 'Pendiente'
+ORDER BY {ordenFecha};";
 
-        var resultado = new List<CuentaBancariaPendienteDTO>();
-
-        using var connection = _connectionFactory.CreateConnection();
         using var command = new SqlCommand(sql, connection);
-
-        await connection.OpenAsync();
         using var reader = await command.ExecuteReaderAsync();
 
         while (await reader.ReadAsync())
@@ -56,7 +73,7 @@ ORDER BY cb.FechaCreacion DESC;";
                 EstadoValidacion = reader["EstadoValidacion"]?.ToString() ?? string.Empty,
                 ObservacionesValidacion = reader["ObservacionesValidacion"] == DBNull.Value ? null : reader["ObservacionesValidacion"]?.ToString(),
                 Activa = string.Equals(reader["EstadoCuenta"]?.ToString(), "Activa", StringComparison.OrdinalIgnoreCase),
-                FechaRegistro = reader.GetDateTime(reader.GetOrdinal("FechaCreacion"))
+                FechaRegistro = reader.GetDateTime(reader.GetOrdinal("FechaReferencia"))
             });
         }
 
@@ -65,22 +82,69 @@ ORDER BY cb.FechaCreacion DESC;";
 
     public async Task ValidarCuentaAsync(ValidacionCuentaBancariaDTO dto)
     {
-        const string sql = @"
-UPDATE dbo.CuentasBancarias
-SET
-    EstadoValidacion = @EstadoValidacion,
-    ObservacionesValidacion = @Observaciones,
-    FechaActualizacion = SYSUTCDATETIME()
-WHERE IdCuentaBancaria = @IdCuentaBancaria;";
-
         using var connection = _connectionFactory.CreateConnection();
-        using var command = new SqlCommand(sql, connection);
+        await connection.OpenAsync();
+
+        var columnas = await ObtenerColumnasCuentaBancariaAsync(connection);
+        var asignaciones = new List<string> { "EstadoValidacion = @EstadoValidacion" };
+        var sql = string.Empty;
+        using var command = new SqlCommand { Connection = connection };
 
         command.Parameters.AddWithValue("@IdCuentaBancaria", dto.IdCuentaBancaria);
-        command.Parameters.AddWithValue("@EstadoValidacion", dto.Aprobada ? "Aprobada" : "Rechazada");
-        command.Parameters.AddWithValue("@Observaciones", (object?)dto.Observaciones ?? DBNull.Value);
+        command.Parameters.AddWithValue("@EstadoValidacion", dto.Aprobada ? "Validada" : "Rechazada");
 
-        await connection.OpenAsync();
+        if (columnas.Contains("ObservacionesValidacion", StringComparer.OrdinalIgnoreCase))
+        {
+            asignaciones.Add("ObservacionesValidacion = @Observaciones");
+            command.Parameters.AddWithValue("@Observaciones", (object?)dto.Observaciones ?? DBNull.Value);
+        }
+
+        if (columnas.Contains("ValidadoPor", StringComparer.OrdinalIgnoreCase))
+        {
+            asignaciones.Add("ValidadoPor = @ValidadoPor");
+            command.Parameters.AddWithValue("@ValidadoPor", dto.IdAdministrador);
+        }
+
+        if (columnas.Contains("FechaValidacion", StringComparer.OrdinalIgnoreCase))
+        {
+            asignaciones.Add("FechaValidacion = SYSUTCDATETIME()");
+        }
+
+        if (columnas.Contains("FechaActualizacion", StringComparer.OrdinalIgnoreCase))
+        {
+            asignaciones.Add("FechaActualizacion = SYSUTCDATETIME()");
+        }
+
+        if (dto.Aprobada && columnas.Contains("Activa", StringComparer.OrdinalIgnoreCase))
+        {
+            asignaciones.Add("Activa = 1");
+        }
+
+        sql = $@"
+UPDATE dbo.CuentasBancarias
+SET {string.Join(", ", asignaciones)}
+WHERE IdCuentaBancaria = @IdCuentaBancaria;";
+        command.CommandText = sql;
+
         await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<HashSet<string>> ObtenerColumnasCuentaBancariaAsync(SqlConnection connection)
+    {
+        const string sql = @"
+SELECT c.COLUMN_NAME
+FROM INFORMATION_SCHEMA.COLUMNS c
+WHERE c.TABLE_SCHEMA = 'dbo'
+  AND c.TABLE_NAME = 'CuentasBancarias';";
+
+        using var command = new SqlCommand(sql, connection);
+        using var reader = await command.ExecuteReaderAsync();
+        var columnas = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (await reader.ReadAsync())
+        {
+            columnas.Add(reader["COLUMN_NAME"]?.ToString() ?? string.Empty);
+        }
+
+        return columnas;
     }
 }

--- a/PSA.DataAccess/DAO/EvaluacionTecnicaDAO.cs
+++ b/PSA.DataAccess/DAO/EvaluacionTecnicaDAO.cs
@@ -276,9 +276,22 @@ SELECT CAST(1 AS bit);";
             command.Parameters.AddWithValue("@EstadoPendiente", EstadosEvaluacionTecnica.Pendiente);
             command.Parameters.AddWithValue("@EstadoEnProceso", EstadosEvaluacionTecnica.EnProceso);
 
-            await connection.OpenAsync();
-            var result = await command.ExecuteScalarAsync();
-            return result is bool boolResult && boolResult;
+            try
+            {
+                await connection.OpenAsync();
+                var result = await command.ExecuteScalarAsync();
+                return result is bool boolResult && boolResult;
+            }
+            catch (SqlException ex)
+            {
+                Console.Error.WriteLine($"Error SQL al registrar resultado de evaluación #{idEvaluacion}: {ex.Message}");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error inesperado al registrar resultado de evaluación #{idEvaluacion}: {ex.Message}");
+                return false;
+            }
         }
 
         public async Task<bool> ActualizarEstadoEvaluacionAsync(int idEvaluacion, string nuevoEstado)

--- a/PSA.DataAccess/DAO/PlanPagoDAO.cs
+++ b/PSA.DataAccess/DAO/PlanPagoDAO.cs
@@ -1,0 +1,205 @@
+using Microsoft.Data.SqlClient;
+using PSA.DataAccess;
+using PSA.EntidadesDTO.DTOs.Pagos;
+
+namespace PSA.DataAccess.DAO;
+
+public class PlanPagoDAO(IDbConnectionFactory connectionFactory)
+{
+    private readonly IDbConnectionFactory _connectionFactory = connectionFactory;
+
+    public async Task<PlanPagoDTO?> GenerarPlanPagoAsync(GenerarPlanPagoRequestDTO request)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand("dbo.SP_Pagos_GenerarPlanPago", connection)
+        {
+            CommandType = System.Data.CommandType.StoredProcedure
+        };
+        command.Parameters.AddWithValue("@IdFinca", request.IdFinca);
+        command.Parameters.AddWithValue("@Anio", request.Anio);
+        command.Parameters.AddWithValue("@Simular", request.Simular);
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return null;
+        }
+
+        return MapPlanPago(reader);
+    }
+
+    public async Task<List<CuotaPlanPagoDTO>> ObtenerHistorialCuotasDuenoAsync(int idPropietario)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand("dbo.SP_Pagos_ObtenerHistorialDueno", connection)
+        {
+            CommandType = System.Data.CommandType.StoredProcedure
+        };
+        command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+
+        using var reader = await command.ExecuteReaderAsync();
+        var resultado = new List<CuotaPlanPagoDTO>();
+        while (await reader.ReadAsync())
+        {
+            resultado.Add(new CuotaPlanPagoDTO
+            {
+                IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+                IdCuotaPago = reader.GetInt32(reader.GetOrdinal("IdCuotaPago")),
+                IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+                NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+                Anio = reader.GetInt32(reader.GetOrdinal("Anio")),
+                Mes = reader.GetInt32(reader.GetOrdinal("Mes")),
+                FechaProgramada = reader.GetDateTime(reader.GetOrdinal("FechaProgramada")),
+                MontoProgramado = reader.GetDecimal(reader.GetOrdinal("MontoProgramado")),
+                MontoPendiente = reader.GetDecimal(reader.GetOrdinal("MontoPendiente")),
+                EstadoCuota = reader["EstadoCuota"]?.ToString() ?? string.Empty,
+                FechaPago = reader["FechaPago"] == DBNull.Value ? null : reader.GetDateTime(reader.GetOrdinal("FechaPago"))
+            });
+        }
+
+        return resultado;
+    }
+
+    public async Task<List<PlanPagoResumenDTO>> ObtenerPlanesDuenoAsync(int idPropietario)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand("dbo.SP_Pagos_ObtenerPlanesDueno", connection)
+        {
+            CommandType = System.Data.CommandType.StoredProcedure
+        };
+        command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+
+        using var reader = await command.ExecuteReaderAsync();
+        var resultado = new List<PlanPagoResumenDTO>();
+        while (await reader.ReadAsync())
+        {
+            resultado.Add(new PlanPagoResumenDTO
+            {
+                IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+                IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+                NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+                Anio = reader.GetInt32(reader.GetOrdinal("Anio")),
+                MontoMensualCalculado = reader.GetDecimal(reader.GetOrdinal("MontoMensualCalculado")),
+                MontoAnualEstimado = reader.GetDecimal(reader.GetOrdinal("MontoAnualEstimado")),
+                EstadoPlan = reader["EstadoPlan"]?.ToString() ?? string.Empty,
+                IdCuentaBancaria = reader["IdCuentaBancaria"] == DBNull.Value
+                    ? null
+                    : reader.GetInt32(reader.GetOrdinal("IdCuentaBancaria"))
+            });
+        }
+
+        return resultado;
+    }
+
+    public async Task<List<CuentaBancariaDuenoDTO>> ObtenerCuentasBancariasDuenoAsync(int idUsuario)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand("dbo.SP_Pagos_ObtenerCuentasBancariasDueno", connection)
+        {
+            CommandType = System.Data.CommandType.StoredProcedure
+        };
+        command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+
+        using var reader = await command.ExecuteReaderAsync();
+        var resultado = new List<CuentaBancariaDuenoDTO>();
+        while (await reader.ReadAsync())
+        {
+            resultado.Add(new CuentaBancariaDuenoDTO
+            {
+                IdCuentaBancaria = reader.GetInt32(reader.GetOrdinal("IdCuentaBancaria")),
+                Banco = reader["Banco"]?.ToString() ?? string.Empty,
+                NumeroCuenta = reader["NumeroCuenta"]?.ToString() ?? string.Empty,
+                TipoCuenta = reader["TipoCuenta"]?.ToString() ?? string.Empty,
+                Titular = reader["Titular"]?.ToString() ?? string.Empty,
+                EstadoValidacion = reader["EstadoValidacion"]?.ToString() ?? string.Empty,
+                Activa = reader.GetBoolean(reader.GetOrdinal("Activa")),
+                FechaRegistro = reader.GetDateTime(reader.GetOrdinal("FechaRegistro"))
+            });
+        }
+
+        return resultado;
+    }
+
+    public async Task<int> RegistrarCuentaBancariaDuenoAsync(RegistrarCuentaBancariaDTO dto)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand("dbo.SP_Pagos_RegistrarCuentaBancariaDueno", connection)
+        {
+            CommandType = System.Data.CommandType.StoredProcedure
+        };
+        command.Parameters.AddWithValue("@IdUsuario", dto.IdUsuario);
+        command.Parameters.AddWithValue("@Banco", dto.Banco.Trim());
+        command.Parameters.AddWithValue("@NumeroCuenta", dto.NumeroCuenta.Trim());
+        command.Parameters.AddWithValue("@TipoCuenta", dto.TipoCuenta.Trim());
+        command.Parameters.AddWithValue("@Titular", dto.Titular.Trim());
+
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result ?? 0);
+    }
+
+    public async Task<bool> AsociarCuentaPlanAsync(int idPlanPago, int idUsuario, int idCuentaBancaria)
+    {
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand("dbo.SP_Pagos_AsociarCuentaPlan", connection)
+        {
+            CommandType = System.Data.CommandType.StoredProcedure
+        };
+        command.Parameters.AddWithValue("@IdPlanPago", idPlanPago);
+        command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+        command.Parameters.AddWithValue("@IdCuentaBancaria", idCuentaBancaria);
+
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result ?? 0) > 0;
+    }
+
+    private static PlanPagoDTO MapPlanPago(SqlDataReader reader)
+    {
+        return new PlanPagoDTO
+        {
+            IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+            IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+            NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+            Anio = reader.GetInt32(reader.GetOrdinal("Anio")),
+            IdConfiguracionPago = reader.GetInt32(reader.GetOrdinal("IdConfiguracionPago")),
+            IdCuentaBancaria = reader["IdCuentaBancaria"] == DBNull.Value
+                ? null
+                : reader.GetInt32(reader.GetOrdinal("IdCuentaBancaria")),
+            MontoBaseMensual = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")),
+            PorcentajeAjusteTotal = reader.GetDecimal(reader.GetOrdinal("PorcentajeAjusteTotal")),
+            MontoMensualCalculado = reader.GetDecimal(reader.GetOrdinal("MontoMensualCalculado")),
+            EstadoPlan = reader["EstadoPlan"]?.ToString() ?? string.Empty,
+            FechaGeneracion = reader.GetDateTime(reader.GetOrdinal("FechaGeneracion")),
+            DetalleCalculo = new PlanPagoCalculoDetalleDTO
+            {
+                HectareasAprobadas = reader.GetDecimal(reader.GetOrdinal("HectareasAprobadas")),
+                PrecioBasePorHectarea = reader.GetDecimal(reader.GetOrdinal("PrecioBasePorHectarea")),
+                MontoBaseMensual = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")),
+                PorcentajeVegetacion = reader.GetDecimal(reader.GetOrdinal("PorcentajeVegetacion")),
+                PorcentajeHidrico = reader.GetDecimal(reader.GetOrdinal("PorcentajeHidrico")),
+                PorcentajeNacientes = reader.GetDecimal(reader.GetOrdinal("PorcentajeNacientes")),
+                PorcentajePendiente = reader.GetDecimal(reader.GetOrdinal("PorcentajePendiente")),
+                PorcentajeTotalAntesTope = reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAntesTope")),
+                PorcentajeTopeAplicado = reader.GetDecimal(reader.GetOrdinal("PorcentajeTopeAplicado")),
+                PorcentajeTotalAplicado = reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAplicado")),
+                MontoAjusteMensual = reader.GetDecimal(reader.GetOrdinal("MontoAjusteMensual")),
+                MontoFinalMensual = reader.GetDecimal(reader.GetOrdinal("MontoFinalMensual")),
+                VegetacionFinal = reader["VegetacionFinal"]?.ToString() ?? string.Empty,
+                TieneRecursosHidricosFinal = reader.GetBoolean(reader.GetOrdinal("TieneRecursosHidricosFinal")),
+                CantidadNacientesFinal = reader.GetInt32(reader.GetOrdinal("CantidadNacientesFinal")),
+                PendienteFinal = reader["PendienteFinal"]?.ToString() ?? string.Empty
+            }
+        };
+    }
+}

--- a/PSA.DataAccess/DAO/RolPermisoDAO.cs
+++ b/PSA.DataAccess/DAO/RolPermisoDAO.cs
@@ -178,20 +178,14 @@ ORDER BY p.Codigo;";
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-<<<<<<< HEAD
         var metadataEstado = await ObtenerMetadataColumnaAsync(connection, "Roles", "Estado");
         var metadataActivo = await ObtenerMetadataColumnaAsync(connection, "Roles", "Activo");
         var expresionActivo = ObtenerExpresionActivo("dbo.Roles", metadataEstado, metadataActivo);
         var sql = $@"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
-WHERE {expresionActivo} = CAST(1 AS bit)
-=======
-        const string sql = @"
-SELECT IdRol, Nombre, Descripcion
-FROM dbo.Roles
->>>>>>> origin/codex/fix-compilation-errors-in-rolpermisodao-ipmjam
-ORDER BY Nombre;";
+	SELECT IdRol, Nombre, Descripcion
+	FROM dbo.Roles
+	WHERE {expresionActivo} = CAST(1 AS bit)
+	ORDER BY Nombre;";
 
         var roles = new List<RolDTO>();
 

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -20,6 +20,7 @@
 		<Compile Include="DAO\AuditoriaLogDAO.cs" />
 		<Compile Include="DAO\RolPermisoDAO.cs" />
 		<Compile Include="DAO\ConfiguracionPagoDAO.cs" />
+		<Compile Include="DAO\PlanPagoDAO.cs" />
 		<Compile Include="DAO\CuentaBancariaDAO.cs" />
 		<Compile Include="DAO\EvaluacionTecnicaDAO.cs" />
 		<Compile Include="DAO\RecuperacionContrasenaDAO.cs" />

--- a/PSA.EntidadesDTO/DTOs/Pagos/PlanPagoDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Pagos/PlanPagoDTO.cs
@@ -2,12 +2,98 @@
 {
     public class PlanPagoDTO
     {
-        public int Id { get; set; }
-        public int ConfiguracionPagoId { get; set; }
-        public string NombrePlan { get; set; } = string.Empty;
-        public decimal MontoTotal { get; set; }
-        public int CantidadCuotas { get; set; }
-        public DateTime FechaInicio { get; set; }
-        public string Estado { get; set; } = string.Empty;
+        public int IdPlanPago { get; set; }
+        public int IdFinca { get; set; }
+        public string NombreFinca { get; set; } = string.Empty;
+        public int Anio { get; set; }
+        public int IdConfiguracionPago { get; set; }
+        public int? IdCuentaBancaria { get; set; }
+        public decimal MontoBaseMensual { get; set; }
+        public decimal PorcentajeAjusteTotal { get; set; }
+        public decimal MontoMensualCalculado { get; set; }
+        public string EstadoPlan { get; set; } = string.Empty;
+        public DateTime FechaGeneracion { get; set; }
+        public PlanPagoCalculoDetalleDTO? DetalleCalculo { get; set; }
+    }
+
+    public class PlanPagoCalculoDetalleDTO
+    {
+        public decimal HectareasAprobadas { get; set; }
+        public decimal PrecioBasePorHectarea { get; set; }
+        public decimal MontoBaseMensual { get; set; }
+        public decimal PorcentajeVegetacion { get; set; }
+        public decimal PorcentajeHidrico { get; set; }
+        public decimal PorcentajeNacientes { get; set; }
+        public decimal PorcentajePendiente { get; set; }
+        public decimal PorcentajeTotalAntesTope { get; set; }
+        public decimal PorcentajeTopeAplicado { get; set; }
+        public decimal PorcentajeTotalAplicado { get; set; }
+        public decimal MontoAjusteMensual { get; set; }
+        public decimal MontoFinalMensual { get; set; }
+        public string VegetacionFinal { get; set; } = string.Empty;
+        public bool TieneRecursosHidricosFinal { get; set; }
+        public int CantidadNacientesFinal { get; set; }
+        public string PendienteFinal { get; set; } = string.Empty;
+    }
+
+    public class CuotaPlanPagoDTO
+    {
+        public int IdPlanPago { get; set; }
+        public int IdCuotaPago { get; set; }
+        public int IdFinca { get; set; }
+        public string NombreFinca { get; set; } = string.Empty;
+        public int Anio { get; set; }
+        public int Mes { get; set; }
+        public DateTime FechaProgramada { get; set; }
+        public decimal MontoProgramado { get; set; }
+        public decimal MontoPendiente { get; set; }
+        public string EstadoCuota { get; set; } = string.Empty;
+        public DateTime? FechaPago { get; set; }
+    }
+
+    public class GenerarPlanPagoRequestDTO
+    {
+        public int IdFinca { get; set; }
+        public int Anio { get; set; } = DateTime.UtcNow.Year + 1;
+        public bool Simular { get; set; }
+    }
+
+    public class PlanPagoResumenDTO
+    {
+        public int IdPlanPago { get; set; }
+        public int IdFinca { get; set; }
+        public string NombreFinca { get; set; } = string.Empty;
+        public int Anio { get; set; }
+        public decimal MontoMensualCalculado { get; set; }
+        public decimal MontoAnualEstimado { get; set; }
+        public string EstadoPlan { get; set; } = string.Empty;
+        public int? IdCuentaBancaria { get; set; }
+    }
+
+    public class CuentaBancariaDuenoDTO
+    {
+        public int IdCuentaBancaria { get; set; }
+        public string Banco { get; set; } = string.Empty;
+        public string NumeroCuenta { get; set; } = string.Empty;
+        public string TipoCuenta { get; set; } = string.Empty;
+        public string Titular { get; set; } = string.Empty;
+        public string EstadoValidacion { get; set; } = string.Empty;
+        public bool Activa { get; set; }
+        public DateTime FechaRegistro { get; set; }
+    }
+
+    public class RegistrarCuentaBancariaDTO
+    {
+        public int IdUsuario { get; set; }
+        public string Banco { get; set; } = string.Empty;
+        public string NumeroCuenta { get; set; } = string.Empty;
+        public string TipoCuenta { get; set; } = string.Empty;
+        public string Titular { get; set; } = string.Empty;
+    }
+
+    public class AsociarCuentaPlanDTO
+    {
+        public int IdUsuario { get; set; }
+        public int IdCuentaBancaria { get; set; }
     }
 }

--- a/PSA.WebAPI/Controllers/AdministracionController.cs
+++ b/PSA.WebAPI/Controllers/AdministracionController.cs
@@ -183,17 +183,37 @@ namespace PSA.WebAPI.Controllers
         [HttpGet("cuentas-bancarias/pendientes")]
         public async Task<ActionResult<List<CuentaBancariaPendienteDTO>>> ObtenerCuentasPendientes()
         {
-            var cuentas = await _administracionManager.ObtenerCuentasPendientesAsync();
-            return Ok(cuentas);
+            try
+            {
+                var cuentas = await _administracionManager.ObtenerCuentasPendientesAsync();
+                return Ok(cuentas);
+            }
+            catch (Exception ex)
+            {
+                return Problem(
+                    title: "No se pudieron obtener las cuentas bancarias pendientes.",
+                    detail: ex.Message,
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
         }
 
         [HttpPost("cuentas-bancarias/validar")]
         [HttpPost("cuentas-bancarias/validacion")]
         public async Task<ActionResult<bool>> ValidarCuentaBancaria([FromBody] ValidacionCuentaBancariaDTO model)
         {
-            model.IdAdministrador = AdminSistemaId;
-            await _administracionManager.ValidarCuentaBancariaAsync(model, HttpContext.Connection.RemoteIpAddress?.ToString());
-            return Ok(true);
+            try
+            {
+                model.IdAdministrador = AdminSistemaId;
+                await _administracionManager.ValidarCuentaBancariaAsync(model, HttpContext.Connection.RemoteIpAddress?.ToString());
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                return Problem(
+                    title: "No se pudo validar la cuenta bancaria.",
+                    detail: ex.Message,
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
         }
 
         [HttpGet("auditoria")]

--- a/PSA.WebAPI/Controllers/PagosController.cs
+++ b/PSA.WebAPI/Controllers/PagosController.cs
@@ -1,0 +1,110 @@
+using Microsoft.AspNetCore.Mvc;
+using PSA.AppCore.Managers;
+using PSA.EntidadesDTO.DTOs.Pagos;
+
+namespace PSA.WebAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PagosController(PagosManager pagosManager) : BaseApiController
+{
+    private readonly PagosManager _pagosManager = pagosManager;
+
+    [HttpPost("generar-plan")]
+    public async Task<ActionResult<PlanPagoDTO>> GenerarPlan([FromBody] GenerarPlanPagoRequestDTO request)
+    {
+        try
+        {
+            var plan = await _pagosManager.GenerarPlanPagoAsync(
+                request,
+                AdminSistemaId,
+                HttpContext.Connection.RemoteIpAddress?.ToString());
+
+            if (plan == null)
+            {
+                return NotFound(new { Mensaje = "No fue posible generar el plan con los datos actuales." });
+            }
+
+            return Ok(plan);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpGet("dueno/{idPropietario:int}/historial")]
+    public async Task<ActionResult<List<CuotaPlanPagoDTO>>> ObtenerHistorialDueno([FromRoute] int idPropietario)
+    {
+        try
+        {
+            var historial = await _pagosManager.ObtenerHistorialDuenoAsync(idPropietario);
+            return Ok(historial);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpGet("dueno/{idPropietario:int}/planes")]
+    public async Task<ActionResult<List<PlanPagoResumenDTO>>> ObtenerPlanesDueno([FromRoute] int idPropietario)
+    {
+        try
+        {
+            var planes = await _pagosManager.ObtenerPlanesDuenoAsync(idPropietario);
+            return Ok(planes);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpGet("dueno/{idUsuario:int}/cuentas-bancarias")]
+    public async Task<ActionResult<List<CuentaBancariaDuenoDTO>>> ObtenerCuentasBancariasDueno([FromRoute] int idUsuario)
+    {
+        try
+        {
+            var cuentas = await _pagosManager.ObtenerCuentasBancariasDuenoAsync(idUsuario);
+            return Ok(cuentas);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpPost("dueno/cuentas-bancarias")]
+    public async Task<ActionResult<int>> RegistrarCuentaBancariaDueno([FromBody] RegistrarCuentaBancariaDTO model)
+    {
+        try
+        {
+            var idCuenta = await _pagosManager.RegistrarCuentaBancariaDuenoAsync(model);
+            return Ok(idCuenta);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpPut("dueno/planes/{idPlanPago:int}/cuenta-bancaria")]
+    public async Task<IActionResult> AsociarCuentaPlan([FromRoute] int idPlanPago, [FromBody] AsociarCuentaPlanDTO model)
+    {
+        try
+        {
+            var actualizado = await _pagosManager.AsociarCuentaPlanAsync(idPlanPago, model);
+            if (!actualizado)
+            {
+                return BadRequest(new { Mensaje = "No fue posible asociar la cuenta al plan seleccionado." });
+            }
+
+            return Ok(new { Mensaje = "Cuenta bancaria asociada correctamente al plan de pago." });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+}

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddScoped<EvaluacionDAO>();
 builder.Services.AddScoped<AuditoriaLogDAO>();
 builder.Services.AddScoped<RolPermisoDAO>();
 builder.Services.AddScoped<ConfiguracionPagoDAO>();
+builder.Services.AddScoped<PlanPagoDAO>();
 builder.Services.AddScoped<CuentaBancariaDAO>();
 builder.Services.AddScoped<DashboardDAO>();
 builder.Services.AddScoped<ReportesDAO>();
@@ -60,6 +61,7 @@ builder.Services.AddScoped<RecuperacionContrasenaManager>();
 builder.Services.AddScoped<EvaluacionTecnicaManager>();
 builder.Services.AddScoped<FincaManager>();
 builder.Services.AddScoped<AdministracionManager>();
+builder.Services.AddScoped<PagosManager>();
 builder.Services.AddScoped<ReportesManager>();
 builder.Services.AddScoped<LandingManager>();
 

--- a/PSA.WebApp/Controllers/AdministracionController.cs
+++ b/PSA.WebApp/Controllers/AdministracionController.cs
@@ -172,7 +172,7 @@ namespace PSA.WebApp.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> CrearRol(CrearRolDTO model)
+        public async Task<IActionResult> CrearRol([Bind(Prefix = "NuevoRol")] CrearRolDTO model)
         {
             if (!ModelState.IsValid)
             {
@@ -250,11 +250,16 @@ namespace PSA.WebApp.Controllers
         [HttpGet]
         public async Task<IActionResult> ValidacionCuentasBancarias()
         {
-            var cuentas = await _httpClientService.GetAsync<List<CuentaBancariaPendienteDTO>>("api/Administracion/cuentas-bancarias/pendientes") ?? new();
-            var model = new ValidacionCuentasBancariasViewModel
+            var model = new ValidacionCuentasBancariasViewModel();
+
+            try
             {
-                CuentasPendientes = cuentas
-            };
+                model.CuentasPendientes = await _httpClientService.GetAsync<List<CuentaBancariaPendienteDTO>>("api/Administracion/cuentas-bancarias/pendientes") ?? new();
+            }
+            catch
+            {
+                TempData["Error"] = "No fue posible cargar las cuentas bancarias pendientes en este momento.";
+            }
 
             return View(model);
         }
@@ -263,10 +268,17 @@ namespace PSA.WebApp.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> ValidarCuentaBancaria(ValidacionCuentaBancariaDTO model)
         {
-            var respuesta = await _httpClientService.PostAsync<ValidacionCuentaBancariaDTO, bool>("api/Administracion/cuentas-bancarias/validar", model);
-            TempData[respuesta ? "Exito" : "Error"] = respuesta
-                ? "Validación procesada correctamente."
-                : "No se pudo procesar la validación.";
+            try
+            {
+                var respuesta = await _httpClientService.PostAsync<ValidacionCuentaBancariaDTO, bool>("api/Administracion/cuentas-bancarias/validar", model);
+                TempData[respuesta ? "Exito" : "Error"] = respuesta
+                    ? "Validación procesada correctamente."
+                    : "No se pudo procesar la validación.";
+            }
+            catch
+            {
+                TempData["Error"] = "Ocurrió un error inesperado al validar la cuenta bancaria.";
+            }
 
             return RedirectToAction(nameof(ValidacionCuentasBancarias));
         }

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PSA.EntidadesDTO.DTOs.Evaluaciones;
 using PSA.EntidadesDTO.DTOs.Fincas;
+using PSA.EntidadesDTO.DTOs.Pagos;
 using PSA.WebApp.Models;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -109,6 +110,32 @@ namespace PSA.WebApp.Controllers
             var url = $"api/EvaluacionesTecnicas/reportes?anio={anio}&mes={mes}&estadoEvaluacion={estadoEvaluacion}&decisionTecnica={decisionTecnica}&idIngeniero={idIngeniero}";
             var reporte = await ObtenerSeguroDesdeApiAsync<ReporteEvaluacionesDTO>(client, url, "No fue posible aplicar los filtros del reporte.") ?? new ReporteEvaluacionesDTO();
             return View(new ReporteEvaluacionesViewModel { Anio = anio, Mes = mes, EstadoEvaluacion = estadoEvaluacion, DecisionTecnica = decisionTecnica, Reporte = reporte });
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> GenerarPlanManual(int idFinca, int? anio = null)
+        {
+            if (idFinca <= 0)
+            {
+                TempData["MensajeError"] = "No fue posible identificar la finca para generar el plan.";
+                return RedirectToAction(nameof(HistorialEvaluaciones));
+            }
+
+            var client = _httpClientFactory.CreateClient("AuthApi");
+            var payload = new GenerarPlanPagoRequestDTO
+            {
+                IdFinca = idFinca,
+                Anio = anio ?? (DateTime.UtcNow.Year + 1),
+                Simular = false
+            };
+
+            var response = await client.PostAsJsonAsync("api/Pagos/generar-plan", payload);
+            TempData[response.IsSuccessStatusCode ? "MensajeExito" : "MensajeError"] = response.IsSuccessStatusCode
+                ? "Plan de pago generado manualmente para la evaluación calificada."
+                : "No fue posible generar el plan de pago manual.";
+
+            return RedirectToAction(nameof(HistorialEvaluaciones));
         }
 
         [HttpGet]

--- a/PSA.WebApp/Controllers/PagosController.cs
+++ b/PSA.WebApp/Controllers/PagosController.cs
@@ -1,11 +1,21 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using PSA.EntidadesDTO.DTOs.Pagos;
+using PSA.WebApp.Services;
+using System.Security.Claims;
 
 namespace PSA.WebApp.Controllers
 {
     [Authorize]
     public class PagosController : Controller
     {
+        private readonly HttpClientService _httpClientService;
+
+        public PagosController(HttpClientService httpClientService)
+        {
+            _httpClientService = httpClientService;
+        }
+
         [HttpGet]
         [Authorize(Roles = "1")]
         public IActionResult PlanesPago()
@@ -35,14 +45,100 @@ namespace PSA.WebApp.Controllers
 
         [HttpGet]
         [Authorize(Roles = "2")]
-        public IActionResult HistorialPagos()
+        public async Task<IActionResult> PlanesDueno()
+        {
+            ViewBag.ModuloActivo = "pagos";
+            ViewBag.RolActivo = "Dueno";
+            ViewBag.TituloPagina = "Planes de pago";
+            ViewBag.SubtituloPagina = "Consulte sus planes de pago por finca.";
+            ViewBag.BreadcrumbActual = "Planes de pago";
+
+            var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+            var planes = idUsuario > 0
+                ? await _httpClientService.GetAsync<List<PlanPagoResumenDTO>>($"api/Pagos/dueno/{idUsuario}/planes") ?? new()
+                : new List<PlanPagoResumenDTO>();
+            var cuentas = idUsuario > 0
+                ? await _httpClientService.GetAsync<List<CuentaBancariaDuenoDTO>>($"api/Pagos/dueno/{idUsuario}/cuentas-bancarias") ?? new()
+                : new List<CuentaBancariaDuenoDTO>();
+
+            ViewBag.CuentasValidadasActivas = cuentas
+                .Where(c => string.Equals(c.EstadoValidacion, "Validada", StringComparison.OrdinalIgnoreCase) && c.Activa)
+                .ToList();
+
+            return View(planes);
+        }
+
+        [HttpGet]
+        [Authorize(Roles = "2")]
+        public async Task<IActionResult> HistorialPagos()
         {
             ViewBag.ModuloActivo = "pagos";
             ViewBag.RolActivo = "Dueno";
             ViewBag.TituloPagina = "Historial de pagos";
             ViewBag.SubtituloPagina = "Consulte cuotas históricas y estados de confirmación.";
             ViewBag.BreadcrumbActual = "Historial de pagos";
-            return View();
+
+            var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+            var historial = idUsuario > 0
+                ? await _httpClientService.GetAsync<List<CuotaPlanPagoDTO>>($"api/Pagos/dueno/{idUsuario}/historial") ?? new()
+                : new List<CuotaPlanPagoDTO>();
+
+            return View(historial);
+        }
+
+        [HttpGet]
+        [Authorize(Roles = "2")]
+        public async Task<IActionResult> CuentaBancaria()
+        {
+            ViewBag.ModuloActivo = "pagos";
+            ViewBag.RolActivo = "Dueno";
+            ViewBag.TituloPagina = "Cuenta bancaria";
+            ViewBag.SubtituloPagina = "Registre y consulte el estado de validación de sus cuentas.";
+            ViewBag.BreadcrumbActual = "Cuenta bancaria";
+
+            var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+            var cuentas = idUsuario > 0
+                ? await _httpClientService.GetAsync<List<CuentaBancariaDuenoDTO>>($"api/Pagos/dueno/{idUsuario}/cuentas-bancarias") ?? new()
+                : new List<CuentaBancariaDuenoDTO>();
+
+            ViewBag.CuentaNueva = new RegistrarCuentaBancariaDTO { IdUsuario = idUsuario };
+            return View(cuentas);
+        }
+
+        [HttpPost]
+        [Authorize(Roles = "2")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> RegistrarCuentaBancaria(RegistrarCuentaBancariaDTO model)
+        {
+            var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+            model.IdUsuario = idUsuario;
+            var idCuenta = await _httpClientService.PostAsync<RegistrarCuentaBancariaDTO, int>("api/Pagos/dueno/cuentas-bancarias", model);
+            TempData[idCuenta > 0 ? "Exito" : "Error"] = idCuenta > 0
+                ? "Cuenta bancaria registrada. Queda pendiente de validación por administración."
+                : "No fue posible registrar la cuenta bancaria.";
+
+            return RedirectToAction(nameof(CuentaBancaria));
+        }
+
+        [HttpPost]
+        [Authorize(Roles = "2")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> AsociarCuentaPlan(int idPlanPago, int idCuentaBancaria)
+        {
+            var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+            var resultado = await _httpClientService.PutAsync<AsociarCuentaPlanDTO, object>(
+                $"api/Pagos/dueno/planes/{idPlanPago}/cuenta-bancaria",
+                new AsociarCuentaPlanDTO
+                {
+                    IdUsuario = idUsuario,
+                    IdCuentaBancaria = idCuentaBancaria
+                });
+
+            TempData[resultado != null ? "Exito" : "Error"] = resultado != null
+                ? "Cuenta bancaria asociada correctamente al plan activo."
+                : "No fue posible asociar la cuenta bancaria al plan.";
+
+            return RedirectToAction(nameof(PlanesDueno));
         }
     }
 }

--- a/PSA.WebApp/Views/Administracion/ValidacionCuentasBancarias.cshtml
+++ b/PSA.WebApp/Views/Administracion/ValidacionCuentasBancarias.cshtml
@@ -7,9 +7,9 @@
         <div>
             <span class="eyebrow">Administración</span>
             <h2>Validación de cuentas bancarias</h2>
-            <p>Apruebe o rechace cuentas pendientes de validación.</p>
+            <p>Revise y confirme las cuentas pendientes de validación administrativa.</p>
         </div>
-        <a class="boton-secundario" asp-controller="Administracion" asp-action="GestionUsuarios">Volver a usuarios</a>
+        <a class="boton-secundario" asp-controller="Administracion" asp-action="GestionUsuarios">Volver a administración</a>
     </div>
 
     <section class="tarjeta-panel">
@@ -27,7 +27,7 @@
                 <tbody>
                     @if (Model.CuentasPendientes.Count == 0)
                     {
-                        <tr><td colspan="5" class="text-center text-muted">No hay cuentas bancarias registradas.</td></tr>
+                        <tr><td colspan="5" class="text-center text-muted">No hay cuentas bancarias pendientes de revisión.</td></tr>
                     }
                     else
                     {
@@ -41,22 +41,14 @@
                                 <td>
                                     @if (cuenta.EstadoValidacion == "Pendiente")
                                     {
-                                        <div class="d-flex flex-wrap gap-2">
-                                            <form asp-action="ValidarCuentaBancaria" method="post" class="d-inline">
-                                                @Html.AntiForgeryToken()
-                                                <input type="hidden" name="IdCuentaBancaria" value="@cuenta.IdCuentaBancaria" />
-                                                <input type="hidden" name="Aprobada" value="true" />
-                                                <input type="hidden" name="IdAdministrador" value="1" />
-                                                <button type="submit" class="boton-link border-0 bg-transparent p-0">Aprobar</button>
-                                            </form>
-                                            <form asp-action="ValidarCuentaBancaria" method="post" class="d-inline">
-                                                @Html.AntiForgeryToken()
-                                                <input type="hidden" name="IdCuentaBancaria" value="@cuenta.IdCuentaBancaria" />
-                                                <input type="hidden" name="Aprobada" value="false" />
-                                                <input type="hidden" name="IdAdministrador" value="1" />
-                                                <button type="submit" class="boton-link border-0 bg-transparent p-0 text-danger">Rechazar</button>
-                                            </form>
-                                        </div>
+                                        <button type="button"
+                                                class="boton-link border-0 bg-transparent p-0"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#modalValidarCuenta"
+                                                data-id-cuenta="@cuenta.IdCuentaBancaria"
+                                                data-resumen-cuenta="@($"{cuenta.Banco} · {cuenta.NumeroCuenta} · {cuenta.NombreUsuario}")">
+                                            Validar
+                                        </button>
                                     }
                                     else
                                     {
@@ -71,3 +63,48 @@
         </div>
     </section>
 </section>
+
+<div class="modal fade" id="modalValidarCuenta" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form asp-action="ValidarCuentaBancaria" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="IdCuentaBancaria" id="idCuentaBancariaSeleccionada" />
+                <input type="hidden" name="Aprobada" value="true" />
+                <div class="modal-header">
+                    <h5 class="modal-title">Confirmar validación</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-0">¿Desea marcar como <strong>Validada</strong> la cuenta seleccionada?</p>
+                    <small class="text-muted d-block mt-2" id="resumenCuentaSeleccionada"></small>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="boton-secundario" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">Confirmar validación</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        (function () {
+            const modal = document.getElementById('modalValidarCuenta');
+            const idInput = document.getElementById('idCuentaBancariaSeleccionada');
+            const resumen = document.getElementById('resumenCuentaSeleccionada');
+            if (!modal || !idInput || !resumen) return;
+
+            modal.addEventListener('show.bs.modal', function (event) {
+                const trigger = event.relatedTarget;
+                if (!trigger) return;
+
+                const idCuenta = trigger.getAttribute('data-id-cuenta') || '';
+                const resumenCuenta = trigger.getAttribute('data-resumen-cuenta') || '';
+                idInput.value = idCuenta;
+                resumen.textContent = resumenCuenta;
+            });
+        })();
+    </script>
+}

--- a/PSA.WebApp/Views/Evaluaciones/HistorialEvaluaciones.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/HistorialEvaluaciones.cshtml
@@ -39,7 +39,41 @@
                 </div>
                 <div class="campo-formulario">
                     <label for="estadoEvaluacion">Estado evaluación</label>
-                    <input type="text" id="estadoEvaluacion" name="estadoEvaluacion" value="@Model.EstadoEvaluacion" placeholder="Ej: En proceso" />
+                    <select id="estadoEvaluacion" name="estadoEvaluacion">
+                        <option value="">Todos</option>
+                        @if (Model.EstadoEvaluacion == "Pendiente")
+                        {
+                            <option value="Pendiente" selected="selected">Pendiente</option>
+                        }
+                        else
+                        {
+                            <option value="Pendiente">Pendiente</option>
+                        }
+                        @if (Model.EstadoEvaluacion == "En proceso")
+                        {
+                            <option value="En proceso" selected="selected">En proceso</option>
+                        }
+                        else
+                        {
+                            <option value="En proceso">En proceso</option>
+                        }
+                        @if (Model.EstadoEvaluacion == "Evaluada – Califica")
+                        {
+                            <option value="Evaluada – Califica" selected="selected">Evaluada – Califica</option>
+                        }
+                        else
+                        {
+                            <option value="Evaluada – Califica">Evaluada – Califica</option>
+                        }
+                        @if (Model.EstadoEvaluacion == "Evaluada – No califica")
+                        {
+                            <option value="Evaluada – No califica" selected="selected">Evaluada – No califica</option>
+                        }
+                        else
+                        {
+                            <option value="Evaluada – No califica">Evaluada – No califica</option>
+                        }
+                    </select>
                 </div>
                 <div class="campo-formulario">
                     <label for="decisionTecnica">Decisión técnica</label>
@@ -117,7 +151,18 @@
                                 <td>@(string.IsNullOrWhiteSpace(item.DecisionTecnica) ? "N/A" : item.DecisionTecnica)</td>
                                 <td>@(item.FechaVisita?.ToString("dd/MM/yyyy") ?? "N/A")</td>
                                 <td>@(item.FechaDecision?.ToString("dd/MM/yyyy") ?? "N/A")</td>
-                                <td><a class="boton-link" asp-controller="Evaluaciones" asp-action="DetalleEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">Ver detalle</a></td>
+                                <td>
+                                    <a class="boton-link" asp-controller="Evaluaciones" asp-action="DetalleEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">Ver detalle</a>
+                                    @if (string.Equals(item.EstadoEvaluacion, "Evaluada – Califica", StringComparison.OrdinalIgnoreCase)
+                                            && string.Equals(item.DecisionTecnica, "Califica", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        <form method="post" asp-controller="Evaluaciones" asp-action="GenerarPlanManual" class="mt-2">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="idFinca" value="@item.IdFinca" />
+                                            <button type="submit" class="boton-secundario">Generar plan manual</button>
+                                        </form>
+                                    }
+                                </td>
                             </tr>
                         }
                     }

--- a/PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml
+++ b/PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml
@@ -1,0 +1,90 @@
+@model List<PSA.EntidadesDTO.DTOs.Pagos.CuentaBancariaDuenoDTO>
+@{
+    ViewData["Title"] = "Cuenta bancaria";
+    var cuentaNueva = ViewBag.CuentaNueva as PSA.EntidadesDTO.DTOs.Pagos.RegistrarCuentaBancariaDTO ?? new();
+}
+<section class="seccion-pagina">
+    <div class="cabecera-pagina">
+        <div>
+            <span class="eyebrow">Consulta del propietario</span>
+            <h2>Cuenta bancaria</h2>
+            <p>Registre cuentas para habilitar pagos y consulte su estado de validación.</p>
+        </div>
+        <div class="d-flex gap-2">
+            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalNuevaCuenta">Nueva Cuenta Bancaria</button>
+            <a class="boton-secundario" asp-controller="Pagos" asp-action="PlanesDueno">Ver planes</a>
+        </div>
+    </div>
+
+    <section class="tarjeta-panel">
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Banco</th>
+                        <th>Cuenta</th>
+                        <th>Tipo</th>
+                        <th>Titular</th>
+                        <th>Estado validación</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if (!Model.Any())
+                    {
+                        <tr><td colspan="5" class="text-center text-muted">No tiene cuentas bancarias registradas.</td></tr>
+                    }
+                    else
+                    {
+                        @foreach (var cuenta in Model)
+                        {
+                            <tr>
+                                <td>@cuenta.Banco</td>
+                                <td>@cuenta.NumeroCuenta</td>
+                                <td>@cuenta.TipoCuenta</td>
+                                <td>@cuenta.Titular</td>
+                                <td><span class="badge-estado badge-pendiente">@cuenta.EstadoValidacion</span></td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+    </section>
+</section>
+
+<div class="modal fade" id="modalNuevaCuenta" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form asp-action="RegistrarCuentaBancaria" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="IdUsuario" value="@cuentaNueva.IdUsuario" />
+                <div class="modal-header">
+                    <h5 class="modal-title">Nueva cuenta bancaria</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Banco</label>
+                        <input class="form-control" name="Banco" required />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Número de cuenta</label>
+                        <input class="form-control" name="NumeroCuenta" required />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Tipo de cuenta</label>
+                        <input class="form-control" name="TipoCuenta" required />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Titular</label>
+                        <input class="form-control" name="Titular" required />
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="boton-secundario" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">Registrar cuenta</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/PSA.WebApp/Views/Pagos/HistorialPagos.cshtml
+++ b/PSA.WebApp/Views/Pagos/HistorialPagos.cshtml
@@ -1,3 +1,4 @@
+@model List<PSA.EntidadesDTO.DTOs.Pagos.CuotaPlanPagoDTO>
 @{
     ViewData["Title"] = "Historial de pagos";
 }
@@ -24,20 +25,27 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td>Río Verde</td>
-                        <td>Enero 2026</td>
-                        <td>₡104 166</td>
-                        <td><span class="badge-estado badge-exito">Confirmado</span></td>
-                        <td><a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="1">Ver plan</a></td>
-                    </tr>
-                    <tr>
-                        <td>Río Verde</td>
-                        <td>Febrero 2026</td>
-                        <td>₡104 166</td>
-                        <td><span class="badge-estado badge-pendiente">Pendiente</span></td>
-                        <td><a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="1">Ver plan</a></td>
-                    </tr>
+                    @if (!Model.Any())
+                    {
+                        <tr>
+                            <td colspan="5" class="text-center text-muted">No hay cuotas de pago registradas para sus fincas.</td>
+                        </tr>
+                    }
+                    else
+                    {
+                        @foreach (var cuota in Model)
+                        {
+                            var periodo = $"{cuota.FechaProgramada:MMMM yyyy}";
+                            var estadoCss = cuota.EstadoCuota == "Pagada" ? "badge-exito" : "badge-pendiente";
+                            <tr>
+                                <td>@cuota.NombreFinca</td>
+                                <td>@periodo</td>
+                                <td>₡@cuota.MontoProgramado.ToString("N2")</td>
+                                <td><span class="badge-estado @estadoCss">@cuota.EstadoCuota</span></td>
+                                <td><a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="@cuota.IdPlanPago">Ver plan</a></td>
+                            </tr>
+                        }
+                    }
                 </tbody>
             </table>
         </div>

--- a/PSA.WebApp/Views/Pagos/PlanesDueno.cshtml
+++ b/PSA.WebApp/Views/Pagos/PlanesDueno.cshtml
@@ -1,0 +1,87 @@
+@model List<PSA.EntidadesDTO.DTOs.Pagos.PlanPagoResumenDTO>
+@{
+    ViewData["Title"] = "Planes de pago";
+    var cuentasValidadasActivas = ViewBag.CuentasValidadasActivas as List<PSA.EntidadesDTO.DTOs.Pagos.CuentaBancariaDuenoDTO> ?? new();
+}
+<section class="seccion-pagina">
+    <div class="cabecera-pagina">
+        <div>
+            <span class="eyebrow">Consulta del propietario</span>
+            <h2>Planes de pago</h2>
+            <p>Un plan por finca aprobada para pago.</p>
+        </div>
+        <a class="boton-secundario" asp-controller="Pagos" asp-action="HistorialPagos">Ver historial de cuotas</a>
+    </div>
+
+    <section class="tarjeta-panel">
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Finca</th>
+                        <th>Año</th>
+                        <th>Monto mensual</th>
+                        <th>Monto anual</th>
+                        <th>Estado</th>
+                        <th>Cuenta bancaria</th>
+                        <th>Acción</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if (!Model.Any())
+                    {
+                        <tr><td colspan="7" class="text-center text-muted">No hay planes de pago disponibles.</td></tr>
+                    }
+                    else
+                    {
+                        @foreach (var plan in Model)
+                        {
+                            <tr>
+                                <td>@plan.NombreFinca</td>
+                                <td>@plan.Anio</td>
+                                <td>₡@plan.MontoMensualCalculado.ToString("N2")</td>
+                                <td>₡@plan.MontoAnualEstimado.ToString("N2")</td>
+                                <td><span class="badge-estado badge-pendiente">@plan.EstadoPlan</span></td>
+                                <td>
+                                    @if (plan.IdCuentaBancaria.HasValue)
+                                    {
+                                        <span>Asociada (#@plan.IdCuentaBancaria.Value)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-danger">Pendiente de asociar</span>
+                                    }
+                                </td>
+                                <td>
+                                    <a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="@plan.IdPlanPago">Ver detalle</a>
+                                    @if (string.Equals(plan.EstadoPlan, "Activo", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        <form method="post" asp-controller="Pagos" asp-action="AsociarCuentaPlan" class="mt-2">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="idPlanPago" value="@plan.IdPlanPago" />
+                                            <select name="idCuentaBancaria" required>
+                                                <option value="">Seleccionar cuenta...</option>
+                                                @foreach (var cuenta in cuentasValidadasActivas)
+                                                {
+                                                    if (plan.IdCuentaBancaria == cuenta.IdCuentaBancaria)
+                                                    {
+                                                        <option value="@cuenta.IdCuentaBancaria" selected="selected">@cuenta.Banco - @cuenta.NumeroCuenta</option>
+                                                    }
+                                                    else
+                                                    {
+                                                        <option value="@cuenta.IdCuentaBancaria">@cuenta.Banco - @cuenta.NumeroCuenta</option>
+                                                    }
+                                                }
+                                            </select>
+                                            <button type="submit" class="boton-secundario mt-1">Guardar cuenta</button>
+                                        </form>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+    </section>
+</section>

--- a/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
+++ b/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
@@ -39,6 +39,7 @@
             <a class="item-menu @((controllerActual == "dashboard" && accionActual == "administrador") ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Administrador">Inicio</a>
             <a class="item-menu @((controllerActual == "administracion" && (accionActual == "gestionusuarios" || accionActual == "crearusuario" || accionActual == "editarusuario" || accionActual == "reasignarcliente")) ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="GestionUsuarios">Usuarios</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "rolespermisos") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="RolesPermisos">Roles y permisos</a>
+            <a class="item-menu @((controllerActual == "administracion" && accionActual == "validacioncuentasbancarias") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="ValidacionCuentasBancarias">Cuentas bancarias</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "parametrospago") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="ParametrosPago">Configuración de pagos</a>
             <a class="item-menu @(moduloActivo == "reportes" || controllerActual == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "auditorialogs") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="AuditoriaLogs">Auditoría</a>
@@ -49,7 +50,8 @@
         {
             <a class="item-menu @(moduloActivo == "dashboard" ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Dueno">Inicio</a>
             <a class="item-menu @(moduloActivo == "fincas" ? "activo" : string.Empty)" asp-controller="Fincas" asp-action="MisFincas">Mis fincas</a>
-            <a class="item-menu item-menu--proximamente" href="#" data-omitir-trobber-global="true" aria-disabled="true">Cuenta bancaria</a>
+            <a class="item-menu @((controllerActual == "pagos" && accionActual == "cuentabancaria") ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="CuentaBancaria">Cuenta bancaria</a>
+            <a class="item-menu @((controllerActual == "pagos" && accionActual == "planesdueno") ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="PlanesDueno">Planes de pago</a>
             <a class="item-menu @(moduloActivo == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
             <a class="item-menu @(moduloActivo == "notificaciones" ? "activo" : string.Empty)" asp-controller="Notificaciones" asp-action="Index">Notificaciones</a>
             <a class="item-menu @(moduloActivo == "mi-perfil" ? "activo" : string.Empty)" asp-controller="MiPerfil" asp-action="Index">Mi perfil</a>

--- a/scripts/sql/20260418_pagos_motor_calculo.sql
+++ b/scripts/sql/20260418_pagos_motor_calculo.sql
@@ -1,0 +1,34 @@
+USE PSA_CostaRica;
+GO
+
+IF OBJECT_ID(N'dbo.PlanesPagoDetalleCalculo', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.PlanesPagoDetalleCalculo
+    (
+        IdDetalleCalculo            INT IDENTITY(1,1) NOT NULL,
+        IdPlanPago                  INT NOT NULL,
+        HectareasAprobadas          DECIMAL(12,2) NOT NULL,
+        PrecioBasePorHectarea       DECIMAL(10,2) NOT NULL,
+        PorcentajeVegetacion        DECIMAL(5,2) NOT NULL,
+        PorcentajeHidrico           DECIMAL(5,2) NOT NULL,
+        PorcentajeNacientes         DECIMAL(5,2) NOT NULL,
+        PorcentajePendiente         DECIMAL(5,2) NOT NULL,
+        PorcentajeTotalAntesTope    DECIMAL(5,2) NOT NULL,
+        PorcentajeTopeAplicado      DECIMAL(5,2) NOT NULL,
+        PorcentajeTotalAplicado     DECIMAL(5,2) NOT NULL,
+        MontoBaseMensual            DECIMAL(10,2) NOT NULL,
+        MontoAjusteMensual          DECIMAL(10,2) NOT NULL,
+        MontoFinalMensual           DECIMAL(10,2) NOT NULL,
+        VegetacionFinal             VARCHAR(100) NOT NULL,
+        TieneRecursosHidricosFinal  BIT NOT NULL,
+        CantidadNacientesFinal      INT NOT NULL,
+        PendienteFinal              VARCHAR(50) NOT NULL,
+        FechaCalculo                DATETIME2 NOT NULL CONSTRAINT DF_PlanesPagoDetalleCalculo_FechaCalculo DEFAULT (SYSDATETIME()),
+        CONSTRAINT PK_PlanesPagoDetalleCalculo PRIMARY KEY (IdDetalleCalculo),
+        CONSTRAINT FK_PlanesPagoDetalleCalculo_PlanesPago FOREIGN KEY (IdPlanPago) REFERENCES dbo.PlanesPago(IdPlanPago),
+        CONSTRAINT UQ_PlanesPagoDetalleCalculo_IdPlanPago UNIQUE (IdPlanPago)
+    );
+END;
+GO
+
+PRINT 'Ejecute también BaseDatos/04_creacion_stored_procedures.sql (SP de pagos), BaseDatos/05_creacion_triggers.sql (autogeneración) y scripts/sql/20260418_pagos_plan_sin_cuenta.sql (plan sin cuenta inicial).';

--- a/scripts/sql/20260418_pagos_plan_sin_cuenta.sql
+++ b/scripts/sql/20260418_pagos_plan_sin_cuenta.sql
@@ -1,0 +1,22 @@
+USE PSA_CostaRica;
+GO
+
+IF COL_LENGTH('dbo.PlanesPago', 'IdCuentaBancaria') IS NOT NULL
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM sys.columns c
+        INNER JOIN sys.objects o ON o.object_id = c.object_id
+        WHERE o.name = 'PlanesPago'
+          AND o.schema_id = SCHEMA_ID('dbo')
+          AND c.name = 'IdCuentaBancaria'
+          AND c.is_nullable = 0
+    )
+    BEGIN
+        ALTER TABLE dbo.PlanesPago
+        ALTER COLUMN IdCuentaBancaria INT NULL;
+    END
+END;
+GO
+
+PRINT 'Ejecute también BaseDatos/04_creacion_stored_procedures.sql y BaseDatos/05_creacion_triggers.sql para alinear SP/Triggers al modelo de plan sin cuenta inicial.';


### PR DESCRIPTION
### Motivation

- Introduce a payments subsystem to generate and manage yearly payment plans for approved farms and allow owners to register and associate bank accounts for payouts.
- Make schema and data access resilient to environments with different existing columns or missing permission catalog to support incremental deployments.

### Description

- Database schema: add `Permisos`, `RolesPermisos`, and `PlanesPagoDetalleCalculo` tables, make `PlanesPago.IdCuentaBancaria` nullable, and adjust cleanup in `01_creacion_bd_y_tablas.sql` to include new tables; provide helper scripts in `scripts/sql/` for incremental deployment (`20260418_pagos_motor_calculo.sql`, `20260418_pagos_plan_sin_cuenta.sql`).
- Stored procedures & triggers: add `SP_Pagos_*` procedures to simulate/generate plans, obtain owner history/plans and manage owner bank accounts, and add triggers `TR_EvaluacionesTecnicas_GenerarPlanPago` and `TR_CuentasBancarias_GenerarPlanPagoPendiente` to auto-generate plans when evaluations or bank validations change.
- Data access and business logic: add `PlanPagoDAO`, `PagosManager` and DTOs under `PSA.EntidadesDTO.DTOs.Pagos` and wire services in `Program.cs`; extend `CuentaBancariaDAO` to dynamically adapt to existing schema columns and to set validation state to `Validada` when approved; add error handling to `EvaluacionTecnicaDAO` and fix `RolPermisoDAO` SQL/formatting.
- Web/API/UI: add `PagosController` API and server-side `PagosManager` usage; add UI pages and partials for owner flows (`PlanesDueno`, `HistorialPagos`, `CuentaBancaria`), administration flows for validating bank accounts with modal UI, and small UX/audit message adjustments across controllers and views.

### Testing

- No automated tests were executed as part of this rollout; changes should be validated by running database migration scripts (`BaseDatos/04_creacion_stored_procedures.sql`, `BaseDatos/05_creacion_triggers.sql` and the new `scripts/sql/*`) and performing manual end-to-end checks in a staging environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c76b9b3c832d8af509069f54ad5b)