### PR TITLE
Refactor: exposición y vistas de Planes de Pago separadas por rol (Dueño / Ingeniero / Admin)

### DIFF
--- a/PSA.AppCore/Managers/PagosManager.cs
+++ b/PSA.AppCore/Managers/PagosManager.cs
@@ -6,10 +6,12 @@ namespace PSA.AppCore.Managers;
 
 public class PagosManager(
     PlanPagoDAO planPagoDao,
-    IPaymentPlanService paymentPlanService)
+    IPaymentPlanService paymentPlanService,
+    IPaymentPlanReadService paymentPlanReadService)
 {
     private readonly PlanPagoDAO _planPagoDao = planPagoDao;
     private readonly IPaymentPlanService _paymentPlanService = paymentPlanService;
+    private readonly IPaymentPlanReadService _paymentPlanReadService = paymentPlanReadService;
 
     public async Task<PlanPagoDTO?> GenerarPlanPagoAsync(GenerarPlanPagoRequestDTO request, int idUsuario, string? ip)
     {
@@ -51,15 +53,61 @@ public class PagosManager(
         return _planPagoDao.ObtenerPlanesDuenoAsync(idPropietario);
     }
 
+    public Task<List<OwnerPaymentPlanDto>> ObtenerPlanesOwnerAsync(int idPropietario)
+    {
+        if (idPropietario <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un propietario válido.");
+        }
+
+        return _paymentPlanReadService.ObtenerPlanesOwnerAsync(idPropietario);
+    }
+
+    public Task<OwnerPaymentPlanDetailDto?> ObtenerDetalleOwnerAsync(int idPropietario, int idPlanPago)
+    {
+        if (idPropietario <= 0 || idPlanPago <= 0)
+        {
+            throw new InvalidOperationException("Propietario o plan inválido.");
+        }
+
+        return _paymentPlanReadService.ObtenerDetalleOwnerAsync(idPropietario, idPlanPago);
+    }
+
     public Task<List<PlanPagoResumenDTO>> ObtenerPlanesPendientesIngenieroAsync(int idIngeniero)
     {
         return _planPagoDao.ObtenerPlanesPendientesAprobacionIngenieroAsync(idIngeniero);
+    }
+
+    public Task<EngineerPaymentImpactDto?> ObtenerImpactoIngenieroAsync(int idIngeniero, int idEvaluacion)
+    {
+        if (idIngeniero <= 0 || idEvaluacion <= 0)
+        {
+            throw new InvalidOperationException("Ingeniero o evaluación inválidos.");
+        }
+
+        return _paymentPlanReadService.ObtenerImpactoIngenieroAsync(idIngeniero, idEvaluacion);
     }
 
     public Task<List<PlanPagoResumenDTO>> ObtenerPlanesConFiltrosAsync(FiltroPlanesPagoDTO filtro)
     {
         filtro ??= new FiltroPlanesPagoDTO();
         return _planPagoDao.ObtenerPlanesConFiltrosAsync(filtro);
+    }
+
+    public Task<List<AdminPaymentPlanDto>> ObtenerPlanesAdminAsync(AdminPaymentPlanFilterDto filtro)
+    {
+        filtro ??= new AdminPaymentPlanFilterDto();
+        return _paymentPlanReadService.ObtenerPlanesAdminAsync(filtro);
+    }
+
+    public Task<AdminPaymentPlanDetailDto?> ObtenerDetalleAdminAsync(int idPlanPago)
+    {
+        if (idPlanPago <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un plan válido.");
+        }
+
+        return _paymentPlanReadService.ObtenerDetalleAdminAsync(idPlanPago);
     }
 
     public Task<List<CuentaBancariaDuenoDTO>> ObtenerCuentasBancariasDuenoAsync(int idUsuario)

--- a/PSA.AppCore/Services/PaymentPlanReadService.cs
+++ b/PSA.AppCore/Services/PaymentPlanReadService.cs
@@ -1,0 +1,33 @@
+using PSA.DataAccess.DAO;
+using PSA.EntidadesDTO.DTOs.Pagos;
+
+namespace PSA.AppCore.Services;
+
+public interface IPaymentPlanReadService
+{
+    Task<List<OwnerPaymentPlanDto>> ObtenerPlanesOwnerAsync(int idPropietario);
+    Task<OwnerPaymentPlanDetailDto?> ObtenerDetalleOwnerAsync(int idPropietario, int idPlanPago);
+    Task<EngineerPaymentImpactDto?> ObtenerImpactoIngenieroAsync(int idIngeniero, int idEvaluacion);
+    Task<List<AdminPaymentPlanDto>> ObtenerPlanesAdminAsync(AdminPaymentPlanFilterDto filtro);
+    Task<AdminPaymentPlanDetailDto?> ObtenerDetalleAdminAsync(int idPlanPago);
+}
+
+public class PaymentPlanReadService(PlanPagoDAO planPagoDao) : IPaymentPlanReadService
+{
+    private readonly PlanPagoDAO _planPagoDao = planPagoDao;
+
+    public Task<List<OwnerPaymentPlanDto>> ObtenerPlanesOwnerAsync(int idPropietario)
+        => _planPagoDao.ObtenerPlanesOwnerAsync(idPropietario);
+
+    public Task<OwnerPaymentPlanDetailDto?> ObtenerDetalleOwnerAsync(int idPropietario, int idPlanPago)
+        => _planPagoDao.ObtenerDetalleOwnerAsync(idPropietario, idPlanPago);
+
+    public Task<EngineerPaymentImpactDto?> ObtenerImpactoIngenieroAsync(int idIngeniero, int idEvaluacion)
+        => _planPagoDao.ObtenerImpactoPagoIngenieroAsync(idIngeniero, idEvaluacion);
+
+    public Task<List<AdminPaymentPlanDto>> ObtenerPlanesAdminAsync(AdminPaymentPlanFilterDto filtro)
+        => _planPagoDao.ObtenerPlanesAdminAsync(filtro);
+
+    public Task<AdminPaymentPlanDetailDto?> ObtenerDetalleAdminAsync(int idPlanPago)
+        => _planPagoDao.ObtenerDetalleAdminAsync(idPlanPago);
+}

--- a/PSA.DataAccess/DAO/PlanPagoDAO.cs
+++ b/PSA.DataAccess/DAO/PlanPagoDAO.cs
@@ -500,6 +500,418 @@ ORDER BY pp.Anio DESC, pp.IdPlanPago DESC;";
         return Convert.ToInt32(result ?? 0);
     }
 
+    public async Task<List<OwnerPaymentPlanDto>> ObtenerPlanesOwnerAsync(int idPropietario)
+    {
+        const string sql = @"
+SELECT
+    pp.IdPlanPago,
+    pp.IdFinca,
+    f.NombreFinca,
+    pp.Anio,
+    pp.EstadoPlan,
+    pp.MontoMensualCalculado,
+    CAST(pp.MontoMensualCalculado * 12 AS DECIMAL(12,2)) AS MontoAnual,
+    cb.EstadoValidacion AS EstadoCuentaBancaria,
+    cb.NumeroCuenta,
+    dc.HectareasAprobadas,
+    dc.VegetacionFinal,
+    dc.PorcentajeTotalAplicado,
+    dc.PorcentajeTopeAplicado,
+    dc.PorcentajeTotalAntesTope
+FROM dbo.PlanesPago pp
+INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+LEFT JOIN dbo.CuentasBancarias cb ON cb.IdCuentaBancaria = pp.IdCuentaBancaria
+LEFT JOIN dbo.PlanesPagoDetalleCalculo dc ON dc.IdPlanPago = pp.IdPlanPago
+WHERE f.IdPropietario = @IdPropietario
+ORDER BY pp.Anio DESC, pp.IdPlanPago DESC;";
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+
+        using var reader = await command.ExecuteReaderAsync();
+        var resultado = new List<OwnerPaymentPlanDto>();
+        while (await reader.ReadAsync())
+        {
+            var cuenta = reader["NumeroCuenta"]?.ToString();
+            var porcentajeTope = reader["PorcentajeTopeAplicado"] == DBNull.Value ? 0 : reader.GetDecimal(reader.GetOrdinal("PorcentajeTopeAplicado"));
+            var porcentajeAntesTope = reader["PorcentajeTotalAntesTope"] == DBNull.Value ? 0 : reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAntesTope"));
+            resultado.Add(new OwnerPaymentPlanDto
+            {
+                IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+                IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+                NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+                Anio = reader.GetInt32(reader.GetOrdinal("Anio")),
+                EstadoPlan = reader["EstadoPlan"]?.ToString() ?? string.Empty,
+                MontoMensual = reader.GetDecimal(reader.GetOrdinal("MontoMensualCalculado")),
+                MontoAnual = reader.GetDecimal(reader.GetOrdinal("MontoAnual")),
+                EstadoCuentaBancaria = reader["EstadoCuentaBancaria"]?.ToString() ?? "Pendiente",
+                CuentaBancariaMascara = MascaraCuenta(cuenta),
+                ResumenCalculo = new OwnerPaymentCalculationSummaryDto
+                {
+                    HectareasAprobadas = reader["HectareasAprobadas"] == DBNull.Value ? 0 : reader.GetDecimal(reader.GetOrdinal("HectareasAprobadas")),
+                    CoberturaVegetacion = reader["VegetacionFinal"]?.ToString() ?? "No disponible",
+                    AjusteAplicadoPorcentaje = reader["PorcentajeTotalAplicado"] == DBNull.Value ? 0 : reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAplicado")),
+                    TopeAplicadoPorcentaje = porcentajeTope,
+                    SeAplicoTope = porcentajeAntesTope > porcentajeTope && porcentajeTope > 0
+                }
+            });
+        }
+
+        return resultado;
+    }
+
+    public async Task<OwnerPaymentPlanDetailDto?> ObtenerDetalleOwnerAsync(int idPropietario, int idPlanPago)
+    {
+        var planes = await ObtenerPlanesOwnerAsync(idPropietario);
+        var plan = planes.FirstOrDefault(p => p.IdPlanPago == idPlanPago);
+        if (plan == null)
+        {
+            return null;
+        }
+
+        return new OwnerPaymentPlanDetailDto
+        {
+            Plan = plan,
+            Cuotas = await ObtenerCuotasPorPlanAsync(idPlanPago)
+        };
+    }
+
+    public async Task<EngineerPaymentImpactDto?> ObtenerImpactoPagoIngenieroAsync(int idIngeniero, int idEvaluacion)
+    {
+        const string sql = @"
+SELECT TOP 1
+    e.IdEvaluacion,
+    f.IdFinca,
+    f.NombreFinca,
+    e.DecisionTecnica,
+    pp.IdPlanPago,
+    pp.EstadoPlan,
+    pp.MontoMensualCalculado,
+    CAST(pp.MontoMensualCalculado * 12 AS DECIMAL(12,2)) AS MontoAnual,
+    cb.EstadoValidacion AS EstadoCuentaBancaria,
+    pp.IdCuentaBancaria
+FROM dbo.EvaluacionesTecnicas e
+INNER JOIN dbo.Fincas f ON f.IdFinca = e.IdFinca
+LEFT JOIN dbo.PlanesPago pp ON pp.IdEvaluacion = e.IdEvaluacion
+LEFT JOIN dbo.CuentasBancarias cb ON cb.IdCuentaBancaria = pp.IdCuentaBancaria
+WHERE e.IdEvaluacion = @IdEvaluacion
+  AND e.IdIngeniero = @IdIngeniero;";
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdEvaluacion", idEvaluacion);
+        command.Parameters.AddWithValue("@IdIngeniero", idIngeniero);
+
+        using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return null;
+        }
+
+        var decision = reader["DecisionTecnica"]?.ToString() ?? string.Empty;
+        var idPlan = reader["IdPlanPago"] == DBNull.Value ? null : reader.GetInt32(reader.GetOrdinal("IdPlanPago"));
+        var estadoPlan = reader["EstadoPlan"]?.ToString() ?? string.Empty;
+        var estadoCuenta = reader["EstadoCuentaBancaria"]?.ToString() ?? "Pendiente";
+
+        return new EngineerPaymentImpactDto
+        {
+            IdEvaluacion = reader.GetInt32(reader.GetOrdinal("IdEvaluacion")),
+            IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+            NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+            DecisionTecnica = decision,
+            GeneroPlan = idPlan.HasValue,
+            IdPlanPago = idPlan,
+            EstadoContinuidad = ResolverEstadoContinuidad(decision, idPlan.HasValue, estadoPlan, estadoCuenta),
+            MontoMensualReferencial = reader["MontoMensualCalculado"] == DBNull.Value ? null : reader.GetDecimal(reader.GetOrdinal("MontoMensualCalculado")),
+            MontoAnualReferencial = reader["MontoAnual"] == DBNull.Value ? null : reader.GetDecimal(reader.GetOrdinal("MontoAnual")),
+            EstadoCuentaBancaria = estadoCuenta,
+            CuentaRegistrada = reader["IdCuentaBancaria"] != DBNull.Value,
+            CuentaValidada = string.Equals(estadoCuenta, "Validada", StringComparison.OrdinalIgnoreCase)
+        };
+    }
+
+    public async Task<List<AdminPaymentPlanDto>> ObtenerPlanesAdminAsync(AdminPaymentPlanFilterDto filtro)
+    {
+        filtro ??= new AdminPaymentPlanFilterDto();
+        var condiciones = new List<string>();
+        var parametros = new List<SqlParameter>();
+
+        if (filtro.Anio.HasValue)
+        {
+            condiciones.Add("pp.Anio = @Anio");
+            parametros.Add(new SqlParameter("@Anio", filtro.Anio.Value));
+        }
+
+        if (filtro.IdFinca.HasValue)
+        {
+            condiciones.Add("pp.IdFinca = @IdFinca");
+            parametros.Add(new SqlParameter("@IdFinca", filtro.IdFinca.Value));
+        }
+
+        if (filtro.IdPropietario.HasValue)
+        {
+            condiciones.Add("f.IdPropietario = @IdPropietario");
+            parametros.Add(new SqlParameter("@IdPropietario", filtro.IdPropietario.Value));
+        }
+
+        if (filtro.IdIngeniero.HasValue)
+        {
+            condiciones.Add("e.IdIngeniero = @IdIngeniero");
+            parametros.Add(new SqlParameter("@IdIngeniero", filtro.IdIngeniero.Value));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filtro.Provincia))
+        {
+            condiciones.Add("f.Provincia = @Provincia");
+            parametros.Add(new SqlParameter("@Provincia", filtro.Provincia.Trim()));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filtro.Canton))
+        {
+            condiciones.Add("f.Canton = @Canton");
+            parametros.Add(new SqlParameter("@Canton", filtro.Canton.Trim()));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filtro.Distrito))
+        {
+            condiciones.Add("f.Distrito = @Distrito");
+            parametros.Add(new SqlParameter("@Distrito", filtro.Distrito.Trim()));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filtro.EstadoPlan))
+        {
+            condiciones.Add("pp.EstadoPlan = @EstadoPlan");
+            parametros.Add(new SqlParameter("@EstadoPlan", filtro.EstadoPlan.Trim()));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filtro.EstadoBancario))
+        {
+            condiciones.Add("COALESCE(cb.EstadoValidacion, 'Pendiente') = @EstadoBancario");
+            parametros.Add(new SqlParameter("@EstadoBancario", filtro.EstadoBancario.Trim()));
+        }
+
+        var where = condiciones.Count > 0 ? $"WHERE {string.Join(" AND ", condiciones)}" : string.Empty;
+        var sql = $@"
+SELECT
+    pp.IdPlanPago,
+    pp.IdFinca,
+    f.NombreFinca,
+    f.Provincia,
+    f.Canton,
+    f.Distrito,
+    pp.Anio,
+    pp.EstadoPlan,
+    pp.MontoMensualCalculado,
+    CAST(pp.MontoMensualCalculado * 12 AS DECIMAL(12,2)) AS MontoAnual,
+    COALESCE(cb.EstadoValidacion, 'Pendiente') AS EstadoBancario,
+    cb.NumeroCuenta,
+    cp.Version AS VersionConfiguracion,
+    prop.Nombre + ' ' + prop.Apellido1 AS Propietario,
+    e.IdIngeniero,
+    COALESCE(ing.Nombre + ' ' + ing.Apellido1, 'Sin asignar') AS Ingeniero
+FROM dbo.PlanesPago pp
+INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+INNER JOIN dbo.Usuarios prop ON prop.IdUsuario = f.IdPropietario
+INNER JOIN dbo.ConfiguracionesPago cp ON cp.IdConfiguracionPago = pp.IdConfiguracionPago
+LEFT JOIN dbo.CuentasBancarias cb ON cb.IdCuentaBancaria = pp.IdCuentaBancaria
+LEFT JOIN dbo.EvaluacionesTecnicas e ON e.IdEvaluacion = pp.IdEvaluacion
+LEFT JOIN dbo.Usuarios ing ON ing.IdUsuario = e.IdIngeniero
+{where}
+ORDER BY pp.Anio DESC, pp.IdPlanPago DESC;";
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+        using var command = new SqlCommand(sql, connection);
+        if (parametros.Count > 0)
+        {
+            command.Parameters.AddRange(parametros.ToArray());
+        }
+
+        using var reader = await command.ExecuteReaderAsync();
+        var resultado = new List<AdminPaymentPlanDto>();
+        while (await reader.ReadAsync())
+        {
+            resultado.Add(new AdminPaymentPlanDto
+            {
+                IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+                IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+                NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+                Propietario = reader["Propietario"]?.ToString() ?? string.Empty,
+                IdIngeniero = reader["IdIngeniero"] == DBNull.Value ? null : reader.GetInt32(reader.GetOrdinal("IdIngeniero")),
+                Ingeniero = reader["Ingeniero"]?.ToString() ?? string.Empty,
+                Provincia = reader["Provincia"]?.ToString() ?? string.Empty,
+                Canton = reader["Canton"]?.ToString() ?? string.Empty,
+                Distrito = reader["Distrito"]?.ToString() ?? string.Empty,
+                Anio = reader.GetInt32(reader.GetOrdinal("Anio")),
+                EstadoPlan = reader["EstadoPlan"]?.ToString() ?? string.Empty,
+                EstadoBancario = reader["EstadoBancario"]?.ToString() ?? "Pendiente",
+                CuentaBancariaMascara = MascaraCuenta(reader["NumeroCuenta"]?.ToString()),
+                MontoMensual = reader.GetDecimal(reader.GetOrdinal("MontoMensualCalculado")),
+                MontoAnual = reader.GetDecimal(reader.GetOrdinal("MontoAnual")),
+                VersionConfiguracion = reader.GetInt32(reader.GetOrdinal("VersionConfiguracion"))
+            });
+        }
+
+        return resultado;
+    }
+
+    public async Task<AdminPaymentPlanDetailDto?> ObtenerDetalleAdminAsync(int idPlanPago)
+    {
+        var plan = (await ObtenerPlanesAdminAsync(new AdminPaymentPlanFilterDto()))
+            .FirstOrDefault(p => p.IdPlanPago == idPlanPago);
+        if (plan == null)
+        {
+            return null;
+        }
+
+        const string sqlDetalle = @"
+SELECT TOP 1 *
+FROM dbo.PlanesPagoDetalleCalculo
+WHERE IdPlanPago = @IdPlanPago;";
+
+        const string sqlBitacora = @"
+SELECT TOP 20 FechaAccion, Accion, Detalle, IdUsuario
+FROM dbo.AuditoriaLog
+WHERE Modulo = 'Pagos'
+  AND IdRegistroAfectado = @IdPlanPago
+ORDER BY FechaAccion DESC;";
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var commandDetalle = new SqlCommand(sqlDetalle, connection);
+        commandDetalle.Parameters.AddWithValue("@IdPlanPago", idPlanPago);
+        using var readerDetalle = await commandDetalle.ExecuteReaderAsync();
+
+        var calculo = new PlanPagoCalculoDetalleDTO();
+        if (await readerDetalle.ReadAsync())
+        {
+            calculo = new PlanPagoCalculoDetalleDTO
+            {
+                HectareasAprobadas = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("HectareasAprobadas")),
+                PrecioBasePorHectarea = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PrecioBasePorHectarea")),
+                MontoBaseMensual = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("MontoBaseMensual")),
+                PorcentajeVegetacion = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeVegetacion")),
+                PorcentajeHidrico = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeHidrico")),
+                PorcentajeNacientes = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeNacientes")),
+                PorcentajePendiente = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajePendiente")),
+                PorcentajeTotalAntesTope = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeTotalAntesTope")),
+                PorcentajeTopeAplicado = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeTopeAplicado")),
+                PorcentajeTotalAplicado = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeTotalAplicado")),
+                MontoAjusteMensual = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("MontoAjusteMensual")),
+                MontoFinalMensual = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("MontoFinalMensual")),
+                VegetacionFinal = readerDetalle["VegetacionFinal"]?.ToString() ?? string.Empty,
+                TieneRecursosHidricosFinal = readerDetalle.GetBoolean(readerDetalle.GetOrdinal("TieneRecursosHidricosFinal")),
+                CantidadNacientesFinal = readerDetalle.GetInt32(readerDetalle.GetOrdinal("CantidadNacientesFinal")),
+                PendienteFinal = readerDetalle["PendienteFinal"]?.ToString() ?? string.Empty
+            };
+        }
+
+        await readerDetalle.CloseAsync();
+
+        var bitacora = new List<AuditoriaPlanPagoDto>();
+        using var commandBitacora = new SqlCommand(sqlBitacora, connection);
+        commandBitacora.Parameters.AddWithValue("@IdPlanPago", idPlanPago);
+        using var readerBitacora = await commandBitacora.ExecuteReaderAsync();
+        while (await readerBitacora.ReadAsync())
+        {
+            bitacora.Add(new AuditoriaPlanPagoDto
+            {
+                FechaAccion = readerBitacora.GetDateTime(readerBitacora.GetOrdinal("FechaAccion")),
+                Accion = readerBitacora["Accion"]?.ToString() ?? string.Empty,
+                Detalle = readerBitacora["Detalle"]?.ToString(),
+                IdUsuario = readerBitacora["IdUsuario"] == DBNull.Value ? null : readerBitacora.GetInt32(readerBitacora.GetOrdinal("IdUsuario"))
+            });
+        }
+
+        return new AdminPaymentPlanDetailDto
+        {
+            Plan = plan,
+            Calculo = calculo,
+            Cuotas = await ObtenerCuotasPorPlanAsync(idPlanPago),
+            Bitacora = bitacora
+        };
+    }
+
+    private async Task<List<CuotaPlanPagoDTO>> ObtenerCuotasPorPlanAsync(int idPlanPago)
+    {
+        const string sql = @"
+SELECT pp.IdPlanPago, c.IdCuotaPago, pp.IdFinca, f.NombreFinca, pp.Anio, c.Mes, c.FechaProgramada, c.MontoProgramado, c.MontoPendiente, c.EstadoCuota, c.FechaPago
+FROM dbo.CuotasPago c
+INNER JOIN dbo.PlanesPago pp ON pp.IdPlanPago = c.IdPlanPago
+INNER JOIN dbo.Fincas f ON f.IdFinca = pp.IdFinca
+WHERE c.IdPlanPago = @IdPlanPago
+ORDER BY c.Mes;";
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdPlanPago", idPlanPago);
+        using var reader = await command.ExecuteReaderAsync();
+
+        var cuotas = new List<CuotaPlanPagoDTO>();
+        while (await reader.ReadAsync())
+        {
+            cuotas.Add(new CuotaPlanPagoDTO
+            {
+                IdPlanPago = reader.GetInt32(reader.GetOrdinal("IdPlanPago")),
+                IdCuotaPago = reader.GetInt32(reader.GetOrdinal("IdCuotaPago")),
+                IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
+                NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+                Anio = reader.GetInt32(reader.GetOrdinal("Anio")),
+                Mes = reader.GetInt32(reader.GetOrdinal("Mes")),
+                FechaProgramada = reader.GetDateTime(reader.GetOrdinal("FechaProgramada")),
+                MontoProgramado = reader.GetDecimal(reader.GetOrdinal("MontoProgramado")),
+                MontoPendiente = reader.GetDecimal(reader.GetOrdinal("MontoPendiente")),
+                EstadoCuota = reader["EstadoCuota"]?.ToString() ?? string.Empty,
+                FechaPago = reader["FechaPago"] == DBNull.Value ? null : reader.GetDateTime(reader.GetOrdinal("FechaPago"))
+            });
+        }
+
+        return cuotas;
+    }
+
+    private static string? MascaraCuenta(string? numeroCuenta)
+    {
+        if (string.IsNullOrWhiteSpace(numeroCuenta))
+        {
+            return null;
+        }
+
+        var compacta = new string(numeroCuenta.Where(char.IsLetterOrDigit).ToArray());
+        if (compacta.Length <= 4)
+        {
+            return $"****{compacta}";
+        }
+
+        return $"****{compacta[^4..]}";
+    }
+
+    private static string ResolverEstadoContinuidad(string decisionTecnica, bool generoPlan, string estadoPlan, string estadoCuenta)
+    {
+        if (!string.Equals(decisionTecnica, "Califica", StringComparison.OrdinalIgnoreCase))
+        {
+            return "No califica";
+        }
+
+        if (!generoPlan)
+        {
+            return "Pendiente de generación";
+        }
+
+        if (!string.Equals(estadoCuenta, "Validada", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Bloqueado por cuenta bancaria";
+        }
+
+        return string.Equals(estadoPlan, EstadosPlanPago.Activo, StringComparison.OrdinalIgnoreCase)
+            ? "Plan generado correctamente"
+            : "Pendiente de continuidad";
+    }
+
     private static PlanPagoDTO MapPlanPago(SqlDataReader reader)
     {
         return new PlanPagoDTO

--- a/PSA.EntidadesDTO/DTOs/Pagos/PlanPagoDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Pagos/PlanPagoDTO.cs
@@ -130,6 +130,100 @@
         public bool SoloPendientes { get; set; }
     }
 
+    public class OwnerPaymentPlanDto
+    {
+        public int IdPlanPago { get; set; }
+        public int IdFinca { get; set; }
+        public string NombreFinca { get; set; } = string.Empty;
+        public int Anio { get; set; }
+        public string EstadoPlan { get; set; } = string.Empty;
+        public decimal MontoMensual { get; set; }
+        public decimal MontoAnual { get; set; }
+        public string EstadoCuentaBancaria { get; set; } = "Pendiente";
+        public string? CuentaBancariaMascara { get; set; }
+        public OwnerPaymentCalculationSummaryDto ResumenCalculo { get; set; } = new();
+    }
+
+    public class OwnerPaymentCalculationSummaryDto
+    {
+        public decimal HectareasAprobadas { get; set; }
+        public string CoberturaVegetacion { get; set; } = string.Empty;
+        public decimal AjusteAplicadoPorcentaje { get; set; }
+        public decimal TopeAplicadoPorcentaje { get; set; }
+        public bool SeAplicoTope { get; set; }
+    }
+
+    public class OwnerPaymentPlanDetailDto
+    {
+        public OwnerPaymentPlanDto Plan { get; set; } = new();
+        public List<CuotaPlanPagoDTO> Cuotas { get; set; } = new();
+    }
+
+    public class EngineerPaymentImpactDto
+    {
+        public int IdEvaluacion { get; set; }
+        public int IdFinca { get; set; }
+        public string NombreFinca { get; set; } = string.Empty;
+        public string DecisionTecnica { get; set; } = string.Empty;
+        public bool GeneroPlan { get; set; }
+        public int? IdPlanPago { get; set; }
+        public string EstadoContinuidad { get; set; } = string.Empty;
+        public decimal? MontoMensualReferencial { get; set; }
+        public decimal? MontoAnualReferencial { get; set; }
+        public string EstadoCuentaBancaria { get; set; } = "Pendiente";
+        public bool CuentaRegistrada { get; set; }
+        public bool CuentaValidada { get; set; }
+    }
+
+    public class AdminPaymentPlanFilterDto
+    {
+        public int? Anio { get; set; }
+        public int? IdFinca { get; set; }
+        public int? IdPropietario { get; set; }
+        public int? IdIngeniero { get; set; }
+        public string? Provincia { get; set; }
+        public string? Canton { get; set; }
+        public string? Distrito { get; set; }
+        public string? EstadoPlan { get; set; }
+        public string? EstadoBancario { get; set; }
+    }
+
+    public class AdminPaymentPlanDto
+    {
+        public int IdPlanPago { get; set; }
+        public int IdFinca { get; set; }
+        public string NombreFinca { get; set; } = string.Empty;
+        public string Propietario { get; set; } = string.Empty;
+        public int? IdIngeniero { get; set; }
+        public string Ingeniero { get; set; } = string.Empty;
+        public string Provincia { get; set; } = string.Empty;
+        public string Canton { get; set; } = string.Empty;
+        public string Distrito { get; set; } = string.Empty;
+        public int Anio { get; set; }
+        public string EstadoPlan { get; set; } = string.Empty;
+        public string EstadoBancario { get; set; } = string.Empty;
+        public string? CuentaBancariaMascara { get; set; }
+        public decimal MontoMensual { get; set; }
+        public decimal MontoAnual { get; set; }
+        public int VersionConfiguracion { get; set; }
+    }
+
+    public class AdminPaymentPlanDetailDto
+    {
+        public AdminPaymentPlanDto Plan { get; set; } = new();
+        public PlanPagoCalculoDetalleDTO Calculo { get; set; } = new();
+        public List<CuotaPlanPagoDTO> Cuotas { get; set; } = new();
+        public List<AuditoriaPlanPagoDto> Bitacora { get; set; } = new();
+    }
+
+    public class AuditoriaPlanPagoDto
+    {
+        public DateTime FechaAccion { get; set; }
+        public string Accion { get; set; } = string.Empty;
+        public string? Detalle { get; set; }
+        public int? IdUsuario { get; set; }
+    }
+
     public class PlanPagoGenerationContextDTO
     {
         public int IdFinca { get; set; }

--- a/PSA.WebAPI/Controllers/PagosController.cs
+++ b/PSA.WebAPI/Controllers/PagosController.cs
@@ -6,7 +6,7 @@ namespace PSA.WebAPI.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class PagosController(PagosManager pagosManager) : BaseApiController
+public class PagosController(PagosManager pagosManager) : ControllerBase
 {
     private readonly PagosManager _pagosManager = pagosManager;
 
@@ -17,7 +17,7 @@ public class PagosController(PagosManager pagosManager) : BaseApiController
         {
             var plan = await _pagosManager.GenerarPlanPagoAsync(
                 request,
-                AdminSistemaId,
+                idUsuario: 1,
                 HttpContext.Connection.RemoteIpAddress?.ToString());
 
             if (plan == null)
@@ -26,6 +26,38 @@ public class PagosController(PagosManager pagosManager) : BaseApiController
             }
 
             return Ok(plan);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpGet("dueno/{idPropietario:int}/planes")]
+    public async Task<ActionResult<List<OwnerPaymentPlanDto>>> ObtenerPlanesDueno([FromRoute] int idPropietario)
+    {
+        try
+        {
+            return Ok(await _pagosManager.ObtenerPlanesOwnerAsync(idPropietario));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpGet("dueno/{idPropietario:int}/planes/{idPlanPago:int}")]
+    public async Task<ActionResult<OwnerPaymentPlanDetailDto>> ObtenerDetalleDueno([FromRoute] int idPropietario, [FromRoute] int idPlanPago)
+    {
+        try
+        {
+            var detalle = await _pagosManager.ObtenerDetalleOwnerAsync(idPropietario, idPlanPago);
+            if (detalle == null)
+            {
+                return NotFound(new { Mensaje = "No se encontró el plan solicitado para el propietario." });
+            }
+
+            return Ok(detalle);
         }
         catch (InvalidOperationException ex)
         {
@@ -47,13 +79,18 @@ public class PagosController(PagosManager pagosManager) : BaseApiController
         }
     }
 
-    [HttpGet("dueno/{idPropietario:int}/planes")]
-    public async Task<ActionResult<List<PlanPagoResumenDTO>>> ObtenerPlanesDueno([FromRoute] int idPropietario)
+    [HttpGet("ingeniero/{idIngeniero:int}/evaluaciones/{idEvaluacion:int}/impacto")]
+    public async Task<ActionResult<EngineerPaymentImpactDto>> ObtenerImpactoIngeniero([FromRoute] int idIngeniero, [FromRoute] int idEvaluacion)
     {
         try
         {
-            var planes = await _pagosManager.ObtenerPlanesDuenoAsync(idPropietario);
-            return Ok(planes);
+            var impacto = await _pagosManager.ObtenerImpactoIngenieroAsync(idIngeniero, idEvaluacion);
+            if (impacto == null)
+            {
+                return NotFound(new { Mensaje = "No se encontró la evaluación o no pertenece al ingeniero." });
+            }
+
+            return Ok(impacto);
         }
         catch (InvalidOperationException ex)
         {
@@ -61,42 +98,53 @@ public class PagosController(PagosManager pagosManager) : BaseApiController
         }
     }
 
-    [HttpGet("ingeniero/{idIngeniero:int}/planes-pendientes")]
-    public async Task<ActionResult<List<PlanPagoResumenDTO>>> ObtenerPlanesPendientesIngeniero([FromRoute] int idIngeniero)
-    {
-        try
-        {
-            var planes = await _pagosManager.ObtenerPlanesPendientesIngenieroAsync(idIngeniero);
-            return Ok(planes);
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { Mensaje = ex.Message });
-        }
-    }
-
-    [HttpGet("planes")]
-    public async Task<ActionResult<List<PlanPagoResumenDTO>>> ObtenerPlanesConFiltros(
+    [HttpGet("admin/planes")]
+    public async Task<ActionResult<List<AdminPaymentPlanDto>>> ObtenerPlanesAdmin(
         [FromQuery] int? anio = null,
         [FromQuery] int? idFinca = null,
         [FromQuery] int? idPropietario = null,
         [FromQuery] int? idIngeniero = null,
+        [FromQuery] string? provincia = null,
+        [FromQuery] string? canton = null,
+        [FromQuery] string? distrito = null,
         [FromQuery] string? estadoPlan = null,
-        [FromQuery] bool soloPendientes = false)
+        [FromQuery] string? estadoBancario = null)
     {
         try
         {
-            var planes = await _pagosManager.ObtenerPlanesConFiltrosAsync(new FiltroPlanesPagoDTO
+            var filtro = new AdminPaymentPlanFilterDto
             {
                 Anio = anio,
                 IdFinca = idFinca,
                 IdPropietario = idPropietario,
                 IdIngeniero = idIngeniero,
+                Provincia = provincia,
+                Canton = canton,
+                Distrito = distrito,
                 EstadoPlan = estadoPlan,
-                SoloPendientes = soloPendientes
-            });
+                EstadoBancario = estadoBancario
+            };
 
-            return Ok(planes);
+            return Ok(await _pagosManager.ObtenerPlanesAdminAsync(filtro));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpGet("admin/planes/{idPlanPago:int}")]
+    public async Task<ActionResult<AdminPaymentPlanDetailDto>> ObtenerDetalleAdmin([FromRoute] int idPlanPago)
+    {
+        try
+        {
+            var detalle = await _pagosManager.ObtenerDetalleAdminAsync(idPlanPago);
+            if (detalle == null)
+            {
+                return NotFound(new { Mensaje = "No se encontró el plan solicitado." });
+            }
+
+            return Ok(detalle);
         }
         catch (InvalidOperationException ex)
         {
@@ -143,7 +191,7 @@ public class PagosController(PagosManager pagosManager) : BaseApiController
                 return BadRequest(new { Mensaje = "No fue posible asociar la cuenta al plan seleccionado." });
             }
 
-            return Ok(new { Mensaje = "Cuenta bancaria asociada correctamente al plan de pago. Estado: PendienteAprobacionFinal." });
+            return Ok(new { Mensaje = "Cuenta bancaria asociada correctamente al plan de pago." });
         }
         catch (InvalidOperationException ex)
         {
@@ -159,7 +207,7 @@ public class PagosController(PagosManager pagosManager) : BaseApiController
             var aprobado = await _pagosManager.AprobarPlanFinalAsync(idPlanPago, model, HttpContext.Connection.RemoteIpAddress?.ToString());
             if (!aprobado)
             {
-                return BadRequest(new { Mensaje = "No fue posible activar el plan. Verifique estado pendiente de aprobación y cuenta bancaria válida." });
+                return BadRequest(new { Mensaje = "No fue posible activar el plan. Verifique estado y cuenta bancaria válida." });
             }
 
             return Ok(new { Mensaje = "Plan de pago activado correctamente." });

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -21,6 +21,7 @@
     <Compile Include="Controllers\AdministracionController.cs" />
     <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Controllers\PerfilController.cs" />
+    <Compile Include="Controllers\PagosController.cs" />
     <Compile Include="Controllers\Middleware\ExceptionMiddleware.cs" />
     <Compile Include="Controllers\Models\ApiResponse.cs" />
     <Compile Include="Controllers\RecuperacionContrasenaController.cs" />

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -55,6 +55,7 @@ builder.Services.AddScoped<LandingDAO>();
 
 builder.Services.AddScoped<PSA.AppCore.Services.IPaymentCalculationService, PSA.AppCore.Services.PaymentCalculationService>();
 builder.Services.AddScoped<PSA.AppCore.Services.IPaymentPlanService, PSA.AppCore.Services.PaymentPlanService>();
+builder.Services.AddScoped<PSA.AppCore.Services.IPaymentPlanReadService, PSA.AppCore.Services.PaymentPlanReadService>();
 builder.Services.AddScoped<FincaService>();
 builder.Services.AddScoped<EvaluacionService>();
 builder.Services.AddScoped<FincaEvidenciaService>();

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -228,6 +228,15 @@ namespace PSA.WebApp.Controllers
                 "Detalle de visita técnica y trazabilidad de ajustes.");
             var client = _httpClientFactory.CreateClient("AuthApi");
             var detalle = await client.GetFromJsonAsync<DetalleFincaParaEvaluacionDTO>($"api/EvaluacionesTecnicas/{idEvaluacion}/detalle") ?? new DetalleFincaParaEvaluacionDTO();
+            var idIngeniero = ObtenerIdUsuarioSesion();
+            if (idIngeniero > 0 && detalle.IdEvaluacion > 0)
+            {
+                ViewBag.ImpactoPago = await ObtenerSeguroDesdeApiAsync<EngineerPaymentImpactDto>(
+                    client,
+                    $"api/Pagos/ingeniero/{idIngeniero}/evaluaciones/{detalle.IdEvaluacion}/impacto",
+                    "No fue posible cargar el impacto en plan de pago.");
+            }
+
             return View(detalle);
         }
 

--- a/PSA.WebApp/Controllers/PagosController.cs
+++ b/PSA.WebApp/Controllers/PagosController.cs
@@ -1,7 +1,6 @@
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using PSA.EntidadesDTO.DTOs.Pagos;
-using PSA.EntidadesDTO.DTOs;
 using PSA.WebApp.Services;
 using System.Security.Claims;
 
@@ -19,34 +18,59 @@ namespace PSA.WebApp.Controllers
 
         [HttpGet]
         [Authorize(Roles = "1")]
-        public IActionResult PlanesPago()
+        public async Task<IActionResult> PlanesPago(int? anio = null, string? estadoPlan = null, string? provincia = null, string? canton = null, string? distrito = null, string? estadoBancario = null)
         {
             ViewBag.ModuloActivo = "pagos";
             ViewBag.RolActivo = "Administrador";
             ViewBag.TituloPagina = "Planes de pago";
-            ViewBag.SubtituloPagina = "Consulte los planes generados y su estado general.";
+            ViewBag.SubtituloPagina = "Listado administrativo completo con filtros operativos.";
             ViewBag.BreadcrumbActual = "Planes de pago";
-            return View();
+            ViewBag.Anio = anio;
+            ViewBag.EstadoPlan = estadoPlan;
+            ViewBag.Provincia = provincia;
+            ViewBag.Canton = canton;
+            ViewBag.Distrito = distrito;
+            ViewBag.EstadoBancario = estadoBancario;
+
+            var query = $"?anio={anio}&estadoPlan={Uri.EscapeDataString(estadoPlan ?? string.Empty)}&provincia={Uri.EscapeDataString(provincia ?? string.Empty)}&canton={Uri.EscapeDataString(canton ?? string.Empty)}&distrito={Uri.EscapeDataString(distrito ?? string.Empty)}&estadoBancario={Uri.EscapeDataString(estadoBancario ?? string.Empty)}";
+            var planes = await _httpClientService.GetAsync<List<AdminPaymentPlanDto>>($"api/Pagos/admin/planes{query}") ?? new();
+            return View(planes);
         }
 
         [HttpGet]
-        [Authorize(Roles = "1,2,3")]
-        public IActionResult DetallePlanPago(int? id = null)
+        [Authorize(Roles = "1,2")]
+        public async Task<IActionResult> DetallePlanPago(int id)
         {
             ViewBag.ModuloActivo = "pagos";
             var rol = User.FindFirstValue(ClaimTypes.Role);
-            ViewBag.RolActivo = rol == "3" ? "Ingeniero" : rol == "2" ? "Dueno" : "Administrador";
-            ViewBag.PlanPagoId = id ?? 1;
-            ViewBag.TituloPagina = "Detalle del plan de pago";
-            ViewBag.SubtituloPagina = "Revise cuotas mensuales, estado de pago y atrasos.";
-            ViewBag.BreadcrumbPadreTexto = rol == "3" ? "Planes pendientes por aprobación" : "Planes de pago";
-            ViewBag.BreadcrumbPadreUrl = rol == "3"
-                ? Url.Action("PlanesIngenieroPendientes", "Pagos")
-                : rol == "2"
-                    ? Url.Action("PlanesDueno", "Pagos")
-                    : Url.Action("PlanesPago", "Pagos");
-            ViewBag.BreadcrumbActual = "Detalle del plan";
-            return View();
+            var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var parsedId) ? parsedId : 0;
+
+            if (rol == "2")
+            {
+                ViewBag.RolActivo = "Dueno";
+                ViewBag.BreadcrumbPadreTexto = "Mis pagos";
+                ViewBag.BreadcrumbPadreUrl = Url.Action(nameof(PlanesDueno));
+                var detalleOwner = await _httpClientService.GetAsync<OwnerPaymentPlanDetailDto>($"api/Pagos/dueno/{idUsuario}/planes/{id}");
+                if (detalleOwner == null)
+                {
+                    TempData["Error"] = "No se encontró el plan solicitado o no pertenece a su usuario.";
+                    return RedirectToAction(nameof(PlanesDueno));
+                }
+
+                return View("DetallePlanPagoDueno", detalleOwner);
+            }
+
+            ViewBag.RolActivo = "Administrador";
+            ViewBag.BreadcrumbPadreTexto = "Planes de pago";
+            ViewBag.BreadcrumbPadreUrl = Url.Action(nameof(PlanesPago));
+            var detalleAdmin = await _httpClientService.GetAsync<AdminPaymentPlanDetailDto>($"api/Pagos/admin/planes/{id}");
+            if (detalleAdmin == null)
+            {
+                TempData["Error"] = "No se encontró el plan solicitado.";
+                return RedirectToAction(nameof(PlanesPago));
+            }
+
+            return View("DetallePlanPagoAdmin", detalleAdmin);
         }
 
         [HttpGet]
