### PR TITLE
Maneja validación de tipo de cuenta y errores sin tumbar el registro

### DIFF
--- a/PSA.AppCore/Managers/PagosManager.cs
+++ b/PSA.AppCore/Managers/PagosManager.cs
@@ -11,6 +11,15 @@ public class PagosManager(
     IPaymentPlanReadService paymentPlanReadService,
     INotificationDispatcher notificationDispatcher)
 {
+    private static readonly HashSet<string> TiposCuentaPermitidos = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Ahorro",
+        "Corriente",
+        "IBAN",
+        "SINPE",
+        "Otra"
+    };
+
     private readonly PlanPagoDAO _planPagoDao = planPagoDao;
     private readonly IPaymentPlanService _paymentPlanService = paymentPlanService;
     private readonly IPaymentPlanReadService _paymentPlanReadService = paymentPlanReadService;
@@ -136,6 +145,12 @@ public class PagosManager(
             || string.IsNullOrWhiteSpace(dto.Titular))
         {
             throw new InvalidOperationException("Debe completar todos los datos de la cuenta bancaria.");
+        }
+
+        dto.TipoCuenta = dto.TipoCuenta.Trim();
+        if (!TiposCuentaPermitidos.Contains(dto.TipoCuenta))
+        {
+            throw new InvalidOperationException("El tipo de cuenta no es válido. Use: Ahorro, Corriente, IBAN, SINPE u Otra.");
         }
 
         var idCuenta = await _planPagoDao.RegistrarCuentaBancariaDuenoAsync(dto);

--- a/PSA.DataAccess/DAO/PlanPagoDAO.cs
+++ b/PSA.DataAccess/DAO/PlanPagoDAO.cs
@@ -496,8 +496,15 @@ ORDER BY pp.Anio DESC, pp.IdPlanPago DESC;";
         command.Parameters.AddWithValue("@TipoCuenta", dto.TipoCuenta.Trim());
         command.Parameters.AddWithValue("@Titular", dto.Titular.Trim());
 
-        var result = await command.ExecuteScalarAsync();
-        return Convert.ToInt32(result ?? 0);
+        try
+        {
+            var result = await command.ExecuteScalarAsync();
+            return Convert.ToInt32(result ?? 0);
+        }
+        catch (SqlException ex) when (ex.Message.Contains("CK_Cuentas_TipoCuenta", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("El tipo de cuenta no es válido. Use: Ahorro, Corriente, IBAN, SINPE u Otra.", ex);
+        }
     }
 
     public async Task<List<OwnerPaymentPlanDto>> ObtenerPlanesOwnerAsync(int idPropietario)

--- a/PSA.WebAPI/Controllers/PagosController.cs
+++ b/PSA.WebAPI/Controllers/PagosController.cs
@@ -178,6 +178,10 @@ public class PagosController(PagosManager pagosManager) : ControllerBase
         {
             return BadRequest(new { Mensaje = ex.Message });
         }
+        catch (Exception)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, new { Mensaje = "No fue posible registrar la cuenta bancaria en este momento." });
+        }
     }
 
     [HttpPut("dueno/planes/{idPlanPago:int}/cuenta-bancaria")]

--- a/PSA.WebApp/Controllers/PagosController.cs
+++ b/PSA.WebApp/Controllers/PagosController.cs
@@ -143,10 +143,11 @@ namespace PSA.WebApp.Controllers
         {
             var idUsuario = int.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var id) ? id : 0;
             model.IdUsuario = idUsuario;
-            var idCuenta = await _httpClientService.PostAsync<RegistrarCuentaBancariaDTO, int>("api/Pagos/dueno/cuentas-bancarias", model);
+            var resultado = await _httpClientService.PostWithResultAsync<RegistrarCuentaBancariaDTO, int>("api/Pagos/dueno/cuentas-bancarias", model);
+            var idCuenta = resultado.Data;
             TempData[idCuenta > 0 ? "Exito" : "Error"] = idCuenta > 0
                 ? "Cuenta bancaria registrada. Queda pendiente de validación por administración."
-                : "No fue posible registrar la cuenta bancaria.";
+                : resultado.ErrorMessage ?? "No fue posible registrar la cuenta bancaria.";
 
             return RedirectToAction(nameof(CuentaBancaria));
         }

--- a/PSA.WebApp/Services/HttpClientService.cs
+++ b/PSA.WebApp/Services/HttpClientService.cs
@@ -49,6 +49,27 @@ public class HttpClientService
         return await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions);
     }
 
