### PR TITLE
Mejorar validación y mensajes de error en evaluación técnica

### DIFF
--- a/PSA.AppCore/Managers/EvaluacionTecnicaManager.cs
+++ b/PSA.AppCore/Managers/EvaluacionTecnicaManager.cs
@@ -75,11 +75,24 @@ namespace PSA.AppCore.Managers
             }
 
             dto.DecisionTecnica = dto.DecisionTecnica.Trim();
-            if (!dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase)
-                && !dto.DecisionTecnica.Equals("No Califica", StringComparison.OrdinalIgnoreCase))
+            if (dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase))
+            {
+                dto.DecisionTecnica = "Califica";
+            }
+            else if (dto.DecisionTecnica.Equals("No Califica", StringComparison.OrdinalIgnoreCase)
+                || dto.DecisionTecnica.Equals("No califica", StringComparison.OrdinalIgnoreCase))
+            {
+                dto.DecisionTecnica = "No Califica";
+            }
+            else
             {
                 throw new InvalidOperationException("La decisión técnica debe ser 'Califica' o 'No Califica'.");
             }
+
+            dto.VegetacionAjustada = string.IsNullOrWhiteSpace(dto.VegetacionAjustada) ? null : dto.VegetacionAjustada.Trim();
+            dto.UsoSueloAjustado = string.IsNullOrWhiteSpace(dto.UsoSueloAjustado) ? null : dto.UsoSueloAjustado.Trim();
+            dto.PendienteAjustada = string.IsNullOrWhiteSpace(dto.PendienteAjustada) ? null : dto.PendienteAjustada.Trim();
+            dto.Observaciones = string.IsNullOrWhiteSpace(dto.Observaciones) ? null : dto.Observaciones.Trim();
 
             return _evaluacionTecnicaDAO.RegistrarResultadoAsync(idEvaluacion, dto);
         }

--- a/PSA.WebAPI/Controllers/EvaluacionesTecnicasController.cs
+++ b/PSA.WebAPI/Controllers/EvaluacionesTecnicasController.cs
@@ -49,13 +49,20 @@ namespace PSA.WebAPI.Controllers
         [HttpPut("{idEvaluacion:int}/resultado")]
         public async Task<IActionResult> RegistrarResultado([FromRoute] int idEvaluacion, [FromBody] RegistrarResultadoEvaluacionDTO dto)
         {
-            var actualizado = await _evaluacionTecnicaManager.RegistrarResultadoAsync(idEvaluacion, dto);
-            if (!actualizado)
+            try
             {
-                return BadRequest(new { Mensaje = "No fue posible registrar el resultado de evaluación." });
-            }
+                var actualizado = await _evaluacionTecnicaManager.RegistrarResultadoAsync(idEvaluacion, dto);
+                if (!actualizado)
+                {
+                    return BadRequest(new { Mensaje = "No fue posible registrar el resultado de evaluación. Verifique que la evaluación esté en estado Pendiente o En proceso." });
+                }
 
-            return Ok(new { Mensaje = "Resultado de evaluación registrado correctamente." });
+                return Ok(new { Mensaje = "Resultado de evaluación registrado correctamente." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
+            }
         }
 
         [HttpPut("{idEvaluacion:int}/estado")]

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -7,6 +7,7 @@ using PSA.WebApp.Models;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Text.Json;
 
 namespace PSA.WebApp.Controllers
 {
@@ -65,7 +66,7 @@ namespace PSA.WebApp.Controllers
             var response = await client.PutAsJsonAsync($"api/EvaluacionesTecnicas/{idEvaluacion}/resultado", model.Formulario);
             if (!response.IsSuccessStatusCode)
             {
-                TempData["MensajeError"] = "No fue posible guardar la evaluación.";
+                TempData["MensajeError"] = await ObtenerMensajeErrorApiAsync(response, "No fue posible guardar la evaluación.");
                 model.Detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle") ?? new();
                 model.EvidenciasExistentes = await ObtenerEvidenciasPorFincaAsync(client, model.Detalle.IdFinca);
                 CargarCatalogosEvaluacion();
@@ -165,6 +166,29 @@ namespace PSA.WebApp.Controllers
         }
 
         private int ObtenerIdUsuarioSesion() => int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+
+        private static async Task<string> ObtenerMensajeErrorApiAsync(HttpResponseMessage response, string mensajePorDefecto)
+        {
+            try
+            {
+                var contenido = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrWhiteSpace(contenido))
+                    return mensajePorDefecto;
+
+                using var doc = JsonDocument.Parse(contenido);
+                if (doc.RootElement.TryGetProperty("mensaje", out var mensajeCamel) && mensajeCamel.ValueKind == JsonValueKind.String)
+                    return mensajeCamel.GetString() ?? mensajePorDefecto;
+
+                if (doc.RootElement.TryGetProperty("Mensaje", out var mensajePascal) && mensajePascal.ValueKind == JsonValueKind.String)
+                    return mensajePascal.GetString() ?? mensajePorDefecto;
+
+                return mensajePorDefecto;
+            }
+            catch
+            {
+                return mensajePorDefecto;
+            }
+        }
 
         private static async Task<List<FincaEvidenciaDTO>> ObtenerEvidenciasPorFincaAsync(HttpClient client, int idFinca)
         {

--- a/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
@@ -116,7 +116,7 @@
                     <select asp-for="Formulario.DecisionTecnica" required>
                         <option value="">Seleccione...</option>
                         <option value="Califica">Califica</option>
-                        <option value="No califica">No califica</option>
+                        <option value="No Califica">No califica</option>
                     </select>
                     <span asp-validation-for="Formulario.DecisionTecnica" class="text-danger"></span>
                 </div>


### PR DESCRIPTION
### Motivation
- Detectar por qué no se puede guardar una evaluación técnica y ofrecer un diagnóstico claro en la UI en lugar de un mensaje genérico.
- Evitar errores por formatos inconsistentes en `DecisionTecnica` que impidan el guardado o provoquen estados inesperados.
- Asegurar que los campos opcionales no lleguen como cadenas vacías al DAO y evitar problemas al persistir en la base de datos.

### Description
- Normalicé `DecisionTecnica` a valores canónicos (`Califica` / `No Califica`) y acepté variantes (`No califica`) antes de persistir; además hago `Trim()` de cadenas relevantes en `PSA.AppCore/Managers/EvaluacionTecnicaManager.cs`.
- Convierto cadenas vacías de campos opcionales a `null` (`VegetacionAjustada`, `UsoSueloAjustado`, `PendienteAjustada`, `Observaciones`) para que el DAO y la BD reciban valores coherentes.
- En el endpoint `PUT /api/EvaluacionesTecnicas/{idEvaluacion}/resultado` ahora se capturan `InvalidOperationException` y se retornan `400 BadRequest` con el mensaje de validación apropiado en `PSA.WebAPI/Controllers/EvaluacionesTecnicasController.cs`.
- El controlador web extrae el mensaje detallado devuelto por la API y lo muestra al usuario (helper `ObtenerMensajeErrorApiAsync` añadido) y se ajustó la vista para enviar consistentemente `No Califica` en `PSA.WebApp/Controllers/EvaluacionesController.cs` y `PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml`.

### Testing
- Intenté compilar la solución con `dotnet build psa-costa-rica.slnx`, pero falló por ausencia de la herramienta en el entorno (`dotnet: command not found`).
- Verifiqué cambios locales con `git status` y `git diff`, y los cambios fueron confirmados en un commit local exitoso; no se pudieron ejecutar pruebas automatizadas ni build por la falta de `dotnet`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38bfe3b64832d862e636d32d4063b)