@@ -55,46 +79,14 @@ namespace PSA.WebApp.Controllers
         {
             ViewBag.ModuloActivo = "pagos";
             ViewBag.RolActivo = "Dueno";
-            ViewBag.TituloPagina = "Planes de pago";
-            ViewBag.SubtituloPagina = "Consulte sus planes de pago por finca.";
-            ViewBag.BreadcrumbActual = "Planes de pago";
+            ViewBag.TituloPagina = "Mis pagos";
+            ViewBag.SubtituloPagina = "Consulte únicamente los planes de sus fincas aprobadas.";
+            ViewBag.BreadcrumbActual = "Mis pagos";
 
             var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
             var planes = idUsuario > 0
-                ? await _httpClientService.GetAsync<List<PlanPagoResumenDTO>>($"api/Pagos/dueno/{idUsuario}/planes") ?? new()
-                : new List<PlanPagoResumenDTO>();
-            if (idUsuario > 0 && planes.Count == 0)
-            {
-                planes = await _httpClientService.GetAsync<List<PlanPagoResumenDTO>>($"api/Pagos/planes?idPropietario={idUsuario}") ?? new();
-            }
-
-            if (idUsuario > 0 && planes.Count == 0)
-            {
-                var fincas = await _httpClientService.GetAsync<List<FincaResumenDTO>>($"api/Fincas/mis-fincas?idPropietario={idUsuario}") ?? new();
-                if (fincas.Count > 0)
-                {
-                    var planesPorFinca = new List<PlanPagoResumenDTO>();
-                    foreach (var finca in fincas)
-                    {
-                        var planesFinca = await _httpClientService.GetAsync<List<PlanPagoResumenDTO>>($"api/Pagos/planes?idFinca={finca.IdFinca}") ?? new();
-                        planesPorFinca.AddRange(planesFinca);
-                    }
-
-                    planes = planesPorFinca
-                        .GroupBy(p => p.IdPlanPago)
-                        .Select(g => g.First())
-                        .OrderByDescending(p => p.Anio)
-                        .ThenByDescending(p => p.IdPlanPago)
-                        .ToList();
-                }
-            }
-            var cuentas = idUsuario > 0
-                ? await _httpClientService.GetAsync<List<CuentaBancariaDuenoDTO>>($"api/Pagos/dueno/{idUsuario}/cuentas-bancarias") ?? new()
-                : new List<CuentaBancariaDuenoDTO>();
-
-            ViewBag.CuentasValidadasActivas = cuentas
-                .Where(c => string.Equals(c.EstadoValidacion, "Validada", StringComparison.OrdinalIgnoreCase) && c.Activa)
-                .ToList();
+                ? await _httpClientService.GetAsync<List<OwnerPaymentPlanDto>>($"api/Pagos/dueno/{idUsuario}/planes") ?? new()
+                : new List<OwnerPaymentPlanDto>();
 
             return View(planes);
         }
