### PR TITLE
Normalize decision values, trim inputs and enforce engineer assignment with improved error handling

### DIFF
--- a/PSA.AppCore/Managers/EvaluacionTecnicaManager.cs
+++ b/PSA.AppCore/Managers/EvaluacionTecnicaManager.cs
@@ -75,11 +75,24 @@ namespace PSA.AppCore.Managers
             }
 
             dto.DecisionTecnica = dto.DecisionTecnica.Trim();
-            if (!dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase)
-                && !dto.DecisionTecnica.Equals("No Califica", StringComparison.OrdinalIgnoreCase))
+            if (dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase))
+            {
+                dto.DecisionTecnica = "Califica";
+            }
+            else if (dto.DecisionTecnica.Equals("No Califica", StringComparison.OrdinalIgnoreCase)
+                || dto.DecisionTecnica.Equals("No califica", StringComparison.OrdinalIgnoreCase))
+            {
+                dto.DecisionTecnica = "No Califica";
+            }
+            else
             {
                 throw new InvalidOperationException("La decisión técnica debe ser 'Califica' o 'No Califica'.");
             }
+
+            dto.VegetacionAjustada = string.IsNullOrWhiteSpace(dto.VegetacionAjustada) ? null : dto.VegetacionAjustada.Trim();
+            dto.UsoSueloAjustado = string.IsNullOrWhiteSpace(dto.UsoSueloAjustado) ? null : dto.UsoSueloAjustado.Trim();
+            dto.PendienteAjustada = string.IsNullOrWhiteSpace(dto.PendienteAjustada) ? null : dto.PendienteAjustada.Trim();
+            dto.Observaciones = string.IsNullOrWhiteSpace(dto.Observaciones) ? null : dto.Observaciones.Trim();
 
             return _evaluacionTecnicaDAO.RegistrarResultadoAsync(idEvaluacion, dto);
         }

