### PR TITLE
Require email for token validation/reset and standardize expiration handling

### DIFF
--- a/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
+++ b/PSA.AppCore/Managers/RecuperacionContrasenaManager.cs
@@ -32,16 +32,16 @@ namespace PSA.AppCore.Managers
 
         public async Task SolicitarRecuperacionAsync(string email)
         {
-            var (token, nombreUsuario, fechaExpiracionUtc) = await GenerarTokenConNombreAsync(email);
+            var (token, nombreUsuario, fechaExpiracion) = await GenerarTokenConNombreAsync(email);
 
             await _passwordRecoveryEmailSender.SendRecoveryEmailAsync(
                 destino: email.Trim(),
                 nombreUsuario: nombreUsuario,
                 token: token,
-                fechaExpiracionUtc: fechaExpiracionUtc);
+                fechaExpiracion: fechaExpiracion);
         }
 
-        public async Task<(string Token, string NombreUsuario, DateTime FechaExpiracionUtc)> GenerarTokenConNombreAsync(string email)
+        public async Task<(string Token, string NombreUsuario, DateTime FechaExpiracion)> GenerarTokenConNombreAsync(string email)
         {
             if (string.IsNullOrWhiteSpace(email))
             {
@@ -66,8 +66,8 @@ namespace PSA.AppCore.Managers
             await _tokenRecuperacionDAO.InvalidarTokensActivosPorUsuarioAsync(usuario.IdUsuario);
 
             var token = RandomNumberGenerator.GetInt32(0, 1_000_000).ToString("D6");
-            var fechaExpiracionUtc = DateTime.UtcNow.Add(_passwordRecoveryPolicy.TokenLifetime);
-            await _tokenRecuperacionDAO.CrearTokenAsync(usuario.IdUsuario, token, fechaExpiracionUtc);
+            var fechaExpiracion = DateTime.Now.Add(_passwordRecoveryPolicy.TokenLifetime);
+            await _tokenRecuperacionDAO.CrearTokenAsync(usuario.IdUsuario, token, fechaExpiracion);
 
             await _auditoriaLogDAO.RegistrarEventoAsync(
                 idUsuario: usuario.IdUsuario,
@@ -78,18 +78,28 @@ namespace PSA.AppCore.Managers
                 detalle: "Se generó token de recuperación de contraseña."
             );
 
-            return (token, usuario.NombreCompleto, fechaExpiracionUtc);
+            return (token, usuario.NombreCompleto, fechaExpiracion);
         }
 
-        public async Task<TokenRecuperacionValidationResult> ValidarTokenAsync(string token)
+        public async Task<TokenRecuperacionValidationResult> ValidarTokenAsync(string token, string email)
         {
-            if (string.IsNullOrWhiteSpace(token))
+            if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(email))
+            {
+                return new TokenRecuperacionValidationResult { Estado = EstadoTokenRecuperacion.Invalido };
+            }
+
+            var usuario = await _usuarioDAO.ObtenerPorEmailAsync(email.Trim());
+            if (usuario == null)
             {
                 return new TokenRecuperacionValidationResult { Estado = EstadoTokenRecuperacion.Invalido };
             }
 
             var registro = await _tokenRecuperacionDAO.ObtenerTokenPorValorAsync(token.Trim());
             var estado = DeterminarEstado(registro);
+            if (registro == null || registro.IdUsuario != usuario.IdUsuario)
+            {
+                estado = EstadoTokenRecuperacion.Invalido;
+            }
 
             await _auditoriaLogDAO.RegistrarEventoAsync(
                 idUsuario: registro?.IdUsuario,
@@ -107,7 +117,18 @@ namespace PSA.AppCore.Managers
 
         public async Task<bool> TokenEsValidoAsync(string token)
         {
-            var resultado = await ValidarTokenAsync(token);
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return false;
+            }
+
+            var registro = await _tokenRecuperacionDAO.ObtenerTokenPorValorAsync(token.Trim());
+            return DeterminarEstado(registro) == EstadoTokenRecuperacion.Vigente;
+        }
+
+        public async Task<bool> TokenEsValidoAsync(string token, string email)
+        {
+            var resultado = await ValidarTokenAsync(token, email);
             return resultado.EsValido;
         }
 
@@ -122,11 +143,16 @@ namespace PSA.AppCore.Managers
             return TokenEsValidoAsync(token).GetAwaiter().GetResult();
         }
 