@@ -166,55 +158,10 @@ namespace PSA.WebApp.Controllers
                 });
 
             TempData[resultado != null ? "Exito" : "Error"] = resultado != null
-                ? "Cuenta bancaria asociada correctamente. El plan pasó a PendienteAprobacionFinal."
+                ? "Cuenta bancaria asociada correctamente."
                 : "No fue posible asociar la cuenta bancaria al plan.";
 
             return RedirectToAction(nameof(PlanesDueno));
-        }
-
-        [HttpGet]
-        [Authorize(Roles = "3")]
-        public async Task<IActionResult> PlanesIngenieroPendientes(int? anio = null, string? estadoPlan = null)
-        {
-            ViewBag.ModuloActivo = "pagos";
-            ViewBag.RolActivo = "Ingeniero";
-            ViewBag.TituloPagina = "Planes pendientes de aprobación";
-            ViewBag.SubtituloPagina = "Aprobación final de planes con cuenta bancaria asociada.";
-            ViewBag.BreadcrumbActual = "Planes pendientes";
-            ViewBag.Anio = anio;
-            ViewBag.EstadoPlan = estadoPlan;
-
-            var soloPendientes = string.IsNullOrWhiteSpace(estadoPlan);
-            var query = $"?soloPendientes={soloPendientes.ToString().ToLowerInvariant()}";
-            if (anio.HasValue)
-            {
-                query += $"&anio={anio.Value}";
-            }
-            if (!string.IsNullOrWhiteSpace(estadoPlan))
-            {
-                query += $"&estadoPlan={Uri.EscapeDataString(estadoPlan)}";
-            }
-
-            var planes = await _httpClientService.GetAsync<List<PlanPagoResumenDTO>>($"api/Pagos/planes{query}") ?? new();
-
-            return View(planes);
-        }
-
-        [HttpPost]
-        [Authorize(Roles = "3")]
-        [ValidateAntiForgeryToken]
-        public async Task<IActionResult> AprobarPlanIngeniero(int idPlanPago)
-        {
-            var idIngeniero = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
-            var resultado = await _httpClientService.PutAsync<AprobarPlanPagoFinalDTO, object>(
-                $"api/Pagos/ingeniero/planes/{idPlanPago}/aprobar-final",
-                new AprobarPlanPagoFinalDTO { IdIngeniero = idIngeniero });
-
-            TempData[resultado != null ? "Exito" : "Error"] = resultado != null
-                ? "Plan aprobado y activado correctamente."
-                : "No fue posible aprobar el plan seleccionado.";
-
-            return RedirectToAction(nameof(PlanesIngenieroPendientes));
         }
     }
 }

