### PR TITLE
Centraliza y estandariza notificaciones (in‑app + email) en AppCore

### DIFF
--- a/PSA.AppCore/Managers/AdministracionManager.cs
+++ b/PSA.AppCore/Managers/AdministracionManager.cs
@@ -1,4 +1,5 @@
 using PSA.AppCore.Servicios;
+using PSA.AppCore.Services.Notifications;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs.Administracion;
 using PSA.EntidadesDTO.DTOs.Usuarios;
@@ -14,6 +15,7 @@ public class AdministracionManager
     private readonly CuentaBancariaDAO _cuentaBancariaDao;
     private readonly AuditoriaLogDAO _auditoriaLogDao;
     private readonly IServicioHashContrasena _servicioHashContrasena;
+    private readonly INotificationDispatcher _notificationDispatcher;
 
     public AdministracionManager(
         UsuarioDAO usuarioDao,
@@ -21,7 +23,8 @@ public class AdministracionManager
         ConfiguracionPagoDAO configuracionPagoDao,
         CuentaBancariaDAO cuentaBancariaDao,
         AuditoriaLogDAO auditoriaLogDao,
-        IServicioHashContrasena servicioHashContrasena)
+        IServicioHashContrasena servicioHashContrasena,
+        INotificationDispatcher notificationDispatcher)
     {
         _usuarioDao = usuarioDao;
         _rolPermisoDao = rolPermisoDao;
@@ -29,6 +32,7 @@ public class AdministracionManager
         _cuentaBancariaDao = cuentaBancariaDao;
         _auditoriaLogDao = auditoriaLogDao;
         _servicioHashContrasena = servicioHashContrasena;
+        _notificationDispatcher = notificationDispatcher;
     }
 
     public Task<List<UsuarioAdminListadoDTO>> ObtenerUsuariosAsync(int? idRol = null)
@@ -203,6 +207,9 @@ public class AdministracionManager
 
     public async Task ValidarCuentaBancariaAsync(ValidacionCuentaBancariaDTO model, string? ip)
     {
+        var cuentas = await _cuentaBancariaDao.ObtenerPendientesValidacionAsync();
+        var cuenta = cuentas.FirstOrDefault(c => c.IdCuentaBancaria == model.IdCuentaBancaria);
+
         await _cuentaBancariaDao.ValidarCuentaAsync(model);
 
         await _auditoriaLogDao.RegistrarEventoAsync(
@@ -213,6 +220,23 @@ public class AdministracionManager
             detalle: $"Cuenta {model.IdCuentaBancaria} validada con resultado: {(model.Aprobada ? "Validada" : "Rechazada")}",
             idRegistroAfectado: model.IdCuentaBancaria,
             ipOrigen: ip);
+
+        if (cuenta != null)
+        {
+            await _notificationDispatcher.NotifyInAppAsync(
+                cuenta.IdUsuario,
+                model.Aprobada ? "Cuenta bancaria aprobada" : "Cuenta bancaria rechazada",
+                model.Aprobada
+                    ? "Su cuenta bancaria fue validada y ya puede usarse en planes de pago."
+                    : "Su cuenta bancaria fue rechazada. Revise observaciones y registre una nueva cuenta si aplica.",
+                model.Aprobada ? NotificationCatalog.TipoSuccess : NotificationCatalog.TipoWarning,
+                cuenta.IdCuentaBancaria);
+
+            await _notificationDispatcher.NotifyEmailAsync(
+                cuenta.EmailUsuario,
+                model.Aprobada ? "Cuenta bancaria validada" : "Cuenta bancaria rechazada",
+                NotificationCatalog.EmailCuentaBancaria(cuenta.NombreUsuario, model.Aprobada, model.Observaciones));
+        }
     }
 
     public Task<List<AuditoriaEventoDTO>> ObtenerEventosAuditoriaAsync(AuditoriaFiltroDTO filtro)

--- a/PSA.AppCore/Managers/EvaluacionTecnicaManager.cs
+++ b/PSA.AppCore/Managers/EvaluacionTecnicaManager.cs
@@ -1,3 +1,4 @@
+using PSA.AppCore.Services.Notifications;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs.Evaluaciones;
 
@@ -7,11 +8,19 @@ namespace PSA.AppCore.Managers
     {
         private readonly EvaluacionTecnicaDAO _evaluacionTecnicaDAO;
         private readonly Services.IPaymentPlanService _paymentPlanService;
+        private readonly INotificationDispatcher _notificationDispatcher;
+        private readonly UsuarioDAO _usuarioDao;
 
-        public EvaluacionTecnicaManager(EvaluacionTecnicaDAO evaluacionTecnicaDAO, Services.IPaymentPlanService paymentPlanService)
+        public EvaluacionTecnicaManager(
+            EvaluacionTecnicaDAO evaluacionTecnicaDAO,
+            Services.IPaymentPlanService paymentPlanService,
+            INotificationDispatcher notificationDispatcher,
+            UsuarioDAO usuarioDao)
         {
             _evaluacionTecnicaDAO = evaluacionTecnicaDAO ?? throw new ArgumentNullException(nameof(evaluacionTecnicaDAO));
             _paymentPlanService = paymentPlanService ?? throw new ArgumentNullException(nameof(paymentPlanService));
+            _notificationDispatcher = notificationDispatcher ?? throw new ArgumentNullException(nameof(notificationDispatcher));
+            _usuarioDao = usuarioDao ?? throw new ArgumentNullException(nameof(usuarioDao));
         }
 
         public Task<int> CrearPendientePorNuevaFincaAsync(int idFinca)
@@ -25,9 +34,7 @@ namespace PSA.AppCore.Managers
         }
 
         public Task<List<BandejaEvaluacionPendienteDTO>> ObtenerBandejaPendienteAsync()