-        public async Task RestablecerContrasenaAsync(string token, string nuevaContrasena)
+        public async Task RestablecerContrasenaAsync(string token, string email, string nuevaContrasena)
         {
             if (string.IsNullOrWhiteSpace(token))
             {
                 throw new InvalidOperationException("El token es obligatorio.");
+            }
+
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                throw new InvalidOperationException("El correo es obligatorio.");
             }
 
             if (string.IsNullOrWhiteSpace(nuevaContrasena) || nuevaContrasena.Trim().Length < 8)
@@ -134,8 +160,19 @@ namespace PSA.AppCore.Managers
                 throw new InvalidOperationException("La nueva contraseña debe contener al menos 8 caracteres.");
             }
 
+            var usuario = await _usuarioDAO.ObtenerPorEmailAsync(email.Trim());
+            if (usuario == null)
+            {
+                throw new InvalidOperationException("token inválido");
+            }
+
             var registro = await _tokenRecuperacionDAO.ObtenerTokenPorValorAsync(token.Trim());
             var estado = DeterminarEstado(registro);
+            if (registro == null || registro.IdUsuario != usuario.IdUsuario)
+            {
+                estado = EstadoTokenRecuperacion.Invalido;
+            }
+
             if (estado != EstadoTokenRecuperacion.Vigente || registro == null)
             {
                 await _auditoriaLogDAO.RegistrarEventoAsync(
@@ -149,21 +186,21 @@ namespace PSA.AppCore.Managers
                 throw new InvalidOperationException(ObtenerMensajePorEstado(estado));
             }
 
-            var usuario = await _usuarioDAO.ObtenerPorIdAsync(registro.IdUsuario);
-            if (usuario == null)
+            var usuarioConToken = await _usuarioDAO.ObtenerPorIdAsync(registro.IdUsuario);
+            if (usuarioConToken == null)
             {
                 throw new InvalidOperationException("No se encontró el usuario asociado al token.");
             }
 
             var hash = _servicioHash.GenerarHash(nuevaContrasena.Trim());
-            await _usuarioDAO.ActualizarPasswordHashPorEmailAsync(usuario.Email, hash);
+            await _usuarioDAO.ActualizarPasswordHashPorEmailAsync(usuarioConToken.Email, hash);
             await _tokenRecuperacionDAO.MarcarTokenComoUsadoAsync(registro.IdToken);
 
             await _auditoriaLogDAO.RegistrarEventoAsync(
-                idUsuario: usuario.IdUsuario,
+                idUsuario: usuarioConToken.IdUsuario,
                 modulo: "Autenticacion",
                 tablaAfectada: "Usuarios",
-                idRegistroAfectado: usuario.IdUsuario,
+                idRegistroAfectado: usuarioConToken.IdUsuario,
                 accion: "CAMBIO_CONTRASENA_EXITOSO",
                 detalle: "Se restableció la contraseña usando token de recuperación."
             );
@@ -181,7 +218,7 @@ namespace PSA.AppCore.Managers
                 return EstadoTokenRecuperacion.Utilizado;
             }
 
-            return registro.FechaExpiracion <= DateTime.UtcNow
+            return registro.FechaExpiracion <= DateTime.Now
                 ? EstadoTokenRecuperacion.Expirado
                 : EstadoTokenRecuperacion.Vigente;
         }

--- a/PSA.AppCore/Services/Security/PasswordRecoveryContracts.cs
+++ b/PSA.AppCore/Services/Security/PasswordRecoveryContracts.cs
@@ -7,7 +7,7 @@ public interface IPasswordRecoveryPolicy
 
 public interface IPasswordRecoveryEmailSender
 {
-    Task SendRecoveryEmailAsync(string destino, string nombreUsuario, string token, DateTime fechaExpiracionUtc);
+    Task SendRecoveryEmailAsync(string destino, string nombreUsuario, string token, DateTime fechaExpiracion);
 }
 
 public enum EstadoTokenRecuperacion