--- a/PSA.WebApp/Views/Evaluaciones/DetalleEvaluacion.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/DetalleEvaluacion.cshtml
@@ -46,4 +46,26 @@
             <li>Recursos hídricos ajustados: @(Model.RecursosHidricosAjustado.HasValue ? (Model.RecursosHidricosAjustado.Value ? "Sí" : "No") : "Sin ajuste")</li>
         </ul>
     </section>
+
+    <section class="tarjeta-panel">
+        <h3>Impacto en Plan de Pago</h3>
+        @{
+            var impacto = ViewBag.ImpactoPago as PSA.EntidadesDTO.DTOs.Pagos.EngineerPaymentImpactDto;
+        }
+        @if (impacto == null)
+        {
+            <p class="text-muted">No hay información de impacto de pago para esta evaluación.</p>
+        }
+        else
+        {
+            <ul class="lista-timeline">
+                <li>Decisión técnica: @impacto.DecisionTecnica</li>
+                <li>¿Generó plan?: @(impacto.GeneroPlan ? "Sí" : "No")</li>
+                <li>Estado de continuidad: @impacto.EstadoContinuidad</li>
+                <li>Cuenta bancaria: @impacto.EstadoCuentaBancaria (solo indicador)</li>
+                <li>Monto mensual referencial: @(impacto.MontoMensualReferencial.HasValue ? $"₡{impacto.MontoMensualReferencial.Value:N2}" : "No aplica")</li>
+                <li>Monto anual referencial: @(impacto.MontoAnualReferencial.HasValue ? $"₡{impacto.MontoAnualReferencial.Value:N2}" : "No aplica")</li>
+            </ul>
+        }
+    </section>
 </section>