-        {
-            return _evaluacionTecnicaDAO.ObtenerBandejaPendientesAsync();
-        }
+            => _evaluacionTecnicaDAO.ObtenerBandejaPendientesAsync();
 
         public Task<DetalleFincaParaEvaluacionDTO?> ObtenerDetalleAsync(int idEvaluacion)
         {
@@ -39,7 +46,7 @@ namespace PSA.AppCore.Managers
             return _evaluacionTecnicaDAO.ObtenerDetalleParaEvaluacionAsync(idEvaluacion);
         }
 
-        public Task<bool> AsignarIngenieroAsync(int idEvaluacion, int idIngeniero)
+        public async Task<bool> AsignarIngenieroAsync(int idEvaluacion, int idIngeniero)
         {
             if (idEvaluacion <= 0)
             {
@@ -51,7 +58,31 @@ namespace PSA.AppCore.Managers
                 throw new InvalidOperationException("El ingeniero asignado es inválido.");
             }
 
-            return _evaluacionTecnicaDAO.AsignarIngenieroAsync(idEvaluacion, idIngeniero);
+            var asignado = await _evaluacionTecnicaDAO.AsignarIngenieroAsync(idEvaluacion, idIngeniero);
+            if (!asignado)
+            {
+                return false;
+            }
+
+            var detalle = await _evaluacionTecnicaDAO.ObtenerDetalleParaEvaluacionAsync(idEvaluacion);
+            if (detalle != null)
+            {
+                await _notificationDispatcher.NotifyInAppAsync(
+                    detalle.IdPropietario,
+                    "Evaluación en proceso",
+                    $"La evaluación técnica de la finca \"{detalle.NombreFinca}\" fue tomada y está en proceso.",
+                    NotificationCatalog.TipoInfo,
+                    detalle.IdFinca);
+
+                await _notificationDispatcher.NotifyInAppAsync(
+                    idIngeniero,
+                    "Evaluación asignada",
+                    $"Se le asignó la evaluación #{idEvaluacion} de la finca \"{detalle.NombreFinca}\".",
+                    NotificationCatalog.TipoSuccess,
+                    idEvaluacion);
+            }
+
+            return true;
         }
 
         public async Task<bool> RegistrarResultadoAsync(int idEvaluacion, RegistrarResultadoEvaluacionDTO dto)
@@ -97,7 +128,12 @@ namespace PSA.AppCore.Managers
             dto.Observaciones = string.IsNullOrWhiteSpace(dto.Observaciones) ? null : dto.Observaciones.Trim();
 
             var resultado = await _evaluacionTecnicaDAO.RegistrarResultadoAsync(idEvaluacion, dto);
-            if (resultado && dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase))
+            if (!resultado)
+            {
+                return false;
+            }
+
+            if (dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase))
             {
                 await _paymentPlanService.GeneratePreliminaryPlanFromEvaluationAsync(
                     idEvaluacion,
@@ -106,7 +142,44 @@ namespace PSA.AppCore.Managers
                     ip: null);
             }
 
-            return resultado;
+            var detalle = await _evaluacionTecnicaDAO.ObtenerDetalleParaEvaluacionAsync(idEvaluacion);
+            if (detalle != null)
+            {
+                var tituloEstado = dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase)
+                    ? "Finca califica"
+                    : "Finca no califica";
+                var mensajeEstado = dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase)
+                    ? $"La evaluación de \"{detalle.NombreFinca}\" finalizó y la finca califica para el programa."
+                    : $"La evaluación de \"{detalle.NombreFinca}\" finalizó y la finca no califica para el programa.";
+
+                await _notificationDispatcher.NotifyInAppAsync(
+                    detalle.IdPropietario,
+                    tituloEstado,
+                    mensajeEstado,
+                    dto.DecisionTecnica.Equals("Califica", StringComparison.OrdinalIgnoreCase) ? NotificationCatalog.TipoSuccess : NotificationCatalog.TipoWarning,
+                    detalle.IdFinca);
+
+                if (detalle.IdIngeniero.HasValue)
+                {
+                    await _notificationDispatcher.NotifyInAppAsync(
+                        detalle.IdIngeniero.Value,
+                        "Evaluación finalizada",
+                        $"La evaluación #{idEvaluacion} de la finca \"{detalle.NombreFinca}\" se guardó y finalizó correctamente.",
+                        NotificationCatalog.TipoSuccess,
+                        idEvaluacion);
+                }
+
+                var propietario = await _usuarioDao.ObtenerPorIdAsync(detalle.IdPropietario);
+                if (propietario != null)
+                {
+                    await _notificationDispatcher.NotifyEmailAsync(
+                        propietario.Email,
+                        $"Resultado de evaluación técnica - {detalle.NombreFinca}",
+                        NotificationCatalog.EmailResultadoEvaluacion(propietario.NombreCompleto, detalle.NombreFinca, dto.DecisionTecnica, dto.Observaciones));
+                }
+            }
+
+            return true;
         }
 
         public Task<bool> AvanzarEstadoAsync(int idEvaluacion, string nuevoEstado)

