### PR TITLE
Corregir clave duplicada `ConnectionStrings` en PSA.WebAPI/appsettings.json

### DIFF
--- a/PSA.WebAPI/appsettings.json
+++ b/PSA.WebAPI/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "PSAConnection": ""
+    "PSAConnection": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=PSA_CostaRica;Integrated Security=True;TrustServerCertificate=True"
   },
   "PasswordRecovery": {
     "TokenLifetimeMinutes": 1
@@ -20,20 +20,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "PSAConnection": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=PSA_CostaRica;Integrated Security=True;TrustServerCertificate=True"
-  },
-  "PasswordRecovery": {
-    "TokenLifetimeMinutes": 1
-  },
-  "SmtpSettings": {
-    "Host": "",
-    "Port": 587,
-    "EnableSsl": true,
-    "FromName": "",
-    "FromEmail": "",
-    "Username": "",
-    "Password": ""
-  }
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
### Motivation
- El archivo `PSA.WebAPI/appsettings.json` contenía claves duplicadas (p. ej. `ConnectionStrings:PSAConnection`) provocando una `FormatException` y fallos al iniciar la aplicación.

### Description
- Se limpió `PSA.WebAPI/appsettings.json` eliminando secciones repetidas y dejando una única entrada para `ConnectionStrings:PSAConnection`, `PasswordRecovery` y `SmtpSettings`, preservando `Logging` y `AllowedHosts`.

### Testing
- Se validó el JSON con `python -m json.tool PSA.WebAPI/appsettings.json` (éxito) y se intentó `dotnet build PSA.WebAPI/PSA.WebAPI.csproj -nologo` pero falló en este entorno porque `dotnet` no está instalado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e544789d00832d8908b4f1a6a35982)