--- a/PSA.WebApp/Views/Pagos/DetallePlanPagoAdmin.cshtml
+++ b/PSA.WebApp/Views/Pagos/DetallePlanPagoAdmin.cshtml
@@ -1,0 +1,66 @@
+@model PSA.EntidadesDTO.DTOs.Pagos.AdminPaymentPlanDetailDto
+@{ ViewData["Title"] = "Detalle del plan"; }
+<section class="seccion-pagina">
+    <div class="cabecera-pagina">
+        <div>
+            <span class="eyebrow">Plan #@Model.Plan.IdPlanPago</span>
+            <h2>@Model.Plan.NombreFinca (@Model.Plan.Anio)</h2>
+            <p>Detalle operativo: cálculo, cuotas y auditoría.</p>
+        </div>
+        <a class="boton-secundario" asp-action="PlanesPago">Volver</a>
+    </div>
+
+    <section class="tarjeta-panel">
+        <ul class="lista-timeline">
+            <li>Propietario: @Model.Plan.Propietario</li>
+            <li>Ingeniero: @Model.Plan.Ingeniero</li>
+            <li>Estado del plan: @Model.Plan.EstadoPlan</li>
+            <li>Estado bancario: @Model.Plan.EstadoBancario (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</li>
+            <li>Versión de configuración: @Model.Plan.VersionConfiguracion</li>
+            <li>Precio base por hectárea: ₡@Model.Calculo.PrecioBasePorHectarea.ToString("N2")</li>
+            <li>Hectáreas aprobadas: @Model.Calculo.HectareasAprobadas.ToString("N2")</li>
+            <li>Porcentaje total aplicado: @Model.Calculo.PorcentajeTotalAplicado.ToString("N2")%</li>
+            <li>Monto mensual: ₡@Model.Plan.MontoMensual.ToString("N2")</li>
+            <li>Monto anual: ₡@Model.Plan.MontoAnual.ToString("N2")</li>
+        </ul>
+    </section>
+
+    <section class="tarjeta-panel">
+        <h3>Cuotas</h3>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead><tr><th>Mes</th><th>Programada</th><th>Monto</th><th>Pendiente</th><th>Estado</th><th>Pago</th></tr></thead>
+                <tbody>
+                @foreach (var cuota in Model.Cuotas)
+                {
+                    <tr>
+                        <td>@cuota.Mes</td>
+                        <td>@cuota.FechaProgramada.ToString("dd/MM/yyyy")</td>
+                        <td>₡@cuota.MontoProgramado.ToString("N2")</td>
+                        <td>₡@cuota.MontoPendiente.ToString("N2")</td>
+                        <td>@cuota.EstadoCuota</td>
+                        <td>@(cuota.FechaPago?.ToString("dd/MM/yyyy") ?? "N/A")</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="tarjeta-panel">
+        <h3>Bitácora del plan</h3>
+        <ul class="lista-timeline">
+            @if (!Model.Bitacora.Any())
+            {
+                <li>Sin registros de auditoría disponibles para este plan.</li>
+            }
+            else
+            {
+                @foreach (var log in Model.Bitacora)
+                {
+                    <li>@log.FechaAccion.ToString("dd/MM/yyyy HH:mm") - @log.Accion - @(log.Detalle ?? "Sin detalle")</li>
+                }
+            }
+        </ul>
+    </section>
+</section>

--- a/PSA.WebApp/Views/Pagos/DetallePlanPagoDueno.cshtml
+++ b/PSA.WebApp/Views/Pagos/DetallePlanPagoDueno.cshtml
@@ -1,0 +1,46 @@
+@model PSA.EntidadesDTO.DTOs.Pagos.OwnerPaymentPlanDetailDto
+@{ ViewData["Title"] = "Detalle del plan"; }
+<section class="seccion-pagina">
+    <div class="cabecera-pagina">
+        <div>
+            <span class="eyebrow">Plan #@Model.Plan.IdPlanPago</span>
+            <h2>@Model.Plan.NombreFinca (@Model.Plan.Anio)</h2>
+            <p>Resumen simple del cálculo y estado de cuotas.</p>
+        </div>
+        <a class="boton-secundario" asp-action="PlanesDueno">Volver</a>
+    </div>
+
+    <section class="tarjeta-panel">
+        <ul class="lista-timeline">
+            <li>Estado general: @Model.Plan.EstadoPlan</li>
+            <li>Monto mensual: ₡@Model.Plan.MontoMensual.ToString("N2")</li>
+            <li>Monto anual: ₡@Model.Plan.MontoAnual.ToString("N2")</li>
+            <li>Cuenta bancaria: @Model.Plan.EstadoCuentaBancaria (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</li>
+            <li>Hectáreas aprobadas: @Model.Plan.ResumenCalculo.HectareasAprobadas.ToString("N2")</li>
+            <li>Cobertura/vegetación: @Model.Plan.ResumenCalculo.CoberturaVegetacion</li>
+            <li>Ajuste aplicado: @Model.Plan.ResumenCalculo.AjusteAplicadoPorcentaje.ToString("N2")%</li>
+            <li>Tope aplicado: @(Model.Plan.ResumenCalculo.SeAplicoTope ? $"Sí ({Model.Plan.ResumenCalculo.TopeAplicadoPorcentaje:N2}%)" : "No")</li>
+        </ul>
+    </section>
+
+    <section class="tarjeta-panel">
+        <h3>Cuotas mensuales</h3>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead><tr><th>Mes</th><th>Fecha programada</th><th>Monto</th><th>Estado</th><th>Fecha pago</th></tr></thead>
+                <tbody>
+                @foreach (var cuota in Model.Cuotas)
+                {
+                    <tr>
+                        <td>@cuota.Mes</td>
+                        <td>@cuota.FechaProgramada.ToString("dd/MM/yyyy")</td>
+                        <td>₡@cuota.MontoProgramado.ToString("N2")</td>
+                        <td>@cuota.EstadoCuota</td>
+                        <td>@(cuota.FechaPago?.ToString("dd/MM/yyyy") ?? "Pendiente")</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    </section>
+</section>

--- a/PSA.WebApp/Views/Pagos/PlanesDueno.cshtml
+++ b/PSA.WebApp/Views/Pagos/PlanesDueno.cshtml
@@ -1,16 +1,18 @@
-@model List<PSA.EntidadesDTO.DTOs.Pagos.PlanPagoResumenDTO>
+@model List<PSA.EntidadesDTO.DTOs.Pagos.OwnerPaymentPlanDto>
 @{
-    ViewData["Title"] = "Planes de pago";
-    var cuentasValidadasActivas = ViewBag.CuentasValidadasActivas as List<PSA.EntidadesDTO.DTOs.Pagos.CuentaBancariaDuenoDTO> ?? new();
+    ViewData["Title"] = "Mis pagos";
 }
 <section class="seccion-pagina">
     <div class="cabecera-pagina">
         <div>
             <span class="eyebrow">Consulta del propietario</span>
-            <h2>Planes de pago</h2>
-            <p>Un plan por finca aprobada para pago.</p>
+            <h2>Mis pagos</h2>
+            <p>Solo se muestran planes asociados a sus fincas aprobadas.</p>
         </div>
-        <a class="boton-secundario" asp-controller="Pagos" asp-action="HistorialPagos">Ver historial de cuotas</a>
+        <div class="d-flex gap-2">
+            <a class="boton-secundario" asp-controller="Pagos" asp-action="CuentaBancaria">Cuenta bancaria</a>
+            <a class="boton-secundario" asp-controller="Pagos" asp-action="HistorialPagos">Historial de cuotas</a>
+        </div>
     </div>
 
     <section class="tarjeta-panel">
@@ -20,9 +22,9 @@
                     <tr>
                         <th>Finca</th>
                         <th>Año</th>
+                        <th>Estado</th>
                         <th>Monto mensual</th>
                         <th>Monto anual</th>
-                        <th>Estado</th>
                         <th>Cuenta bancaria</th>
                         <th>Acción</th>
                     </tr>
@@ -39,46 +41,11 @@
                             <tr>
                                 <td>@plan.NombreFinca</td>
                                 <td>@plan.Anio</td>
-                                <td>₡@plan.MontoMensualCalculado.ToString("N2")</td>
-                                <td>₡@plan.MontoAnualEstimado.ToString("N2")</td>
-                                <td><span class="badge-estado badge-pendiente">@plan.EstadoPlan</span></td>
-                                <td>
-                                    @if (plan.IdCuentaBancaria.HasValue)
-                                    {
-                                        <span>Asociada (#@plan.IdCuentaBancaria.Value)</span>
-                                    }
-                                    else
-                                    {
-                                        <span class="text-danger">Pendiente de asociar</span>
-                                    }
-                                </td>
-                                <td>
-                                    <a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="@plan.IdPlanPago">Ver detalle</a>
-                                    @if (string.Equals(plan.EstadoPlan, "PendienteDatosBancarios", StringComparison.OrdinalIgnoreCase)
-                                        || string.Equals(plan.EstadoPlan, "BorradorGenerado", StringComparison.OrdinalIgnoreCase)
-                                        || string.Equals(plan.EstadoPlan, "PendienteAprobacionFinal", StringComparison.OrdinalIgnoreCase))
-                                    {
-                                        <form method="post" asp-controller="Pagos" asp-action="AsociarCuentaPlan" class="mt-2">
-                                            @Html.AntiForgeryToken()
-                                            <input type="hidden" name="idPlanPago" value="@plan.IdPlanPago" />
-                                            <select name="idCuentaBancaria" required>
-                                                <option value="">Seleccionar cuenta...</option>
-                                                @foreach (var cuenta in cuentasValidadasActivas)
-                                                {
-                                                    if (plan.IdCuentaBancaria == cuenta.IdCuentaBancaria)
-                                                    {
-                                                        <option value="@cuenta.IdCuentaBancaria" selected="selected">@cuenta.Banco - @cuenta.NumeroCuenta</option>
-                                                    }
-                                                    else
-                                                    {
-                                                        <option value="@cuenta.IdCuentaBancaria">@cuenta.Banco - @cuenta.NumeroCuenta</option>
-                                                    }
-                                                }
-                                            </select>
-                                            <button type="submit" class="boton-secundario mt-1">Asignar cuenta</button>
-                                        </form>
-                                    }
-                                </td>
+                                <td>@plan.EstadoPlan</td>
+                                <td>₡@plan.MontoMensual.ToString("N2")</td>
+                                <td>₡@plan.MontoAnual.ToString("N2")</td>
+                                <td>@plan.EstadoCuentaBancaria (@(plan.CuentaBancariaMascara ?? "Sin cuenta"))</td>
+                                <td><a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="@plan.IdPlanPago">Ver detalle</a></td>
                             </tr>
                         }
                     }

--- a/PSA.WebApp/Views/Pagos/PlanesPago.cshtml
+++ b/PSA.WebApp/Views/Pagos/PlanesPago.cshtml
@@ -1,3 +1,4 @@
+@model List<PSA.EntidadesDTO.DTOs.Pagos.AdminPaymentPlanDto>
 @{
     ViewData["Title"] = "Planes de pago";
 }
@@ -5,32 +6,69 @@
     <div class="cabecera-pagina">
         <div>
             <span class="eyebrow">Módulo de pagos</span>
-            <h2>Planes de pago</h2>
-            <p>Vista administrativa para consulta de planes y su progreso.</p>
+            <h2>Planes de pago (administración)</h2>
+            <p>Consulta global con filtros por ubicación, estado y situación bancaria.</p>
         </div>
-        <a class="boton-secundario" asp-controller="Reportes" asp-action="Index">Ver reportes</a>
     </div>
 
     <section class="tarjeta-panel">
+        <form method="get" class="d-flex flex-wrap gap-2 mb-3">
+            <input class="form-control" style="max-width:120px" type="number" name="anio" value="@ViewBag.Anio" placeholder="Año" />
+            <input class="form-control" style="max-width:180px" type="text" name="provincia" value="@ViewBag.Provincia" placeholder="Provincia" />
+            <input class="form-control" style="max-width:180px" type="text" name="canton" value="@ViewBag.Canton" placeholder="Cantón" />
+            <input class="form-control" style="max-width:180px" type="text" name="distrito" value="@ViewBag.Distrito" placeholder="Distrito" />
+            <select class="form-select" style="max-width:220px" name="estadoPlan">
+                <option value="">Estado plan (todos)</option>
+                <option value="PendienteDatosBancarios">PendienteDatosBancarios</option>
+                <option value="PendienteAprobacionFinal">PendienteAprobacionFinal</option>
+                <option value="Activo">Activo</option>
+                <option value="Finalizado">Finalizado</option>
+                <option value="Cancelado">Cancelado</option>
+            </select>
+            <select class="form-select" style="max-width:180px" name="estadoBancario">
+                <option value="">Estado bancario (todos)</option>
+                <option value="Pendiente">Pendiente</option>
+                <option value="Validada">Validada</option>
+                <option value="Rechazada">Rechazada</option>
+            </select>
+            <button type="submit" class="boton-secundario">Filtrar</button>
+        </form>
+
         <div class="tabla-responsive">
             <table class="tabla-base">
                 <thead>
                     <tr>
                         <th>Plan</th>
                         <th>Finca</th>
-                        <th>Año</th>
+                        <th>Propietario</th>
+                        <th>Ubicación</th>
                         <th>Estado</th>
+                        <th>Cuenta</th>
+                        <th>Monto mensual</th>
                         <th>Acción</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td>PLAN-2026-001</td>
-                        <td>Río Verde</td>
-                        <td>2026</td>
-                        <td><span class="badge-estado badge-exito">Activo</span></td>
-                        <td><a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="1">Ver detalle</a></td>
-                    </tr>
+                @if (!Model.Any())
+                {
+                    <tr><td colspan="8" class="text-center text-muted">No hay planes para los filtros seleccionados.</td></tr>
+                }
+                else
+                {
+                    @foreach (var plan in Model)
+                    {
+                        <tr>
+                            <td>#@plan.IdPlanPago (@plan.Anio)</td>
+                            <td>@plan.NombreFinca</td>
+                            <td>@plan.Propietario</td>
+                            <td>@plan.Provincia, @plan.Canton, @plan.Distrito</td>
+                            <td>@plan.EstadoPlan</td>
+                            <td>@plan.EstadoBancario (@(plan.CuentaBancariaMascara ?? "Sin cuenta"))</td>
+                            <td>₡@plan.MontoMensual.ToString("N2")</td>
+                            <td><a class="boton-link" asp-action="DetallePlanPago" asp-route-id="@plan.IdPlanPago">Ver detalle</a></td>
+                        </tr>
+                    }
+                }
                 </tbody>
             </table>
         </div>

--- a/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
+++ b/PSA.WebApp/Views/Shared/_BarraLateral.cshtml
@@ -30,7 +30,6 @@
             <a class="item-menu @(moduloActivo == "dashboard" ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Ingeniero">Inicio</a>
             <a class="item-menu @(moduloActivo == "evaluaciones" ? "activo" : string.Empty)" asp-controller="Evaluaciones" asp-action="FincasPendientes">Visitas técnicas pendientes</a>
             <a class="item-menu @(moduloActivo == "evaluaciones" ? "activo" : string.Empty)" asp-controller="Evaluaciones" asp-action="HistorialEvaluaciones">Resultados de visitas técnicas</a>
-            <a class="item-menu @((controllerActual == "pagos" && accionActual == "planesingenieropendientes") ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="PlanesIngenieroPendientes">Pagos por aprobar</a>
             <a class="item-menu @(moduloActivo == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
             <a class="item-menu item-menu--proximamente" href="#" data-omitir-trobber-global="true" aria-disabled="true">Notificaciones</a>
             <a class="item-menu @(moduloActivo == "mi-perfil" ? "activo" : string.Empty)" asp-controller="MiPerfil" asp-action="Index">Mi perfil</a>
@@ -42,6 +41,7 @@
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "rolespermisos") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="RolesPermisos">Roles y permisos</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "validacioncuentasbancarias") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="ValidacionCuentasBancarias">Cuentas bancarias</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "parametrospago") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="ParametrosPago">Configuración de pagos</a>
+            <a class="item-menu @((controllerActual == "pagos" && (accionActual == "planespago" || accionActual == "detalleplanpago")) ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="PlanesPago">Planes de pago</a>
             <a class="item-menu @(moduloActivo == "reportes" || controllerActual == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
             <a class="item-menu @((controllerActual == "administracion" && accionActual == "auditorialogs") ? "activo" : string.Empty)" asp-controller="Administracion" asp-action="AuditoriaLogs">Auditoría</a>
             <a class="item-menu item-menu--proximamente" href="#" data-omitir-trobber-global="true" aria-disabled="true">Notificaciones</a>
