### PR TITLE
Evitar violación del índice único al crear Configuración de Pago (Activa)

### DIFF
--- a/PSA.DataAccess/DAO/ConfiguracionPagoDAO.cs
+++ b/PSA.DataAccess/DAO/ConfiguracionPagoDAO.cs
@@ -16,6 +16,7 @@ public class ConfiguracionPagoDAO(IDbConnectionFactory connectionFactory)
         var columnas = await ObtenerColumnasConfiguracionPagoAsync(connection);
         var autogenerarVersion = columnas.Contains("Version", StringComparer.OrdinalIgnoreCase) && dto.Version <= 0;
         var versionCalculada = dto.Version;
+        var requiereActivacionPosterior = dto.Activa && columnas.Contains("Activa", StringComparer.OrdinalIgnoreCase);
 
         using var tx = connection.BeginTransaction();
 
@@ -37,8 +38,8 @@ public class ConfiguracionPagoDAO(IDbConnectionFactory connectionFactory)
             AgregarColumnaSiExiste("TopePorcentajeAjuste", dto.TopePorcentajeAjuste);
             AgregarColumnaSiExiste("FechaVigenciaDesde", dto.FechaVigenciaDesde);
             AgregarColumnaSiExiste("FechaVigenciaHasta", dto.FechaVigenciaHasta);
-            AgregarColumnaSiExiste("Estado", dto.Activa ? "Activa" : "Inactiva");
-            AgregarColumnaSiExiste("Activa", dto.Activa);
+            AgregarColumnaSiExiste("Estado", dto.Activa && !requiereActivacionPosterior ? "Activa" : "Inactiva");
+            AgregarColumnaSiExiste("Activa", requiereActivacionPosterior ? false : dto.Activa);
             AgregarColumnaSiExiste("IdAdministrador", dto.CreadoPor);
             AgregarColumnaSiExiste("CreadoPor", dto.CreadoPor);
 


### PR DESCRIPTION
### Motivation
- Evitar que el guardado de una nueva configuración de pago falle con el error `Cannot insert duplicate key ... UX_ConfiguracionesPago_Activa` cuando ya existe otra configuración activa en la base de datos. 
- Mantener la lógica de dejar exactamente una configuración activa al final de la transacción y asegurar compatibilidad con esquemas que no tienen la columna `Activa`.

### Description
- Modifiqué `ConfiguracionPagoDAO.CrearConfiguracionAsync` para introducir la variable `requiereActivacionPosterior` que detecta cuando `dto.Activa` es true y la tabla contiene la columna `Activa`. 
- Cambio del valor insertado para las columnas: ahora `Estado` y `Activa` se insertan como inactivos cuando se requiere activación posterior (`Estado = 'Inactiva'` y `Activa = 0`) para evitar violar el índice único durante el `INSERT`. 
- Se mantiene la llamada posterior a `AsegurarUnicaConfiguracionActivaAsync` dentro de la misma transacción para activar la nueva fila y desactivar las demás, preservando el comportamiento funcional final.
- El cambio se realizó respetando esquemas que no tengan la columna `Activa` y sin alterar la lógica de guardado de los ajustes (`GuardarDetallesConfiguracionAsync`).

### Testing
- Se intentó ejecutar `dotnet build psa-costa-rica.slnx` en el entorno, pero falló porque `dotnet` no está disponible (`dotnet: command not found`).
- No se ejecutaron pruebas unitarias automatizadas adicionales en este entorno por la falta de runtime/tools, por lo que no hay builds verdes que reportar aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e315006b80832d9844d4da376964c4)