+    public async Task<ApiResult<TResponse>> PostWithResultAsync<TRequest, TResponse>(string endpoint, TRequest data)
+    {
+        var client = _httpClientFactory.CreateClient("AuthApi");
+        var response = await client.PostAsJsonAsync(endpoint, data, JsonOptions);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return new ApiResult<TResponse>
+            {
+                IsSuccess = false,
+                ErrorMessage = await ExtractErrorMessageAsync(response)
+            };
+        }
+
+        return new ApiResult<TResponse>
+        {
+            IsSuccess = true,
+            Data = await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions)
+        };
+    }
+
     public async Task<TResponse?> PutAsync<TRequest, TResponse>(string endpoint, TRequest data)
     {
         var client = _httpClientFactory.CreateClient("AuthApi");
@@ -93,4 +114,40 @@ public class HttpClientService
 
         return await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions);
     }
+
+    private static async Task<string?> ExtractErrorMessageAsync(HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadAsStringAsync();
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(payload);
+            if (doc.RootElement.TryGetProperty("mensaje", out var mensajeMin))
+            {
+                return mensajeMin.GetString();
+            }
+
+            if (doc.RootElement.TryGetProperty("Mensaje", out var mensajeMay))
+            {
+                return mensajeMay.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Intencional: si la respuesta no es JSON se usa el fallback.
+        }
+
+        return payload;
+    }
+}
+
+public class ApiResult<T>
+{
+    public bool IsSuccess { get; init; }
+    public T? Data { get; init; }
+    public string? ErrorMessage { get; init; }
 }

--- a/PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml
+++ b/PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml
@@ -73,7 +73,14 @@
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Tipo de cuenta</label>
-                        <input class="form-control" name="TipoCuenta" required />
+                        <select class="form-select" name="TipoCuenta" required>
+                            <option value="">Seleccione un tipo</option>
+                            <option value="Ahorro">Ahorro</option>
+                            <option value="Corriente">Corriente</option>
+                            <option value="IBAN">IBAN</option>
+                            <option value="SINPE">SINPE</option>
+                            <option value="Otra">Otra</option>
+                        </select>
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Titular</label>


### PR DESCRIPTION
### Motivation
- Evitar que el registro de cuentas bancarias falle con una excepción no controlada cuando `TipoCuenta` no cumple la restricción CHECK en la base de datos. 
- Mostrar un mensaje claro en la UI (toast/alerta) en lugar de dejar que la API arroje `SqlException` y provoque caída del flujo del usuario.

### Description
- Agregada validación en `PagosManager.RegistrarCuentaBancariaDuenoAsync` para permitir solo los valores `Ahorro`, `Corriente`, `IBAN`, `SINPE` y `Otra`, y devolver `InvalidOperationException` con mensaje amigable cuando no coincide. (`PSA.AppCore/Managers/PagosManager.cs`).
- En `PlanPagoDAO.RegistrarCuentaBancariaDuenoAsync` se captura el `SqlException` del constraint `CK_Cuentas_TipoCuenta` y se traduce a `InvalidOperationException` con mensaje funcional para el usuario. (`PSA.DataAccess/DAO/PlanPagoDAO.cs`).
- El endpoint API `POST api/Pagos/dueno/cuentas-bancarias` ahora captura excepciones generales y responde con un `500` controlado y mensaje legible si ocurre un error inesperado. (`PSA.WebAPI/Controllers/PagosController.cs`).
- Se añadió `PostWithResultAsync` a `HttpClientService` para extraer mensajes de error devueltos por la API y un tipo `ApiResult<T>` para transportar `Data` o `ErrorMessage`. (`PSA.WebApp/Services/HttpClientService.cs`).
- El controlador WebApp `PagosController.RegistrarCuentaBancaria` usa la nueva llamada `PostWithResultAsync` y muestra el `ErrorMessage` recibido en `TempData` para que la UI muestre un toast/alerta con la causa real. (`PSA.WebApp/Controllers/PagosController.cs`).
- En la vista de registro de cuenta bancaria se reemplazó el campo libre de `TipoCuenta` por un `select` con las opciones válidas para prevenir envíos inválidos desde la UI. (`PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml`).

### Testing
- Se intentó compilar con `dotnet build psa-costa-rica.slnx`, pero el entorno no cuenta con `dotnet` instalado y la ejecución falló con `dotnet: command not found` (no se pudo ejecutar build automático aquí).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52578d714832d97acfecda96add6f)