@@ -52,7 +52,7 @@
             <a class="item-menu @(moduloActivo == "dashboard" ? "activo" : string.Empty)" asp-controller="Dashboard" asp-action="Dueno">Inicio</a>
             <a class="item-menu @(moduloActivo == "fincas" ? "activo" : string.Empty)" asp-controller="Fincas" asp-action="MisFincas">Mis fincas</a>
             <a class="item-menu @((controllerActual == "pagos" && accionActual == "cuentabancaria") ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="CuentaBancaria">Cuenta bancaria</a>
-            <a class="item-menu @((controllerActual == "pagos" && accionActual == "planesdueno") ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="PlanesDueno">Planes de pago</a>
+            <a class="item-menu @((controllerActual == "pagos" && (accionActual == "planesdueno" || accionActual == "detalleplanpago" || accionActual == "historialpagos")) ? "activo" : string.Empty)" asp-controller="Pagos" asp-action="PlanesDueno">Mis pagos</a>
             <a class="item-menu @(moduloActivo == "reportes" ? "activo" : string.Empty)" asp-controller="Reportes" asp-action="Index">Reportes</a>
             <a class="item-menu @(moduloActivo == "notificaciones" ? "activo" : string.Empty)" asp-controller="Notificaciones" asp-action="Index">Notificaciones</a>
             <a class="item-menu @(moduloActivo == "mi-perfil" ? "activo" : string.Empty)" asp-controller="MiPerfil" asp-action="Index">Mi perfil</a>