--- a/PSA.AppCore/Managers/FincaManager.cs
+++ b/PSA.AppCore/Managers/FincaManager.cs
@@ -1,5 +1,6 @@
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
+using PSA.AppCore.Services.Notifications;
 
 namespace PSA.AppCore.Managers;
 
@@ -7,11 +8,13 @@ public class FincaManager
 {
     private readonly FincaDAO _fincaDao;
     private readonly EvaluacionTecnicaManager _evaluacionTecnicaManager;
+    private readonly INotificationDispatcher _notificationDispatcher;
 
-    public FincaManager(FincaDAO fincaDao, EvaluacionTecnicaManager evaluacionTecnicaManager)
+    public FincaManager(FincaDAO fincaDao, EvaluacionTecnicaManager evaluacionTecnicaManager, INotificationDispatcher notificationDispatcher)
     {
         _fincaDao = fincaDao;
         _evaluacionTecnicaManager = evaluacionTecnicaManager;
+        _notificationDispatcher = notificationDispatcher;
     }
 
     public Task<List<FincaResumenDTO>> ObtenerPorPropietarioAsync(int idPropietario) => _fincaDao.ObtenerPorPropietarioAsync(idPropietario);
@@ -31,6 +34,13 @@ public class FincaManager
             {
                 Console.Error.WriteLine($"No se pudo crear la evaluación técnica pendiente para la finca {idFinca}: {ex.Message}");
             }
+
+            await _notificationDispatcher.NotifyInAppAsync(
+                dto.IdPropietario,
+                "Finca registrada",
+                $"La finca \"{dto.NombreFinca}\" fue registrada y enviada al flujo de evaluación.",
+                NotificationCatalog.TipoSuccess,
+                idFinca);
 
             return idFinca;
         }

--- a/PSA.AppCore/Managers/NotificacionesManager.cs
+++ b/PSA.AppCore/Managers/NotificacionesManager.cs
@@ -1,0 +1,34 @@
+using PSA.DataAccess.DAO;
+using PSA.EntidadesDTO.DTOs.Notificaciones;
+
+namespace PSA.AppCore.Managers;
+
+public class NotificacionesManager
+{
+    private readonly NotificacionDAO _notificacionDao;
+
+    public NotificacionesManager(NotificacionDAO notificacionDao)
+    {
+        _notificacionDao = notificacionDao;
+    }
+
+    public Task<List<NotificacionDTO>> ObtenerPorUsuarioAsync(int idUsuario, int maximo = 30)
+    {
+        if (idUsuario <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un usuario válido.");
+        }
+
+        return _notificacionDao.ObtenerPorUsuarioAsync(idUsuario, maximo);
+    }
+
+    public Task<int> MarcarLeidasAsync(int idUsuario)
+    {
+        if (idUsuario <= 0)
+        {
+            throw new InvalidOperationException("Debe indicar un usuario válido.");
+        }
+
+        return _notificacionDao.MarcarLeidasAsync(idUsuario);
+    }
+}

--- a/PSA.AppCore/Managers/PagosManager.cs
+++ b/PSA.AppCore/Managers/PagosManager.cs
@@ -1,4 +1,5 @@
 using PSA.AppCore.Services;
+using PSA.AppCore.Services.Notifications;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs.Pagos;
 
