### PR TITLE
Validación de cuentas: solo asignar `ValidadoPor` si el usuario existe

### DIFF
--- a/PSA.DataAccess/DAO/CuentaBancariaDAO.cs
+++ b/PSA.DataAccess/DAO/CuentaBancariaDAO.cs
@@ -99,7 +99,9 @@ ORDER BY {ordenFecha};";
             command.Parameters.AddWithValue("@Observaciones", (object?)dto.Observaciones ?? DBNull.Value);
         }
 
-        if (columnas.Contains("ValidadoPor", StringComparer.OrdinalIgnoreCase))
+        if (columnas.Contains("ValidadoPor", StringComparer.OrdinalIgnoreCase)
+            && dto.IdAdministrador > 0
+            && await UsuarioExisteAsync(connection, dto.IdAdministrador))
         {
             asignaciones.Add("ValidadoPor = @ValidadoPor");
             command.Parameters.AddWithValue("@ValidadoPor", dto.IdAdministrador);
@@ -127,6 +129,19 @@ WHERE IdCuentaBancaria = @IdCuentaBancaria;";
         command.CommandText = sql;
 
         await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<bool> UsuarioExisteAsync(SqlConnection connection, int idUsuario)
+    {
+        const string sql = @"
+SELECT 1
+FROM dbo.Usuarios
+WHERE IdUsuario = @IdUsuario;";
+
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdUsuario", idUsuario);
+        var existe = await command.ExecuteScalarAsync();
+        return existe != null && existe != DBNull.Value;
     }
 
     private static async Task<HashSet<string>> ObtenerColumnasCuentaBancariaAsync(SqlConnection connection)


### PR DESCRIPTION
### Motivation
- La validación administrativa de cuentas fallaba cuando se intentaba escribir `ValidadoPor` con un ID de administrador (por ejemplo `AdminSistemaId = 1`) que no existía en `dbo.Usuarios`, lo que podía provocar un error en la base de datos, reversión de la transacción y el mensaje en el frontend "No se pudo procesar la validación".

### Description
- Se agregó una verificación en `CuentaBancariaDAO.ValidarCuentaAsync` para que `ValidadoPor` solo se incluya en el `UPDATE` si la columna existe, `dto.IdAdministrador > 0` y el usuario existe en la tabla `dbo.Usuarios`, y se añadió el helper `UsuarioExisteAsync` que consulta la existencia del usuario.

### Testing
- Se intentó ejecutar `dotnet build psa-costa-rica.slnx`, pero la ejecución falló porque `dotnet` no está disponible en este entorno, y los cambios quedaron verificados por `git diff` y confirmados con `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e533584e28832db935a741cad6c6b7)