### PR DESCRIPTION
### Motivation
- Corregir la exposición, filtrado y visibilidad de los planes de pago para cada rol (Dueño, Ingeniero, Administrador) sin tocar el motor de cálculo existente.
- Evitar fugas de datos sensibles (números de cuenta completos, parámetros administrativos) y centralizar la lógica de lectura y masking.
- Simplificar la navegación y UX por rol (vistas separadas) y asegurar consultas / endpoints adecuados por responsabilidad.

### Description
- Añadidos DTOs específicos por rol: `OwnerPaymentPlanDto`, `OwnerPaymentPlanDetailDto`, `OwnerPaymentCalculationSummaryDto`, `EngineerPaymentImpactDto`, `AdminPaymentPlanDto`, `AdminPaymentPlanDetailDto`, `AdminPaymentPlanFilterDto` y `AuditoriaPlanPagoDto` en `PSA.EntidadesDTO`. 
- Nuevo servicio de lectura `IPaymentPlanReadService` / `PaymentPlanReadService` en `PSA.AppCore.Services` y wiring en DI para centralizar consultas de solo lectura por rol. 
- Extensiones en `PlanPagoDAO` con queries especializadas y seguras: `ObtenerPlanesOwnerAsync`, `ObtenerDetalleOwnerAsync`, `ObtenerImpactoPagoIngenieroAsync`, `ObtenerPlanesAdminAsync`, `ObtenerDetalleAdminAsync`, junto a `MascaraCuenta` y resolución de estados de continuidad. 
- `PagosManager` expone métodos de lectura por rol y consume el nuevo read service sin modificar el motor de generación/cálculo. 
- Nuevo/actualizado `PagosController` (Web API) con endpoints role-based: `api/Pagos/dueno/...`, `api/Pagos/ingeniero/.../impacto`, `api/Pagos/admin/...` y preservación de operaciones de cuenta/asociación/aprobación. 
- WebApp: `PagosController` y vistas separadas por rol (`PlanesDueno`, `DetallePlanPagoDueno`, `PlanesPago` admin, `DetallePlanPagoAdmin`), ajuste del menú lateral y embebido del bloque de `Impacto en Plan de Pago` dentro de `Evaluaciones/DetalleEvaluacion` para ingenieros. 
- No se modificó la lógica del motor de cálculo (`PaymentCalculationService`); los cambios son de exposición/lectura/UI/filtrado/seguridad.

### Testing
- Intenté ejecutar la compilación con `dotnet build psa-costa-rica.slnx` como prueba automatizada; falló en el entorno por falta de `dotnet` (`/bin/bash: dotnet: command not found`).
- No se ejecutaron pruebas unitarias automáticas por la ausencia de runtime en este entorno; los cambios fueron validados mediante inspección del código y builds locales deben pasar tras ejecutar `dotnet build` en un entorno con .NET instalado. 
- Realicé comprobaciones automatizadas básicas disponibles en el entorno (comandos `git status`, inclusión en `.csproj`, registro de DI) y confirmé commit exitoso (`Refactoriza visualización de planes de pago por rol`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c7391aec832dab9a99235bd3d080)