@@ -7,11 +8,13 @@ namespace PSA.AppCore.Managers;
 public class PagosManager(
     PlanPagoDAO planPagoDao,
     IPaymentPlanService paymentPlanService,
-    IPaymentPlanReadService paymentPlanReadService)
+    IPaymentPlanReadService paymentPlanReadService,
+    INotificationDispatcher notificationDispatcher)
 {
     private readonly PlanPagoDAO _planPagoDao = planPagoDao;
     private readonly IPaymentPlanService _paymentPlanService = paymentPlanService;
     private readonly IPaymentPlanReadService _paymentPlanReadService = paymentPlanReadService;
+    private readonly INotificationDispatcher _notificationDispatcher = notificationDispatcher;
 
     public async Task<PlanPagoDTO?> GenerarPlanPagoAsync(GenerarPlanPagoRequestDTO request, int idUsuario, string? ip)
     {
@@ -120,7 +123,7 @@ public class PagosManager(
         return _planPagoDao.ObtenerCuentasBancariasDuenoAsync(idUsuario);
     }
 
-    public Task<int> RegistrarCuentaBancariaDuenoAsync(RegistrarCuentaBancariaDTO dto)
+    public async Task<int> RegistrarCuentaBancariaDuenoAsync(RegistrarCuentaBancariaDTO dto)
     {
         if (dto.IdUsuario <= 0)
         {
@@ -135,7 +138,34 @@ public class PagosManager(
             throw new InvalidOperationException("Debe completar todos los datos de la cuenta bancaria.");
         }
 
-        return _planPagoDao.RegistrarCuentaBancariaDuenoAsync(dto);
+        var idCuenta = await _planPagoDao.RegistrarCuentaBancariaDuenoAsync(dto);
+        if (idCuenta > 0)
+        {
+            await _notificationDispatcher.NotifyInAppAsync(
+                dto.IdUsuario,
+                "Cuenta bancaria registrada",
+                $"La cuenta bancaria terminada en {ObtenerMascaraCuenta(dto.NumeroCuenta)} quedó registrada y pendiente de validación.",
+                NotificationCatalog.TipoInfo,
+                idCuenta);
+        }
+
+        return idCuenta;
+    }
+
+    private static string ObtenerMascaraCuenta(string numeroCuenta)
+    {
+        if (string.IsNullOrWhiteSpace(numeroCuenta))
+        {
+            return "****";
+        }
+
+        var limpia = new string(numeroCuenta.Where(char.IsDigit).ToArray());
+        if (limpia.Length <= 4)
+        {
+            return limpia;
+        }
+
+        return limpia[^4..];
     }
 
     public Task<bool> AsociarCuentaPlanAsync(int idPlanPago, AsociarCuentaPlanDTO dto, string? ip)

--- a/PSA.AppCore/Services/Notifications/NotificationCatalog.cs
+++ b/PSA.AppCore/Services/Notifications/NotificationCatalog.cs
@@ -1,0 +1,47 @@
+namespace PSA.AppCore.Services.Notifications;
+
+public static class NotificationCatalog
+{
+    public const string TipoInfo = "info";
+    public const string TipoSuccess = "success";
+    public const string TipoWarning = "warning";
+
+    public static string EmailResultadoEvaluacion(string nombreUsuario, string nombreFinca, string decision, string? observaciones)
+    {
+        var observacionesTexto = string.IsNullOrWhiteSpace(observaciones)
+            ? "Sin observaciones adicionales."
+            : observaciones.Trim();
+
+        return $"""
+<h2>Resultado de evaluación técnica</h2>
+<p>Hola {nombreUsuario},</p>
+<p>La evaluación técnica de la finca <strong>{nombreFinca}</strong> finalizó con el estado: <strong>{decision}</strong>.</p>
+<p><strong>Observaciones:</strong> {observacionesTexto}</p>
+<p>Puede ingresar al sistema PSA Costa Rica para revisar el detalle completo.</p>
+""";
+    }
+
+    public static string EmailPlanPago(string nombreUsuario, string nombreFinca, int idPlanPago)
+        => $"""
+<h2>Plan de pagos generado</h2>
+<p>Hola {nombreUsuario},</p>
+<p>Se generó el plan de pago #{idPlanPago} para la finca <strong>{nombreFinca}</strong>.</p>
+<p>Revise el detalle de cuotas desde su panel de pagos.</p>
+""";
+
+    public static string EmailCuentaBancaria(string nombreUsuario, bool aprobada, string? observaciones)
+    {
+        var estado = aprobada ? "validada" : "rechazada";
+        var observacionesTexto = string.IsNullOrWhiteSpace(observaciones)
+            ? "Sin observaciones adicionales."
+            : observaciones.Trim();
+
+        return $"""
+<h2>Resultado de validación de cuenta bancaria</h2>
+<p>Hola {nombreUsuario},</p>
+<p>Su cuenta bancaria fue <strong>{estado}</strong>.</p>
+<p><strong>Observaciones:</strong> {observacionesTexto}</p>
+<p>Si corresponde, puede registrar una nueva cuenta en el módulo de pagos.</p>
+""";
+    }
+}

--- a/PSA.AppCore/Services/Notifications/NotificationContracts.cs
+++ b/PSA.AppCore/Services/Notifications/NotificationContracts.cs
@@ -1,0 +1,12 @@
+namespace PSA.AppCore.Services.Notifications;
+
+public interface INotificationEmailSender
+{
+    Task SendHtmlAsync(string destino, string asunto, string cuerpoHtml);
+}
+
+public interface INotificationDispatcher
+{
+    Task NotifyInAppAsync(int idUsuario, string titulo, string mensaje, string tipo, int? idEntidadReferencia = null);
+    Task NotifyEmailAsync(string? destino, string asunto, string cuerpoHtml);
+}

--- a/PSA.AppCore/Services/Notifications/NotificationDispatcher.cs
+++ b/PSA.AppCore/Services/Notifications/NotificationDispatcher.cs
@@ -1,0 +1,35 @@
+using PSA.DataAccess.DAO;
+
+namespace PSA.AppCore.Services.Notifications;
+
+public class NotificationDispatcher : INotificationDispatcher
+{
+    private readonly NotificacionDAO _notificacionDao;
+    private readonly INotificationEmailSender _emailSender;
+
+    public NotificationDispatcher(NotificacionDAO notificacionDao, INotificationEmailSender emailSender)
+    {
+        _notificacionDao = notificacionDao;
+        _emailSender = emailSender;
+    }
+
+    public Task NotifyInAppAsync(int idUsuario, string titulo, string mensaje, string tipo, int? idEntidadReferencia = null)
+    {
+        if (idUsuario <= 0 || string.IsNullOrWhiteSpace(titulo) || string.IsNullOrWhiteSpace(mensaje))
+        {
+            return Task.CompletedTask;
+        }
+
+        return _notificacionDao.CrearAsync(idUsuario, titulo, mensaje, tipo, idEntidadReferencia);
+    }
+
+    public Task NotifyEmailAsync(string? destino, string asunto, string cuerpoHtml)
+    {
+        if (string.IsNullOrWhiteSpace(destino) || string.IsNullOrWhiteSpace(asunto) || string.IsNullOrWhiteSpace(cuerpoHtml))
+        {
+            return Task.CompletedTask;
+        }
+
+        return _emailSender.SendHtmlAsync(destino.Trim(), asunto.Trim(), cuerpoHtml);
+    }
+}

--- a/PSA.AppCore/Services/PaymentPlanService.cs
+++ b/PSA.AppCore/Services/PaymentPlanService.cs
@@ -1,3 +1,4 @@
+using PSA.AppCore.Services.Notifications;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs.Pagos;
 
@@ -13,11 +14,15 @@ public interface IPaymentPlanService
 public class PaymentPlanService(
     PlanPagoDAO planPagoDao,
     AuditoriaLogDAO auditoriaLogDao,
-    IPaymentCalculationService paymentCalculationService) : IPaymentPlanService
+    IPaymentCalculationService paymentCalculationService,
+    UsuarioDAO usuarioDao,
+    INotificationDispatcher notificationDispatcher) : IPaymentPlanService
 {
     private readonly PlanPagoDAO _planPagoDao = planPagoDao;
     private readonly AuditoriaLogDAO _auditoriaLogDao = auditoriaLogDao;
     private readonly IPaymentCalculationService _paymentCalculationService = paymentCalculationService;
+    private readonly UsuarioDAO _usuarioDao = usuarioDao;
+    private readonly INotificationDispatcher _notificationDispatcher = notificationDispatcher;
 
     public async Task<PlanPagoDTO?> GeneratePreliminaryPlanFromEvaluationAsync(int idEvaluacion, int anioPlan, int? actorId, string? ip)
     {
@@ -44,6 +49,22 @@ public class PaymentPlanService(
             detalle: $"Plan preliminar #{plan.IdPlanPago} generado por evaluación #{idEvaluacion} para finca #{plan.IdFinca}.",
             idRegistroAfectado: plan.IdPlanPago,
             ipOrigen: ip);
+
+        await _notificationDispatcher.NotifyInAppAsync(
+            context.IdPropietario,
+            "Plan de pagos generado",
+            $"Se generó el plan de pagos #{plan.IdPlanPago} para la finca \"{context.NombreFinca}\".",
+            NotificationCatalog.TipoSuccess,
+            plan.IdPlanPago);
+
+        var propietario = await _usuarioDao.ObtenerPorIdAsync(context.IdPropietario);
+        if (propietario != null)
+        {
+            await _notificationDispatcher.NotifyEmailAsync(
+                propietario.Email,
+                $"Plan de pagos generado - {context.NombreFinca}",
+                NotificationCatalog.EmailPlanPago(propietario.NombreCompleto, context.NombreFinca, plan.IdPlanPago));
+        }
 
         return plan;
     }
@@ -84,6 +105,13 @@ public class PaymentPlanService(
             detalle: $"Plan de pago #{idPlanPago} aprobado y activado por ingeniero #{idIngeniero}.",
             idRegistroAfectado: idPlanPago,
             ipOrigen: ip);
+
+        await _notificationDispatcher.NotifyInAppAsync(
+            idIngeniero,
+            "Plan activado",
+            $"El plan de pago #{idPlanPago} fue activado correctamente.",
+            NotificationCatalog.TipoSuccess,
+            idPlanPago);
 
         return true;
     }

--- a/PSA.DataAccess/DAO/NotificacionDAO.cs
+++ b/PSA.DataAccess/DAO/NotificacionDAO.cs
@@ -1,0 +1,93 @@
+using Microsoft.Data.SqlClient;
+using PSA.DataAccess;
+using PSA.EntidadesDTO.DTOs.Notificaciones;
+
+namespace PSA.DataAccess.DAO;
+
+public class NotificacionDAO
+{
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public NotificacionDAO(IDbConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+    }
+
+    public async Task<int> CrearAsync(int idUsuario, string titulo, string mensaje, string tipo, int? idEntidadReferencia = null)
+    {
+        const string sql = @"
+INSERT INTO dbo.Notificaciones (IdUsuario, Titulo, Mensaje, Tipo, IdEntidadReferencia, Leida, FechaCreacion)
+VALUES (@IdUsuario, @Titulo, @Mensaje, @Tipo, @IdEntidadReferencia, 0, SYSDATETIME());
+SELECT CAST(SCOPE_IDENTITY() AS int);";
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+        command.Parameters.AddWithValue("@Titulo", titulo.Trim());
+        command.Parameters.AddWithValue("@Mensaje", mensaje.Trim());
+        command.Parameters.AddWithValue("@Tipo", string.IsNullOrWhiteSpace(tipo) ? "info" : tipo.Trim());
+        command.Parameters.AddWithValue("@IdEntidadReferencia", (object?)idEntidadReferencia ?? DBNull.Value);
+
+        var result = await command.ExecuteScalarAsync();
+        return result == null ? 0 : Convert.ToInt32(result);
+    }
+
+    public async Task<List<NotificacionDTO>> ObtenerPorUsuarioAsync(int idUsuario, int maximo = 30)
+    {
+        const string sql = @"
+SELECT TOP (@Maximo)
+    IdNotificacion,
+    IdUsuario,
+    Titulo,
+    Mensaje,
+    Leida,
+    FechaCreacion,
+    Tipo
+FROM dbo.Notificaciones
+WHERE IdUsuario = @IdUsuario
+ORDER BY FechaCreacion DESC, IdNotificacion DESC;";
+
+        var resultado = new List<NotificacionDTO>();
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+        command.Parameters.AddWithValue("@Maximo", maximo <= 0 ? 30 : maximo);
+
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            resultado.Add(new NotificacionDTO
+            {
+                Id = reader.GetInt32(reader.GetOrdinal("IdNotificacion")),
+                UsuarioId = reader.GetInt32(reader.GetOrdinal("IdUsuario")),
+                Titulo = reader["Titulo"]?.ToString() ?? string.Empty,
+                Mensaje = reader["Mensaje"]?.ToString() ?? string.Empty,
+                Leida = reader.GetBoolean(reader.GetOrdinal("Leida")),
+                FechaEnvio = reader.GetDateTime(reader.GetOrdinal("FechaCreacion")),
+                Tipo = reader["Tipo"] == DBNull.Value ? null : reader["Tipo"]?.ToString()
+            });
+        }
+
+        return resultado;
+    }
+
+    public async Task<int> MarcarLeidasAsync(int idUsuario)
+    {
+        const string sql = @"
+UPDATE dbo.Notificaciones
+SET Leida = 1
+WHERE IdUsuario = @IdUsuario
+  AND Leida = 0;";
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+        return await command.ExecuteNonQueryAsync();
+    }
+}

--- a/PSA.DataAccess/PSA.DataAccess.csproj
+++ b/PSA.DataAccess/PSA.DataAccess.csproj
@@ -28,6 +28,7 @@
 		<Compile Include="DAO\TokenRecuperacionDAO.cs" />
 		<Compile Include="DAO\UsuarioDAO.cs" />
 		<Compile Include="DAO\LandingDAO.cs" />
+		<Compile Include="DAO\NotificacionDAO.cs" />
 		<ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
 	</ItemGroup>

--- a/PSA.WebAPI/Controllers/NotificacionesController.cs
+++ b/PSA.WebAPI/Controllers/NotificacionesController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using PSA.AppCore.Managers;
+
+namespace PSA.WebAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class NotificacionesController(NotificacionesManager notificacionesManager) : ControllerBase
+{
+    private readonly NotificacionesManager _notificacionesManager = notificacionesManager;
+
+    [HttpGet("usuario/{idUsuario:int}")]
+    public async Task<IActionResult> ObtenerPorUsuario([FromRoute] int idUsuario, [FromQuery] int maximo = 30)
+    {
+        try
+        {
+            var notificaciones = await _notificacionesManager.ObtenerPorUsuarioAsync(idUsuario, maximo);
+            return Ok(notificaciones);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+
+    [HttpPost("usuario/{idUsuario:int}/marcar-leidas")]
+    public async Task<IActionResult> MarcarLeidas([FromRoute] int idUsuario)
+    {
+        try
+        {
+            var actualizadas = await _notificacionesManager.MarcarLeidasAsync(idUsuario);
+            return Ok(new { Actualizadas = actualizadas });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+    }
+}

--- a/PSA.WebAPI/CorreoService.cs
+++ b/PSA.WebAPI/CorreoService.cs
@@ -63,5 +63,21 @@ namespace PSA.WebAPI.Services
 
             cliente.Send(mensaje);
         }
+
+        public void EnviarCorreoHtml(string destino, string asunto, string cuerpoHtml)
+        {
+            using var mensaje = new MailMessage();
+            mensaje.From = new MailAddress(_smtp.FromEmail, _smtp.FromName);
+            mensaje.To.Add(destino);
+            mensaje.Subject = asunto;
+            mensaje.Body = cuerpoHtml;
+            mensaje.IsBodyHtml = true;
+
+            using var cliente = new SmtpClient(_smtp.Host, _smtp.Port);
+            cliente.Credentials = new NetworkCredential(_smtp.Username, _smtp.Password);
+            cliente.EnableSsl = _smtp.EnableSsl;
+
+            cliente.Send(mensaje);
+        }
     }
 }

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -22,11 +22,13 @@
     <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Controllers\PerfilController.cs" />
     <Compile Include="Controllers\PagosController.cs" />
+    <Compile Include="Controllers\NotificacionesController.cs" />
     <Compile Include="Controllers\Middleware\ExceptionMiddleware.cs" />
     <Compile Include="Controllers\Models\ApiResponse.cs" />
     <Compile Include="Controllers\RecuperacionContrasenaController.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="CorreoService.cs" />
+    <Compile Include="Services\SmtpNotificationEmailSender.cs" />
     <ProjectReference Include="..\PSA.AppCore\PSA.AppCore.csproj" />
     <ProjectReference Include="..\PSA.DataAccess\PSA.DataAccess.csproj" />
     <ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -1,9 +1,11 @@
 using PSA.AppCore;
 using PSA.AppCore.Managers;
+using PSA.AppCore.Services.Notifications;
 using PSA.AppCore.Servicios;
 using PSA.DataAccess;
 using PSA.DataAccess.DAO;
 using PSA.WebAPI.Controllers.Middleware;
+using PSA.WebAPI.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -52,6 +54,7 @@ builder.Services.AddScoped<CuentaBancariaDAO>();
 builder.Services.AddScoped<DashboardDAO>();
 builder.Services.AddScoped<ReportesDAO>();
 builder.Services.AddScoped<LandingDAO>();
+builder.Services.AddScoped<NotificacionDAO>();
 
 builder.Services.AddScoped<PSA.AppCore.Services.IPaymentCalculationService, PSA.AppCore.Services.PaymentCalculationService>();
 builder.Services.AddScoped<PSA.AppCore.Services.IPaymentPlanService, PSA.AppCore.Services.PaymentPlanService>();
@@ -67,6 +70,9 @@ builder.Services.AddScoped<AdministracionManager>();
 builder.Services.AddScoped<PagosManager>();
 builder.Services.AddScoped<ReportesManager>();
 builder.Services.AddScoped<LandingManager>();
+builder.Services.AddScoped<NotificacionesManager>();
+builder.Services.AddScoped<INotificationEmailSender, SmtpNotificationEmailSender>();
+builder.Services.AddScoped<INotificationDispatcher, NotificationDispatcher>();
 
 var app = builder.Build();
 

--- a/PSA.WebAPI/Services/SmtpNotificationEmailSender.cs
+++ b/PSA.WebAPI/Services/SmtpNotificationEmailSender.cs
@@ -1,0 +1,42 @@
+using PSA.AppCore.Services.Notifications;
+using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
+
+namespace PSA.WebAPI.Services;
+
+public class SmtpNotificationEmailSender : INotificationEmailSender
+{
+    private readonly IConfiguration _configuration;
+
+    public SmtpNotificationEmailSender(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public Task SendHtmlAsync(string destino, string asunto, string cuerpoHtml)
+    {
+        var smtp = new SmtpSettingsDTO
+        {
+            Host = _configuration["SmtpSettings:Host"] ?? string.Empty,
+            Port = int.TryParse(_configuration["SmtpSettings:Port"], out var port) ? port : 587,
+            EnableSsl = bool.TryParse(_configuration["SmtpSettings:EnableSsl"], out var ssl) ? ssl : true,
+            FromName = _configuration["SmtpSettings:FromName"] ?? string.Empty,
+            FromEmail = _configuration["SmtpSettings:FromEmail"] ?? string.Empty,
+            Username = _configuration["SmtpSettings:Username"] ?? string.Empty,
+            Password = _configuration["SmtpSettings:Password"] ?? string.Empty
+        };
+
+        var smtpConfigurado = !string.IsNullOrWhiteSpace(smtp.Host)
+            && !string.IsNullOrWhiteSpace(smtp.FromEmail)
+            && !string.IsNullOrWhiteSpace(smtp.Username)
+            && !string.IsNullOrWhiteSpace(smtp.Password);
+
+        if (!smtpConfigurado)
+        {
+            return Task.CompletedTask;
+        }
+
+        var correoService = new CorreoService(smtp);
+        correoService.EnviarCorreoHtml(destino, asunto, cuerpoHtml);
+        return Task.CompletedTask;
+    }
+}

--- a/PSA.WebApp/Controllers/NotificacionesController.cs
+++ b/PSA.WebApp/Controllers/NotificacionesController.cs
@@ -1,20 +1,56 @@
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PSA.EntidadesDTO.DTOs.Notificaciones;
+using PSA.WebApp.Models;
+using System.Net.Http.Json;
+using System.Security.Claims;
 
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "2")]
     public class NotificacionesController : Controller
     {
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public NotificacionesController(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
         [HttpGet]
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
             ViewBag.ModuloActivo = "notificaciones";
             ViewBag.RolActivo = "Dueno";
             ViewBag.TituloPagina = "Notificaciones";
             ViewBag.SubtituloPagina = "Revise avisos del sistema asociados a evaluaciones, cuentas y pagos.";
             ViewBag.BreadcrumbActual = "Notificaciones";
-            return View();
+
+            var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
+            if (idUsuario <= 0)
+            {
+                TempData["MensajeError"] = "No fue posible identificar su sesión para cargar notificaciones.";
+                return View(new NotificacionesViewModel());
+            }
+
+            var client = _httpClientFactory.CreateClient("AuthApi");
+            var data = await client.GetFromJsonAsync<List<NotificacionDTO>>($"api/Notificaciones/usuario/{idUsuario}?maximo=50") ?? new();
+            await client.PostAsync($"api/Notificaciones/usuario/{idUsuario}/marcar-leidas", content: null);
+
+            var model = new NotificacionesViewModel
+            {
+                Items = data.Select(x => new NotificacionItemViewModel
+                {
+                    Id = x.Id,
+                    Titulo = x.Titulo,
+                    Mensaje = x.Mensaje,
+                    Tipo = x.Tipo,
+                    Leida = x.Leida,
+                    Fecha = x.FechaEnvio
+                }).ToList()
+            };
+
+            return View(model);
         }
     }
 }