--- a/PSA.EntidadesDTO/DTOs/RecuperacionContrasena/ValidarTokenDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/RecuperacionContrasena/ValidarTokenDTO.cs
@@ -3,5 +3,14 @@
     public class ValidarTokenDTO
     {
         public string Token { get; set; } = string.Empty;
+
+        public string Email { get; set; } = string.Empty;
+
+        // Compatibilidad con clientes que envían "correo"
+        public string Correo
+        {
+            get => Email;
+            set => Email = value;
+        }
     }
 }   

--- a/PSA.EntidadesDTO/DTOs/RestablecerContrasenaDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/RestablecerContrasenaDTO.cs
@@ -4,6 +4,17 @@ namespace PSA.EntidadesDTO.DTOs
 {
     public class RestablecerContrasenaDTO
     {
+        [Required(ErrorMessage = "El correo es obligatorio.")]
+        [EmailAddress(ErrorMessage = "Ingrese un correo válido.")]
+        public string Email { get; set; } = string.Empty;
+
+        // Compatibilidad con clientes que envían "correo"
+        public string Correo
+        {
+            get => Email;
+            set => Email = value;
+        }
+
         [Required]
         public string Token { get; set; } = string.Empty;
 

--- a/PSA.WebAPI/Controllers/RecuperacionContrasenaController.cs
+++ b/PSA.WebAPI/Controllers/RecuperacionContrasenaController.cs
@@ -61,16 +61,16 @@ namespace PSA.WebAPI.Controllers
         {
             try
             {
-                if (dto == null || string.IsNullOrWhiteSpace(dto.Token))
+                if (dto == null || string.IsNullOrWhiteSpace(dto.Token) || string.IsNullOrWhiteSpace(dto.Email))
                 {
                     return BadRequest(new RespuestaRecuperacionDTO
                     {
                         Exito = false,
-                        Mensaje = "Debe enviar un token válido."
+                        Mensaje = "Debe enviar token y correo válidos."
                     });
                 }
 
-                var validacion = await _manager.ValidarTokenAsync(dto.Token);
+                var validacion = await _manager.ValidarTokenAsync(dto.Token, dto.Email);
                 var mensaje = validacion.Estado switch
                 {
                     EstadoTokenRecuperacion.Vigente => "Token válido.",
@@ -101,6 +101,7 @@ namespace PSA.WebAPI.Controllers
             try
             {
                 if (dto == null
+                    || string.IsNullOrWhiteSpace(dto.Email)
                     || string.IsNullOrWhiteSpace(dto.Token)
                     || string.IsNullOrWhiteSpace(dto.NuevaContrasena)
                     || string.IsNullOrWhiteSpace(dto.ConfirmarContrasena))
@@ -121,7 +122,7 @@ namespace PSA.WebAPI.Controllers
                     });
                 }
 
-                await _manager.RestablecerContrasenaAsync(dto.Token, dto.NuevaContrasena);
+                await _manager.RestablecerContrasenaAsync(dto.Token, dto.Email, dto.NuevaContrasena);
                 return Ok(new RespuestaRecuperacionDTO
                 {
                     Exito = true,

--- a/PSA.WebAPI/CorreoService.cs
+++ b/PSA.WebAPI/CorreoService.cs
@@ -13,7 +13,7 @@ namespace PSA.WebAPI.Services
             _smtp = smtp;
         }
 
-        public async Task EnviarCorreoRecuperacionAsync(string destino, string nombreUsuario, string token, DateTime fechaExpiracionUtc)
+        public async Task EnviarCorreoRecuperacionAsync(string destino, string nombreUsuario, string token, DateTime fechaExpiracion)
         {
             var asunto = "Recuperación de contraseña - PSA Costa Rica";
 
@@ -25,7 +25,7 @@ namespace PSA.WebAPI.Services
                     <p>Recibimos una solicitud para restablecer tu contraseña.</p>
                     <p>Tu token de recuperación es:</p>
                     <p style='font-size:24px;font-weight:700;letter-spacing:4px;'>{token}</p>
-                    <p>Este token vence el {fechaExpiracionUtc:yyyy-MM-dd HH:mm:ss} UTC (máximo 1 minuto).</p>
+                    <p>Este token vence el {fechaExpiracion:yyyy-MM-dd HH:mm:ss} (máximo 1 minuto).</p>
                     <p>Si no solicitaste este cambio, puedes ignorar este correo.</p>
                 </body>
                 </html>";

--- a/PSA.WebAPI/Services/PasswordRecoveryServices.cs
+++ b/PSA.WebAPI/Services/PasswordRecoveryServices.cs
@@ -34,7 +34,7 @@ public class PasswordRecoveryEmailSender : IPasswordRecoveryEmailSender
         _logger = logger;
     }
 
-    public async Task SendRecoveryEmailAsync(string destino, string nombreUsuario, string token, DateTime fechaExpiracionUtc)
+    public async Task SendRecoveryEmailAsync(string destino, string nombreUsuario, string token, DateTime fechaExpiracion)
     {
         var smtp = new SmtpSettingsDTO
         {
@@ -61,7 +61,7 @@ public class PasswordRecoveryEmailSender : IPasswordRecoveryEmailSender
         try
         {
             var correoService = new CorreoService(smtp);
-            await correoService.EnviarCorreoRecuperacionAsync(destino, nombreUsuario, token, fechaExpiracionUtc);
+            await correoService.EnviarCorreoRecuperacionAsync(destino, nombreUsuario, token, fechaExpiracion);
         }
         catch (Exception ex)
         {

--- a/PSA.WebAPI/appsettings.json
+++ b/PSA.WebAPI/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "PSAConnection": ""
+    "PSAConnection": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=PSA_CostaRica;Integrated Security=True;TrustServerCertificate=True"
   },
   "PasswordRecovery": {
     "TokenLifetimeMinutes": 1
@@ -20,20 +20,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "PSAConnection": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=PSA_CostaRica;Integrated Security=True;TrustServerCertificate=True"
-  },
-  "PasswordRecovery": {
-    "TokenLifetimeMinutes": 1
-  },
-  "SmtpSettings": {
-    "Host": "",
-    "Port": 587,
-    "EnableSsl": true,
-    "FromName": "",
-    "FromEmail": "",
-    "Username": "",
-    "Password": ""
-  }
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
### Motivation
- Asegurar que los tokens de recuperación se usen solo por el usuario dueño del correo asociado al token. 
- Normalizar el manejo y paso de la fecha de expiración al remitente de correos y al almacenamiento para coherencia en la UI. 
- Mantener compatibilidad con clientes que envían `correo` en lugar de `Email` y mejorar las validaciones en la API.

### Description
- Cambia las firmas para validar y restablecer tokens a `ValidarTokenAsync(string token, string email)` y `RestablecerContrasenaAsync(string token, string email, string nuevaContrasena)` y añade una sobrecarga de `TokenEsValidoAsync` que acepta `email`.
- Añade el campo `Email` y la propiedad de compatibilidad `Correo` en `ValidarTokenDTO` y `RestablecerContrasenaDTO`, además de validar `Email` en el controlador `RecuperacionContrasenaController` y reenviar el `email` al manager.
- Unifica el uso de tiempos locales cambiando `DateTime.UtcNow` a `DateTime.Now` para cálculo y almacenamiento de `FechaExpiracion`, renombra parámetros de `fechaExpiracionUtc` a `fechaExpiracion` y propaga el cambio a `IPasswordRecoveryEmailSender`, `PasswordRecoveryEmailSender` y `CorreoService`.
- Ajustes de lógica para validar que el `registro.IdUsuario` coincida con el usuario recuperado por `email` antes de considerar un token vigente, y correcciones en el flujo de restablecimiento para actualizar el password del usuario asociado al token.
- Limpieza de `appsettings.json` (elimina duplicados y establece una cadena de conexión de desarrollo por defecto).

### Testing
- Se compiló la solución con `dotnet build` y la compilación finalizó correctamente. 
- Se ejecutaron los tests automatizados con `dotnet test` y todos los tests unitarios integrados pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e544789d00832d8908b4f1a6a35982)