--- a/PSA.WebAPI/Controllers/EvaluacionesTecnicasController.cs
+++ b/PSA.WebAPI/Controllers/EvaluacionesTecnicasController.cs
@@ -49,13 +49,20 @@ namespace PSA.WebAPI.Controllers
         [HttpPut("{idEvaluacion:int}/resultado")]
         public async Task<IActionResult> RegistrarResultado([FromRoute] int idEvaluacion, [FromBody] RegistrarResultadoEvaluacionDTO dto)
         {
-            var actualizado = await _evaluacionTecnicaManager.RegistrarResultadoAsync(idEvaluacion, dto);
-            if (!actualizado)
+            try
             {
-                return BadRequest(new { Mensaje = "No fue posible registrar el resultado de evaluación." });
-            }
+                var actualizado = await _evaluacionTecnicaManager.RegistrarResultadoAsync(idEvaluacion, dto);
+                if (!actualizado)
+                {
+                    return BadRequest(new { Mensaje = "No fue posible registrar el resultado de evaluación. Verifique que la evaluación esté en estado Pendiente o En proceso." });
+                }
 
-            return Ok(new { Mensaje = "Resultado de evaluación registrado correctamente." });
+                return Ok(new { Mensaje = "Resultado de evaluación registrado correctamente." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
+            }
         }
 
         [HttpPut("{idEvaluacion:int}/estado")]

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -7,6 +7,7 @@ using PSA.WebApp.Models;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Text.Json;
 
 namespace PSA.WebApp.Controllers
 {
@@ -44,6 +45,39 @@ namespace PSA.WebApp.Controllers
             var client = _httpClientFactory.CreateClient("AuthApi");
             var detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle");
             if (detalle == null) return RedirectToAction(nameof(FincasPendientes));
+            var idIngenieroSesion = ObtenerIdUsuarioSesion();
+            if (idIngenieroSesion <= 0)
+            {
+                TempData["MensajeError"] = "No fue posible identificar la sesión del ingeniero actual.";
+                return RedirectToAction(nameof(FincasPendientes));
+            }
+
+            if (detalle.IdIngeniero.HasValue && detalle.IdIngeniero.Value != idIngenieroSesion)
+            {
+                TempData["MensajeError"] = "No puede editar esta evaluación porque está asignada a otro ingeniero.";
+                return RedirectToAction(nameof(FincasPendientes));
+            }
+
+            if (!detalle.IdIngeniero.HasValue)
+            {
+                var responseAsignar = await client.PutAsJsonAsync(
+                    $"api/EvaluacionesTecnicas/{idEvaluacion}/asignar",
+                    new AsignarEvaluacionDTO { IdIngeniero = idIngenieroSesion });
+
+                if (!responseAsignar.IsSuccessStatusCode)
+                {
+                    TempData["MensajeError"] = await ObtenerMensajeErrorApiAsync(responseAsignar, "No fue posible asignar la evaluación al ingeniero actual.");
+                    return RedirectToAction(nameof(FincasPendientes));
+                }
+
+                detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle");
+                if (detalle == null)
+                {
+                    TempData["MensajeError"] = "No fue posible recuperar el detalle de la evaluación después de asignarla.";
+                    return RedirectToAction(nameof(FincasPendientes));
+                }
+            }
+
             var evidencias = await ObtenerEvidenciasPorFincaAsync(client, detalle.IdFinca);
 
             CargarCatalogosEvaluacion();
@@ -62,10 +96,43 @@ namespace PSA.WebApp.Controllers
         {
             if (idEvaluacion <= 0 || model?.Formulario == null) return RedirectToAction(nameof(FincasPendientes));
             var client = _httpClientFactory.CreateClient("AuthApi");
+            var idIngenieroSesion = ObtenerIdUsuarioSesion();
+            if (idIngenieroSesion <= 0)
+            {
+                TempData["MensajeError"] = "No fue posible identificar la sesión del ingeniero actual.";
+                return RedirectToAction(nameof(FincasPendientes));
+            }
+
+            var detalleActual = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle");
+            if (detalleActual == null)
+            {
+                TempData["MensajeError"] = "No se encontró la evaluación solicitada.";
+                return RedirectToAction(nameof(FincasPendientes));
+            }
+
+            if (detalleActual.IdIngeniero.HasValue && detalleActual.IdIngeniero.Value != idIngenieroSesion)
+            {
+                TempData["MensajeError"] = "No puede guardar esta evaluación porque está asignada a otro ingeniero.";
+                return RedirectToAction(nameof(FincasPendientes));
+            }
+
+            if (!detalleActual.IdIngeniero.HasValue)
+            {
+                var responseAsignar = await client.PutAsJsonAsync(
+                    $"api/EvaluacionesTecnicas/{idEvaluacion}/asignar",
+                    new AsignarEvaluacionDTO { IdIngeniero = idIngenieroSesion });
+
+                if (!responseAsignar.IsSuccessStatusCode)
+                {
+                    TempData["MensajeError"] = await ObtenerMensajeErrorApiAsync(responseAsignar, "No fue posible asignar la evaluación antes de guardarla.");
+                    return RedirectToAction(nameof(FincasPendientes));
+                }
+            }
+
             var response = await client.PutAsJsonAsync($"api/EvaluacionesTecnicas/{idEvaluacion}/resultado", model.Formulario);
             if (!response.IsSuccessStatusCode)
             {
-                TempData["MensajeError"] = "No fue posible guardar la evaluación.";
+                TempData["MensajeError"] = await ObtenerMensajeErrorApiAsync(response, "No fue posible guardar la evaluación.");
                 model.Detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle") ?? new();
                 model.EvidenciasExistentes = await ObtenerEvidenciasPorFincaAsync(client, model.Detalle.IdFinca);
                 CargarCatalogosEvaluacion();
@@ -165,6 +232,29 @@ namespace PSA.WebApp.Controllers
         }
 
         private int ObtenerIdUsuarioSesion() => int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+
+        private static async Task<string> ObtenerMensajeErrorApiAsync(HttpResponseMessage response, string mensajePorDefecto)
+        {
+            try
+            {
+                var contenido = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrWhiteSpace(contenido))
+                    return mensajePorDefecto;
+
+                using var doc = JsonDocument.Parse(contenido);
+                if (doc.RootElement.TryGetProperty("mensaje", out var mensajeCamel) && mensajeCamel.ValueKind == JsonValueKind.String)
+                    return mensajeCamel.GetString() ?? mensajePorDefecto;
+
+                if (doc.RootElement.TryGetProperty("Mensaje", out var mensajePascal) && mensajePascal.ValueKind == JsonValueKind.String)
+                    return mensajePascal.GetString() ?? mensajePorDefecto;
+
+                return mensajePorDefecto;
+            }
+            catch
+            {
+                return mensajePorDefecto;
+            }
+        }
 
         private static async Task<List<FincaEvidenciaDTO>> ObtenerEvidenciasPorFincaAsync(HttpClient client, int idFinca)
         {

--- a/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
@@ -116,7 +116,7 @@
                     <select asp-for="Formulario.DecisionTecnica" required>
                         <option value="">Seleccione...</option>
                         <option value="Califica">Califica</option>
-                        <option value="No califica">No califica</option>
+                        <option value="No Califica">No califica</option>
                     </select>
                     <span asp-validation-for="Formulario.DecisionTecnica" class="text-danger"></span>
                 </div>


### PR DESCRIPTION
### Motivation
- Ensure `DecisionTecnica` values are normalized and optional text inputs are trimmed or set to null to avoid inconsistent data storage.
- Prevent engineers from editing evaluations assigned to other users and automatically assign evaluations to the current engineer when appropriate.
- Surface validation errors from the manager layer to the UI and provide clearer API error messages for end users.

### Description
- In `EvaluacionTecnicaManager.RegistrarResultadoAsync` normalize `DecisionTecnica` to `"Califica"` or `"No Califica"`, validate its value, and trim/nullify `VegetacionAjustada`, `UsoSueloAjustado`, `PendienteAjustada`, and `Observaciones` before persisting.
- In `EvaluacionesTecnicasController.RegistrarResultado` wrap manager calls in a `try/catch` and return `BadRequest` with the manager exception message, and improve the failure message when the update returns false.
- In `EvaluacionesController` (WebApp) enforce that the current session engineer (`ObtenerIdUsuarioSesion`) can only edit their assigned evaluations, auto-assign evaluations via `PUT api/EvaluacionesTecnicas/{id}/asignar` when unassigned, and add `ObtenerMensajeErrorApiAsync` to parse API error responses for user-friendly messages.
- Update the view to use the normalized option value `No Califica` and add `using System.Text.Json` to support the new error-parsing helper.

### Testing
- No new automated tests were added to this change, and the existing automated test suite was executed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38bfe3b64832d862e636d32d4063b)