--- a/PSA.WebApp/Models/NotificacionesViewModel.cs
+++ b/PSA.WebApp/Models/NotificacionesViewModel.cs
@@ -1,0 +1,16 @@
+namespace PSA.WebApp.Models;
+
+public class NotificacionesViewModel
+{
+    public List<NotificacionItemViewModel> Items { get; set; } = new();
+}
+
+public class NotificacionItemViewModel
+{
+    public int Id { get; set; }
+    public string Titulo { get; set; } = string.Empty;
+    public string Mensaje { get; set; } = string.Empty;
+    public string? Tipo { get; set; }
+    public bool Leida { get; set; }
+    public DateTime Fecha { get; set; }
+}

--- a/PSA.WebApp/PSA.WebApp.csproj
+++ b/PSA.WebApp/PSA.WebApp.csproj
@@ -25,6 +25,7 @@
     <Compile Include="Models\MiPerfilViewModel.cs" />
     <Compile Include="Models\EvaluacionesViewModels.cs" />
     <Compile Include="Models\ReportesViewModels.cs" />
+    <Compile Include="Models\NotificacionesViewModel.cs" />
     <Compile Include="Models\RecuperarContrasenaViewModel.cs" />
     <Compile Include="Models\RestablecerContrasenaViewModel.cs" />
     <Compile Include="Services\HttpClientService.cs" />

--- a/PSA.WebApp/Views/Notificaciones/Index.cshtml
+++ b/PSA.WebApp/Views/Notificaciones/Index.cshtml
@@ -1,3 +1,4 @@
+@model PSA.WebApp.Models.NotificacionesViewModel
 @{
     ViewData["Title"] = "Notificaciones";
 }
@@ -6,16 +7,28 @@
         <div>
             <span class="eyebrow">Avisos del sistema</span>
             <h2>Notificaciones</h2>
-            <p>Base para comunicación al propietario sobre cambios de estado y pagos.</p>
+            <p>Historial de avisos relevantes sobre evaluaciones, cuentas y pagos.</p>
         </div>
         <a class="boton-secundario" asp-controller="Dashboard" asp-action="Dueno">Volver al dashboard</a>
     </div>
 
     <section class="tarjeta-panel">
-        <ul class="lista-timeline">
-            <li><a asp-controller="Fincas" asp-action="DetalleFinca" asp-route-id="1">Su finca “Los Laureles” fue registrada correctamente.</a></li>
-            <li><a asp-controller="Fincas" asp-action="DetalleFinca" asp-route-id="1">Debe actualizar o registrar una cuenta bancaria para futuros pagos.</a></li>
-            <li><a asp-controller="Evaluaciones" asp-action="EvaluacionesEnProceso">La evaluación técnica de “Río Verde” ya se encuentra en proceso.</a></li>
-        </ul>
+        @if (Model.Items.Count == 0)
+        {
+            <p class="text-muted mb-0">No hay notificaciones para mostrar.</p>
+        }
+        else
+        {
+            <ul class="lista-timeline mb-0">
+                @foreach (var item in Model.Items)
+                {
+                    <li>
+                        <strong>@item.Titulo</strong>
+                        <div>@item.Mensaje</div>
+                        <small class="text-muted">@item.Fecha.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</small>
+                    </li>
+                }
+            </ul>
+        }
     </section>
 </section>

--- a/PSA.WebApp/Views/Shared/_MensajesSistema.cshtml
+++ b/PSA.WebApp/Views/Shared/_MensajesSistema.cshtml
@@ -1,7 +1,7 @@
 @{
     var mensajeExitoHtml = TempData["MensajeExitoHtml"]?.ToString();
-    var mensajeExito = TempData["MensajeExito"]?.ToString();
-    var mensajeError = TempData["MensajeError"]?.ToString();
+    var mensajeExito = TempData["MensajeExito"]?.ToString() ?? TempData["Exito"]?.ToString();
+    var mensajeError = TempData["MensajeError"]?.ToString() ?? TempData["Error"]?.ToString();
 }
 
 @if (!string.IsNullOrWhiteSpace(mensajeExitoHtml))


### PR DESCRIPTION
### Motivation
- Detecté que la tabla `Notificaciones` y algunos correos (recuperación / bienvenida) existían pero no había un mecanismo centralizado para poblar notificaciones desde eventos de negocio, lo que causaba dispersión de mensajes y pérdida de consistencia UX.
- Objetivo: introducir una abstracción de notificaciones por capas para unificar envío in‑app y email, reducir duplicación y preparar persistencia mínima compatible con el esquema actual.

### Description
- Añadí interfaces y dispatcher central en `AppCore` (`INotificationDispatcher`, `INotificationEmailSender`, `NotificationDispatcher`) y un catálogo de plantillas/tipos en `NotificationCatalog` para estandarizar texto y severidad. (ver `PSA.AppCore/Services/Notifications/*`).
- Implementé persistencia y lectura de notificaciones con `NotificacionDAO` y `NotificacionesManager`, y expuse API para listar y marcar leídas (`PSA.WebAPI/Controllers/NotificacionesController.cs`).
- Conecté el dispatcher a eventos MVP clave: registro de finca, asignación y finalización de evaluación, generación de plan de pagos, registro/validación de cuenta bancaria (cambios en `PSA.AppCore/Managers/*` y `PSA.AppCore/Services/PaymentPlanService.cs`).
- Integré envío reutilizable de email SMTP (`SmtpNotificationEmailSender`), añadí `EnviarCorreoHtml` en el servicio existente y configuré DI en `PSA.WebAPI/Program.cs`; adapté front web para consumir API y mostrar historial real (`PSA.WebApp/Controllers/NotificacionesController.cs`, `PSA.WebApp/Views/Notificaciones/Index.cshtml`, `PSA.WebApp/Models/NotificacionesViewModel.cs`).

### Testing
- Intenté compilar la solución con `dotnet build /workspace/HummingBird_Solutions/psa-costa-rica.sln` pero la ejecución falló por ausencia del runtime en este entorno: `dotnet: command not found` (compilación no validada aquí).
- No se ejecutaron tests automáticos porque la herramienta `dotnet` no estuvo disponible en el entorno; no se reportaron fallos de tiempo de ejecución durante modificaciones en los archivos (ediciones locales no validadas por build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5195bd824832d8ef8b09426e0804b)