### PR TITLE
Add JWT authentication, permission-based authorization, finca renewal flow, and related API/UI/DB changes

### DIFF
--- a/PSA.AppCore.Tests/PaymentCalculationServiceTests.cs
+++ b/PSA.AppCore.Tests/PaymentCalculationServiceTests.cs
@@ -66,4 +66,58 @@ public class PaymentCalculationServiceTests
         Assert.Equal(555.53m, result.MontoMensualTotal);
         Assert.Equal(6666.36m, result.MontoAnualTotal);
     }
+
+    [Fact]
+    public void Calculate_Throws_WhenApprovedHectaresAreNegative()
+    {
+        var context = new PlanPagoGenerationContextDTO
+        {
+            HectareasAprobadas = -0.01m,
+            VegetacionFinal = "bosque",
+            TieneRecursosHidricosFinal = false,
+            CantidadNacientesFinal = 0,
+            PendienteFinal = "plana"
+        };
+
+        var config = new PaymentConfigurationVersionDTO
+        {
+            PrecioBasePorHectarea = 100m,
+            TopePorcentajeAjuste = 40m
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _service.Calculate(context, config));
+
+        Assert.Equal("Las hectáreas aprobadas no pueden ser negativas.", ex.Message);
+    }
+
+    [Fact]
+    public void Calculate_TrimsInputAndHandlesMissingPercentages()
+    {
+        var context = new PlanPagoGenerationContextDTO
+        {
+            HectareasAprobadas = 1m,
+            VegetacionFinal = "  bosque secundario  ",
+            TieneRecursosHidricosFinal = true,
+            CantidadNacientesFinal = 1,
+            PendienteFinal = "desconocida"
+        };
+
+        var config = new PaymentConfigurationVersionDTO
+        {
+            PrecioBasePorHectarea = 100m,
+            TopePorcentajeAjuste = 99m,
+            VegetacionAjustes = new(StringComparer.OrdinalIgnoreCase) { ["bosque secundario"] = 15m },
+            HidricosAjustes = new(StringComparer.OrdinalIgnoreCase) { ["Si"] = 8m }
+        };
+
+        var result = _service.Calculate(context, config);
+
+        Assert.Equal(100m, result.MontoBaseMensual);
+        Assert.Equal(15m, result.PorcentajeVegetacion);
+        Assert.Equal(8m, result.PorcentajeHidrico);
+        Assert.Equal(0m, result.PorcentajeNacientes);
+        Assert.Equal(0m, result.PorcentajePendiente);
+        Assert.Equal(23m, result.PorcentajeAjusteAplicado);
+        Assert.Equal(123m, result.MontoMensualTotal);
+    }
 }

--- a/PSA.AppCore/Managers/FincaManager.cs
+++ b/PSA.AppCore/Managers/FincaManager.cs
@@ -1,6 +1,8 @@
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
 using PSA.AppCore.Services.Notifications;
+using PSA.EntidadesDTO.DTOs.Fincas;
+using PSA.EntidadesDTO.DTOs.Pagos;
 
 namespace PSA.AppCore.Managers;
 
@@ -9,21 +11,61 @@ public class FincaManager
     private readonly FincaDAO _fincaDao;
     private readonly EvaluacionTecnicaManager _evaluacionTecnicaManager;
     private readonly INotificationDispatcher _notificationDispatcher;
+    private readonly AuditoriaLogDAO _auditoriaLogDao;
 
-    public FincaManager(FincaDAO fincaDao, EvaluacionTecnicaManager evaluacionTecnicaManager, INotificationDispatcher notificationDispatcher)
+    public FincaManager(
+        FincaDAO fincaDao,
+        EvaluacionTecnicaManager evaluacionTecnicaManager,
+        INotificationDispatcher notificationDispatcher,
+        AuditoriaLogDAO auditoriaLogDao)
     {
         _fincaDao = fincaDao;
         _evaluacionTecnicaManager = evaluacionTecnicaManager;
         _notificationDispatcher = notificationDispatcher;
+        _auditoriaLogDao = auditoriaLogDao;
     }
 
     public Task<List<FincaResumenDTO>> ObtenerPorPropietarioAsync(int idPropietario) => _fincaDao.ObtenerPorPropietarioAsync(idPropietario);
     public Task<FincaDetalleDTO?> ObtenerDetalleAsync(int idFinca, int idPropietario) => _fincaDao.ObtenerDetalleAsync(idFinca, idPropietario);
 
+    public async Task<EstadoRenovacionAnualDTO> ObtenerEstadoRenovacionAnualAsync(int idFinca, int idPropietario)
+    {
+        var detalle = await _fincaDao.ObtenerDetalleAsync(idFinca, idPropietario);
+        if (detalle is null)
+        {
+            throw new InvalidOperationException("La finca no existe o no pertenece al propietario autenticado.");
+        }
+
+        var elegibilidad = await _fincaDao.ObtenerElegibilidadRenovacionAsync(idFinca, idPropietario)
+            ?? throw new InvalidOperationException("No fue posible verificar la elegibilidad de renovación.");
+
+        var estadoExpiradoOVencido = string.Equals(elegibilidad.EstadoPlanActual, EstadosPlanPago.Finalizado, StringComparison.OrdinalIgnoreCase)
+                                     || string.Equals(elegibilidad.EstadoPlanActual, EstadosPlanPago.Cancelado, StringComparison.OrdinalIgnoreCase);
+        var faltaUnaCuota = elegibilidad.TienePlanVigente && elegibilidad.CuotasRestantes == 1;
+        var cumpleCondicionPago = estadoExpiradoOVencido || faltaUnaCuota;
+        var puedeRenovar = cumpleCondicionPago && !elegibilidad.ExisteRenovacionPendienteMismoCiclo;
+
+        var motivo = puedeRenovar
+            ? "Cumple criterios para solicitar renovación anual."
+            : elegibilidad.ExisteRenovacionPendienteMismoCiclo
+                ? "Ya existe una evaluación técnica pendiente activa para esta finca."
+                : "Solo se permite renovar cuando el plan actual está vencido/expirado o cuando falta una única cuota para completarlo.";
+
+        return new EstadoRenovacionAnualDTO
+        {
+            PuedeRenovar = puedeRenovar,
+            Motivo = motivo,
+            EstadoPlanActual = elegibilidad.EstadoPlanActual,
+            CuotasRestantes = elegibilidad.CuotasRestantes,
+            ExisteEvaluacionPendienteActiva = elegibilidad.ExisteRenovacionPendienteMismoCiclo
+        };
+    }
+
     public async Task<int> RegistrarFincaAsync(RegistrarFincaDTO dto)
     {
         try
         {
+            ValidarUbicacionAdministrativa(dto);
             var idFinca = await _fincaDao.CrearFincaAsync(dto);
 
             try
@@ -50,6 +92,26 @@ public class FincaManager
         }
     }
 
+    private static void ValidarUbicacionAdministrativa(RegistrarFincaDTO dto)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Provincia)
+            || string.IsNullOrWhiteSpace(dto.Canton)
+            || string.IsNullOrWhiteSpace(dto.Distrito))
+        {
+            throw new InvalidOperationException("Provincia, cantón y distrito son obligatorios y deben venir resueltos en backend.");
+        }
+
+        var provincia = dto.Provincia.Trim();
+        var canton = dto.Canton.Trim();
+        var distrito = dto.Distrito.Trim();
+        if (provincia.StartsWith("Provincia ", StringComparison.OrdinalIgnoreCase)
+            || canton.StartsWith("Canton ", StringComparison.OrdinalIgnoreCase)
+            || distrito.StartsWith("Distrito ", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("La ubicación administrativa no es válida. Verifique provincia/cantón/distrito.");
+        }
+    }
+
     public Task<bool> ActualizarFincaAsync(int idFinca, RegistrarFincaDTO dto) => _fincaDao.ActualizarFincaAsync(idFinca, dto);
     public Task<bool> EliminarFincaAsync(int idFinca, int idPropietario) => _fincaDao.EliminarFincaAsync(idFinca, idPropietario);
 
@@ -61,7 +123,23 @@ public class FincaManager
             throw new InvalidOperationException("La finca no existe o no pertenece al propietario autenticado.");
         }
 
+        var estadoRenovacion = await ObtenerEstadoRenovacionAnualAsync(idFinca, idPropietario);
+        if (!estadoRenovacion.PuedeRenovar)
+        {
+            throw new InvalidOperationException(estadoRenovacion.Motivo);
+        }
+
         var idEvaluacion = await _evaluacionTecnicaManager.CrearPendientePorNuevaFincaAsync(idFinca);
+
+        await _auditoriaLogDao.RegistrarEventoAsync(
+            idPropietario,
+            "Fincas",
+            "EvaluacionesTecnicas",
+            "RENOVACION_ANUAL_GENERADA",
+            $"Renovación anual generada para finca #{idFinca}. IdEvaluacion={idEvaluacion}. EstadoPlan={estadoRenovacion.EstadoPlanActual}, CuotasRestantes={estadoRenovacion.CuotasRestantes}.",
+            idEvaluacion,
+            ipOrigen);
+
         await _notificationDispatcher.NotifyInAppAsync(
             idPropietario,
             "Renovación anual creada",

--- a/PSA.DataAccess/DAO/FincaDAO.cs
+++ b/PSA.DataAccess/DAO/FincaDAO.cs
@@ -6,6 +6,15 @@ using Microsoft.Data.SqlClient;
 
 namespace PSA.DataAccess.DAO
     {
+        public sealed class RenovacionElegibilidadDbDTO
+        {
+            public bool TienePlanVigente { get; set; }
+            public string? EstadoPlanActual { get; set; }
+            public int CuotasRestantes { get; set; }
+            public int AnioPlanActual { get; set; }
+            public bool ExisteRenovacionPendienteMismoCiclo { get; set; }
+        }
+
         public class FincaDAO
         {
             private readonly IDbConnectionFactory _connectionFactory;
@@ -349,6 +358,56 @@ WHERE IdFinca = @IdFinca";
             {
                 throw new InvalidOperationException("Error inesperado al registrar la finca.", ex);
             }
+        }
+
+        public async Task<RenovacionElegibilidadDbDTO?> ObtenerElegibilidadRenovacionAsync(int idFinca, int idPropietario)
+        {
+            const string sql = @"
+SELECT TOP 1
+    CAST(CASE WHEN pp.IdPlanPago IS NULL THEN 0 ELSE 1 END AS bit) AS TienePlanVigente,
+    pp.EstadoPlan AS EstadoPlanActual,
+    ISNULL((
+        SELECT COUNT(1)
+        FROM dbo.CuotasPago c
+        WHERE c.IdPlanPago = pp.IdPlanPago
+          AND c.EstadoCuota <> 'Ejecutada'
+    ), 0) AS CuotasRestantes,
+    ISNULL(pp.Anio, YEAR(SYSDATETIME())) AS AnioPlanActual,
+    CAST(CASE WHEN EXISTS (
+        SELECT 1
+        FROM dbo.EvaluacionesTecnicas e
+        WHERE e.IdFinca = f.IdFinca
+          AND e.EstadoEvaluacion IN ('Pendiente','En Proceso')
+    ) THEN 1 ELSE 0 END AS bit) AS ExisteRenovacionPendienteMismoCiclo
+FROM dbo.Fincas f
+OUTER APPLY (
+    SELECT TOP 1 p.IdPlanPago, p.EstadoPlan, p.Anio
+    FROM dbo.PlanesPago p
+    WHERE p.IdFinca = f.IdFinca
+    ORDER BY p.Anio DESC, p.IdPlanPago DESC
+) pp
+WHERE f.IdFinca = @IdFinca
+  AND f.IdPropietario = @IdPropietario;";
+
+            using var connection = _connectionFactory.CreateConnection();
+            using var command = new SqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@IdFinca", idFinca);
+            command.Parameters.AddWithValue("@IdPropietario", idPropietario);
+            await connection.OpenAsync();
+            using var reader = await command.ExecuteReaderAsync();
+            if (!await reader.ReadAsync())
+            {
+                return null;
+            }
+
+            return new RenovacionElegibilidadDbDTO
+            {
+                TienePlanVigente = reader.GetBoolean(reader.GetOrdinal("TienePlanVigente")),
+                EstadoPlanActual = reader["EstadoPlanActual"] == DBNull.Value ? null : reader["EstadoPlanActual"]?.ToString(),
+                CuotasRestantes = reader.GetInt32(reader.GetOrdinal("CuotasRestantes")),
+                AnioPlanActual = reader.GetInt32(reader.GetOrdinal("AnioPlanActual")),
+                ExisteRenovacionPendienteMismoCiclo = reader.GetBoolean(reader.GetOrdinal("ExisteRenovacionPendienteMismoCiclo"))
+            };
         }
 
         public async Task<bool> ActualizarFincaAsync(int idFinca, RegistrarFincaDTO dto)

--- a/PSA.DataAccess/DAO/PlanPagoDAO.cs
+++ b/PSA.DataAccess/DAO/PlanPagoDAO.cs
@@ -1132,7 +1132,7 @@ VALUES(@IdPlanPago, @Mes, @FechaProgramada, @MontoProgramado, @MontoPendiente, @
     INNER JOIN dbo.PlanesPago p ON p.IdPlanPago = c.IdPlanPago
     WHERE c.FechaProgramada < @FechaCorte
       AND c.MontoPendiente > 0
-      AND c.EstadoCuota IN ('Pendiente','Notificada','Atrasada')
+      AND c.EstadoCuota IN (@EstadoPendiente,@EstadoNotificada,@EstadoAtrasada)
       AND p.EstadoPlan = @EstadoActivo
 ), ProximaCuota AS (
     SELECT v.IdCuotaPago, v.MontoPendiente, nx.IdCuotaPago AS IdSiguiente
@@ -1149,7 +1149,7 @@ FROM ProximaCuota p
 INNER JOIN dbo.CuotasPago cnext ON cnext.IdCuotaPago = p.IdSiguiente;
 
 UPDATE c
-SET c.EstadoCuota = 'Atrasada', c.MontoPendiente = 0
+SET c.EstadoCuota = @EstadoAtrasada, c.MontoPendiente = 0
 FROM dbo.CuotasPago c
 INNER JOIN ProximaCuota p ON p.IdCuotaPago = c.IdCuotaPago
 WHERE p.IdSiguiente IS NOT NULL;
@@ -1158,6 +1158,9 @@ SELECT @@ROWCOUNT;";
         using var connection = _connectionFactory.CreateConnection();
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@FechaCorte", fechaCorte.Date);
+        command.Parameters.AddWithValue("@EstadoPendiente", EstadosCuotaPago.Pendiente);
+        command.Parameters.AddWithValue("@EstadoNotificada", EstadosCuotaPago.Notificada);
+        command.Parameters.AddWithValue("@EstadoAtrasada", EstadosCuotaPago.Atrasada);
         command.Parameters.AddWithValue("@EstadoActivo", EstadosPlanPago.Activo);
         await connection.OpenAsync();
         return Convert.ToInt32(await command.ExecuteScalarAsync() ?? 0);

--- a/PSA.DataAccess/DAO/RolPermisoDAO.cs
+++ b/PSA.DataAccess/DAO/RolPermisoDAO.cs
@@ -306,6 +306,40 @@ WHERE schema_id = SCHEMA_ID('dbo')
         };
     }
 
+    public async Task<List<string>> ObtenerCodigosPermisoPorRolAsync(int idRol)
+    {
+        if (idRol <= 0)
+        {
+            return new List<string>();
+        }
+
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        var tablaRolPermisos = await ObtenerTablaRolPermisosAsync(connection);
+        var sql = $@"
+SELECT DISTINCT p.Codigo
+FROM {tablaRolPermisos} rp
+INNER JOIN dbo.Permisos p ON p.IdPermiso = rp.IdPermiso
+WHERE rp.IdRol = @IdRol
+ORDER BY p.Codigo;";
+
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdRol", idRol);
+        using var reader = await command.ExecuteReaderAsync();
+        var codigos = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            var codigo = reader["Codigo"]?.ToString();
+            if (!string.IsNullOrWhiteSpace(codigo))
+            {
+                codigos.Add(codigo);
+            }
+        }
+
+        return codigos;
+    }
+
     private static string ObtenerExpresionActivo(
         string aliasTabla,
         (bool Exists, string? SqlType) metadataEstado,

--- a/PSA.EntidadesDTO/DTOs/Fincas/RenovacionAnualDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Fincas/RenovacionAnualDTO.cs
@@ -1,0 +1,10 @@
+namespace PSA.EntidadesDTO.DTOs.Fincas;
+
+public class EstadoRenovacionAnualDTO
+{
+    public bool PuedeRenovar { get; set; }
+    public string Motivo { get; set; } = string.Empty;
+    public string? EstadoPlanActual { get; set; }
+    public int CuotasRestantes { get; set; }
+    public bool ExisteEvaluacionPendienteActiva { get; set; }
+}

--- a/PSA.EntidadesDTO/DTOs/Pagos/PlanPagoDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Pagos/PlanPagoDTO.cs
@@ -15,6 +15,7 @@
         public const string Pendiente = "Pendiente";
         public const string Ejecutada = "Ejecutada";
         public const string Notificada = "Notificada";
+        public const string Atrasada = "Atrasada";
     }
 
     public class PlanPagoDTO

--- a/PSA.EntidadesDTO/DTOs/RespuestaInicioSesionDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/RespuestaInicioSesionDTO.cs
@@ -12,6 +12,10 @@ namespace PSA.EntidadesDTO.DTOs
 
         public DateTime? UltimoAcceso { get; set; }
 
+        public string TokenAcceso { get; set; } = string.Empty;
+
+        public List<string> Permisos { get; set; } = new();
+
         public string Mensaje { get; set; } = string.Empty;
     }
 }

--- a/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
+++ b/PSA.EntidadesDTO/PSA.EntidadesDTO.csproj
@@ -23,6 +23,7 @@
     <Compile Include="DTOs\FincaResumenDTO.cs" />
     <Compile Include="DTOs\Fincas\FincaDTO.cs" />
     <Compile Include="DTOs\Fincas\FincaEvidenciaDTO.cs" />
+    <Compile Include="DTOs\Fincas\RenovacionAnualDTO.cs" />
     <Compile Include="DTOs\InicioSesionDTO.cs" />
     <Compile Include="DTOs\Landing\LandingContenidoDTO.cs" />
     <Compile Include="DTOs\Notificaciones\NotificacionDTO.cs" />

--- a/PSA.WebAPI/Controllers/AdministracionController.cs
+++ b/PSA.WebAPI/Controllers/AdministracionController.cs
@@ -20,6 +20,7 @@ namespace PSA.WebAPI.Controllers
         }
 
         [HttpGet("usuarios")]
+        [Authorize(Policy = Services.Security.AppPermissions.AdminUsuariosVer)]
         public async Task<ActionResult<List<UsuarioAdminListadoDTO>>> ObtenerUsuarios()
         {
             var usuarios = await _administracionManager.ObtenerUsuariosAsync();
@@ -34,6 +35,7 @@ namespace PSA.WebAPI.Controllers
         }
 
         [HttpPost("usuarios")]
+        [Authorize(Policy = Services.Security.AppPermissions.AdminUsuariosCrear)]
         public async Task<ActionResult<bool>> CrearUsuario([FromBody] UsuarioAdminEdicionDTO model)
         {
             await _administracionManager.CrearUsuarioAsync(model, this.GetUserId(), HttpContext.Connection.RemoteIpAddress?.ToString());
@@ -41,6 +43,7 @@ namespace PSA.WebAPI.Controllers
         }
 
         [HttpPut("usuarios/{id:int}")]
+        [Authorize(Policy = Services.Security.AppPermissions.AdminUsuariosEditar)]
         public async Task<ActionResult<bool>> ActualizarUsuario(int id, [FromBody] UsuarioAdminEdicionDTO model)
         {
             model.IdUsuario = id;
@@ -49,6 +52,7 @@ namespace PSA.WebAPI.Controllers
         }
 
         [HttpDelete("usuarios/{id:int}")]
+        [Authorize(Policy = Services.Security.AppPermissions.AdminUsuariosEliminar)]
         public async Task<ActionResult<bool>> EliminarUsuario(int id)
         {
             await _administracionManager.EliminarUsuarioAsync(id, this.GetUserId(), HttpContext.Connection.RemoteIpAddress?.ToString());
@@ -176,6 +180,7 @@ namespace PSA.WebAPI.Controllers
         }
 
         [HttpPost("configuracion-pago")]
+        [Authorize(Policy = Services.Security.AppPermissions.AdminPagosConfigurar)]
         public async Task<ActionResult<bool>> CrearConfiguracionPago([FromBody] ConfiguracionPagoAdminDTO model)
         {
             await _administracionManager.CrearConfiguracionPagoAsync(model, this.GetUserId(), HttpContext.Connection.RemoteIpAddress?.ToString());
@@ -201,6 +206,7 @@ namespace PSA.WebAPI.Controllers
 
         [HttpPost("cuentas-bancarias/validar")]
         [HttpPost("cuentas-bancarias/validacion")]
+        [Authorize(Policy = Services.Security.AppPermissions.AdminCuentasValidar)]
         public async Task<ActionResult<bool>> ValidarCuentaBancaria([FromBody] ValidarCuentaBancariaRequestDTO request)
         {
             try
@@ -226,6 +232,7 @@ namespace PSA.WebAPI.Controllers
         }
 
         [HttpGet("auditoria")]
+        [Authorize(Policy = Services.Security.AppPermissions.AdminAuditoriaConsultar)]
         public async Task<ActionResult<List<AuditoriaEventoDTO>>> ObtenerAuditoria([FromQuery] string? modulo, [FromQuery] string? accion, [FromQuery] DateTime? fechaDesde, [FromQuery] DateTime? fechaHasta, [FromQuery] int maximoRegistros = 50)
         {
             var eventos = await _administracionManager.ObtenerEventosAuditoriaAsync(new AuditoriaFiltroDTO

--- a/PSA.WebAPI/Controllers/AutenticacionController.cs
+++ b/PSA.WebAPI/Controllers/AutenticacionController.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PSA.AppCore.Managers;
+using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
 using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
 using PSA.EntidadesDTO.DTOs.Usuarios;
 using PSA.WebAPI.Services;
+using PSA.WebAPI.Services.Security;
 
 namespace PSA.WebAPI.Controllers
 {
@@ -14,13 +16,19 @@ namespace PSA.WebAPI.Controllers
     {
         private readonly AutenticacionManager _autenticacionManager;
         private readonly IConfiguration _configuration;
+        private readonly RolPermisoDAO _rolPermisoDao;
+        private readonly IJwtTokenService _jwtTokenService;
 
         public AutenticacionController(
             AutenticacionManager autenticacionManager,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            RolPermisoDAO rolPermisoDao,
+            IJwtTokenService jwtTokenService)
         {
             _autenticacionManager = autenticacionManager;
             _configuration = configuration;
+            _rolPermisoDao = rolPermisoDao;
+            _jwtTokenService = jwtTokenService;
         }
 
         [AllowAnonymous]
@@ -54,6 +62,14 @@ namespace PSA.WebAPI.Controllers
             try
             {
                 var respuesta = await _autenticacionManager.IniciarSesionAsync(dto);
+                var permisos = await _rolPermisoDao.ObtenerCodigosPermisoPorRolAsync(respuesta.IdRol);
+                respuesta.Permisos = permisos;
+                respuesta.TokenAcceso = _jwtTokenService.CreateToken(
+                    respuesta.IdUsuario,
+                    respuesta.IdRol,
+                    respuesta.Email,
+                    respuesta.NombreCompleto,
+                    permisos);
                 return Ok(respuesta);
             }
             catch (Exception ex)

--- a/PSA.WebAPI/Controllers/FincasController.cs
+++ b/PSA.WebAPI/Controllers/FincasController.cs
@@ -29,6 +29,21 @@ namespace PSA.WebAPI.Controllers
             return detalle == null ? NotFound(new { Mensaje = "No se encontró la finca solicitada." }) : Ok(detalle);
         }
 
+        [HttpGet("{idFinca:int}/renovacion-anual/estado")]
+        [Authorize(Roles = "2")]
+        [Authorize(Policy = Services.Security.AppPermissions.PropietarioRenovarFinca)]
+        public async Task<IActionResult> ObtenerEstadoRenovacionAnual([FromRoute] int idFinca)
+        {
+            try
+            {
+                return Ok(await _fincaManager.ObtenerEstadoRenovacionAnualAsync(idFinca, this.GetUserId()));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
+            }
+        }
+
         [HttpPost]
         [Authorize(Roles = "2")]
         public async Task<IActionResult> RegistrarFinca([FromBody] PSA.EntidadesDTO.DTOs.RegistrarFincaDTO dto)
@@ -41,10 +56,18 @@ namespace PSA.WebAPI.Controllers
 
         [HttpPost("{idFinca:int}/renovacion-anual")]
         [Authorize(Roles = "2")]
+        [Authorize(Policy = Services.Security.AppPermissions.PropietarioRenovarFinca)]
         public async Task<IActionResult> RenovacionAnual([FromRoute] int idFinca)
         {
-            var idEvaluacion = await _fincaManager.GenerarRenovacionAnualAsync(idFinca, this.GetUserId(), HttpContext.Connection.RemoteIpAddress?.ToString());
-            return Ok(new { IdEvaluacion = idEvaluacion, Mensaje = "Se generó la renovación anual y quedó en cola de pendientes." });
+            try
+            {
+                var idEvaluacion = await _fincaManager.GenerarRenovacionAnualAsync(idFinca, this.GetUserId(), HttpContext.Connection.RemoteIpAddress?.ToString());
+                return Ok(new { IdEvaluacion = idEvaluacion, Mensaje = "Se generó la renovación anual y quedó en cola de pendientes." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { Mensaje = ex.Message });
+            }
         }
     }
 }

--- a/PSA.WebAPI/Controllers/PagosController.cs
+++ b/PSA.WebAPI/Controllers/PagosController.cs
@@ -89,6 +89,7 @@ public class PagosController(PagosManager pagosManager) : ControllerBase
 
     [HttpPost("admin/arrastrar-saldos")]
     [Authorize(Roles = "1")]
+    [Authorize(Policy = Services.Security.AppPermissions.AdminPagosConfigurar)]
     public async Task<IActionResult> ArrastrarSaldosPendientes()
     {
         var total = await _pagosManager.ArrastrarSaldosPendientesAsync(this.GetUserId(), HttpContext.Connection.RemoteIpAddress?.ToString());
@@ -97,6 +98,7 @@ public class PagosController(PagosManager pagosManager) : ControllerBase
 
     [HttpPut("ingeniero/planes/{idPlanPago:int}/aprobar-final")]
     [Authorize(Roles = "3")]
+    [Authorize(Policy = Services.Security.AppPermissions.IngenieroAprobarPlan)]
     public async Task<IActionResult> AprobarPlanFinal([FromRoute] int idPlanPago, [FromBody] AprobarPlanPagoFinalDTO model)
     {
         model.IdIngeniero = this.GetUserId();

--- a/PSA.WebAPI/Controllers/ReportesController.cs
+++ b/PSA.WebAPI/Controllers/ReportesController.cs
@@ -40,12 +40,14 @@ public class ReportesController : ControllerBase
     }
 
     [HttpGet("administrador/pagos-ubicacion")]
+    [Authorize(Policy = Services.Security.AppPermissions.AdminReportes)]
     public async Task<IActionResult> ObtenerPagosPorUbicacion([FromQuery] int? anio = null, [FromQuery] int? mes = null)
     {
         return await EjecutarSeguro(async () => await _reportesManager.ObtenerPagosPorUbicacionAsync(new FiltroReporteDTO { Anio = anio, Mes = mes }));
     }
 
     [HttpGet("administrador/resumen-actividad")]
+    [Authorize(Policy = Services.Security.AppPermissions.AdminReportes)]
     public async Task<IActionResult> ObtenerResumenActividad()
     {
         return await EjecutarSeguro(async () => await _reportesManager.ObtenerResumenActividadAsync());
@@ -71,30 +73,35 @@ public class ReportesController : ControllerBase
     }
 
     [HttpGet("administrador/usuarios-roles")]
+    [Authorize(Policy = Services.Security.AppPermissions.AdminReportes)]
     public async Task<IActionResult> ObtenerUsuariosRoles()
     {
         return await EjecutarSeguro(async () => await _reportesManager.ObtenerReporteUsuariosRolesAsync());
     }
 
     [HttpGet("administrador/fincas-estado")]
+    [Authorize(Policy = Services.Security.AppPermissions.AdminReportes)]
     public async Task<IActionResult> ObtenerFincasPorEstado()
     {
         return await EjecutarSeguro(async () => await _reportesManager.ObtenerReporteFincasPorEstadoAsync());
     }
 
     [HttpGet("administrador/evaluaciones-tecnicas")]
+    [Authorize(Policy = Services.Security.AppPermissions.AdminReportes)]
     public async Task<IActionResult> ObtenerEvaluacionesTecnicasAdmin([FromQuery] int? anio = null, [FromQuery] int? mes = null)
     {
         return await EjecutarSeguro(async () => await _reportesManager.ObtenerReporteEvaluacionesAdminAsync(new FiltroReporteDTO { Anio = anio, Mes = mes }));
     }
 
     [HttpGet("administrador/pagos")]
+    [Authorize(Policy = Services.Security.AppPermissions.AdminReportes)]
     public async Task<IActionResult> ObtenerPagosAdmin([FromQuery] int? anio = null)
     {
         return await EjecutarSeguro(async () => await _reportesManager.ObtenerReportePagosAdminAsync(anio));
     }
 
     [HttpGet("administrador/auditoria-critica")]
+    [Authorize(Policy = Services.Security.AppPermissions.AdminAuditoriaConsultar)]
     public async Task<IActionResult> ObtenerAuditoriaCritica([FromQuery] int top = 50)
     {
         return await EjecutarSeguro(async () => await _reportesManager.ObtenerAuditoriaCriticaAsync(top));

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -30,12 +30,15 @@
     <Compile Include="CorreoService.cs" />
     <Compile Include="Services\SmtpNotificationEmailSender.cs" />
     <Compile Include="Services\PasswordRecoveryServices.cs" />
+    <Compile Include="Services\Security\JwtTokenService.cs" />
+    <Compile Include="Services\Security\PermissionAuthorization.cs" />
     <Compile Include="Extensions\ControllerUserExtensions.cs" />
     <Compile Include="Services\Security\HeaderAuthenticationHandler.cs" />
     <ProjectReference Include="..\PSA.AppCore\PSA.AppCore.csproj" />
     <ProjectReference Include="..\PSA.DataAccess\PSA.DataAccess.csproj" />
     <ProjectReference Include="..\PSA.EntidadesDTO\PSA.EntidadesDTO.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -9,7 +9,11 @@ using PSA.DataAccess.DAO;
 using PSA.WebAPI.Controllers.Middleware;
 using PSA.WebAPI.Services;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
 using PSA.WebAPI.Services.Security;
+using System.Text;
 
 SanitizarAppSettingsSiEsNecesario();
 
@@ -34,12 +38,39 @@ builder.Services.AddScoped<IPasswordPolicy, PasswordPolicy>();
 
 builder.Services.AddAuthentication(options =>
 {
-    options.DefaultAuthenticateScheme = HeaderAuthenticationHandler.SchemeName;
-    options.DefaultChallengeScheme = HeaderAuthenticationHandler.SchemeName;
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
 })
-.AddScheme<AuthenticationSchemeOptions, HeaderAuthenticationHandler>(HeaderAuthenticationHandler.SchemeName, _ => { });
+.AddJwtBearer(options =>
+{
+    var jwtKey = builder.Configuration["Jwt:Key"] ?? string.Empty;
+    var keyBytes = Encoding.UTF8.GetBytes(jwtKey);
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(keyBytes),
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"] ?? "PSA.WebAPI",
+        ValidAudience = builder.Configuration["Jwt:Audience"] ?? "PSA.WebApp",
+        ValidateLifetime = true,
+        ClockSkew = TimeSpan.FromMinutes(2)
+    };
+});
 
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy(AppPermissions.AdminUsuariosVer, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.AdminUsuariosVer)));
+    options.AddPolicy(AppPermissions.AdminUsuariosCrear, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.AdminUsuariosCrear)));
+    options.AddPolicy(AppPermissions.AdminUsuariosEditar, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.AdminUsuariosEditar)));
+    options.AddPolicy(AppPermissions.AdminUsuariosEliminar, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.AdminUsuariosEliminar)));
+    options.AddPolicy(AppPermissions.AdminPagosConfigurar, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.AdminPagosConfigurar)));
+    options.AddPolicy(AppPermissions.AdminCuentasValidar, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.AdminCuentasValidar)));
+    options.AddPolicy(AppPermissions.AdminAuditoriaConsultar, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.AdminAuditoriaConsultar)));
+    options.AddPolicy(AppPermissions.AdminReportes, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.AdminReportes)));
+    options.AddPolicy(AppPermissions.IngenieroAprobarPlan, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.IngenieroAprobarPlan)));
+    options.AddPolicy(AppPermissions.PropietarioRenovarFinca, p => p.Requirements.Add(new PermissionRequirement(AppPermissions.PropietarioRenovarFinca)));
+});
 
 
 
@@ -95,6 +126,8 @@ builder.Services.AddScoped<LandingManager>();
 builder.Services.AddScoped<NotificacionesManager>();
 builder.Services.AddScoped<INotificationEmailSender, SmtpNotificationEmailSender>();
 builder.Services.AddScoped<INotificationDispatcher, NotificationDispatcher>();
+builder.Services.AddScoped<IJwtTokenService, JwtTokenService>();
+builder.Services.AddSingleton<IAuthorizationHandler, PermissionAuthorizationHandler>();
 
 var app = builder.Build();
 

--- a/PSA.WebAPI/Services/Security/JwtTokenService.cs
+++ b/PSA.WebAPI/Services/Security/JwtTokenService.cs
@@ -1,0 +1,59 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace PSA.WebAPI.Services.Security;
+
+public interface IJwtTokenService
+{
+    string CreateToken(int idUsuario, int idRol, string email, string nombreCompleto, IReadOnlyCollection<string> permisos);
+}
+
+public class JwtTokenService(IConfiguration configuration) : IJwtTokenService
+{
+    private readonly IConfiguration _configuration = configuration;
+
+    public string CreateToken(int idUsuario, int idRol, string email, string nombreCompleto, IReadOnlyCollection<string> permisos)
+    {
+        var issuer = _configuration["Jwt:Issuer"] ?? "PSA.WebAPI";
+        var audience = _configuration["Jwt:Audience"] ?? "PSA.WebApp";
+        var key = _configuration["Jwt:Key"];
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new InvalidOperationException("Debe configurar Jwt:Key para emitir tokens.");
+        }
+
+        var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+        var credentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
+        var now = DateTime.UtcNow;
+        var expiresMinutes = int.TryParse(_configuration["Jwt:ExpiryMinutes"], out var configured)
+            ? Math.Clamp(configured, 30, 1440)
+            : 480;
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, idUsuario.ToString()),
+            new(ClaimTypes.NameIdentifier, idUsuario.ToString()),
+            new(ClaimTypes.Role, idRol.ToString()),
+            new(ClaimTypes.Email, email),
+            new(ClaimTypes.Name, nombreCompleto)
+        };
+
+        foreach (var permiso in permisos.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            claims.Add(new Claim("perm", permiso.Trim()));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: issuer,
+            audience: audience,
+            claims: claims,
+            notBefore: now,
+            expires: now.AddMinutes(expiresMinutes),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/PSA.WebAPI/Services/Security/PermissionAuthorization.cs
+++ b/PSA.WebAPI/Services/Security/PermissionAuthorization.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace PSA.WebAPI.Services.Security;
+
+public static class AppPermissions
+{
+    public const string AdminUsuariosVer = "ADMIN_USUARIOS_VER";
+    public const string AdminUsuariosCrear = "ADMIN_USUARIOS_CREAR";
+    public const string AdminUsuariosEditar = "ADMIN_USUARIOS_EDITAR";
+    public const string AdminUsuariosEliminar = "ADMIN_USUARIOS_ELIMINAR";
+    public const string AdminPagosConfigurar = "ADMIN_PAGOS_CONFIGURAR";
+    public const string AdminCuentasValidar = "ADMIN_CUENTAS_VALIDAR";
+    public const string AdminAuditoriaConsultar = "ADMIN_AUDITORIA_CONSULTAR";
+    public const string AdminReportes = "ADMIN_REPORTES_CONSULTAR";
+    public const string IngenieroAprobarPlan = "ING_PLAN_APROBAR";
+    public const string PropietarioRenovarFinca = "DUENO_FINCAS_RENOVAR";
+}
+
+public sealed class PermissionRequirement(string permission) : IAuthorizationRequirement
+{
+    public string Permission { get; } = permission;
+}
+
+public sealed class PermissionAuthorizationHandler : AuthorizationHandler<PermissionRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
+    {
+        var granted = context.User.Claims
+            .Where(c => c.Type == "perm")
+            .Any(c => string.Equals(c.Value, requirement.Permission, StringComparison.OrdinalIgnoreCase));
+
+        if (granted)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/PSA.WebAPI/appsettings.Development.json
+++ b/PSA.WebAPI/appsettings.Development.json
@@ -13,5 +13,11 @@
     "FromEmail": "",
     "Username": "",
     "Password": ""
+  },
+  "Jwt": {
+    "Issuer": "PSA.WebAPI",
+    "Audience": "PSA.WebApp",
+    "Key": "PSA-CostaRica-2026-Token-Signing-Key-Change-This",
+    "ExpiryMinutes": 480
   }
 }

--- a/PSA.WebAPI/appsettings.json
+++ b/PSA.WebAPI/appsettings.json
@@ -14,6 +14,12 @@
     "Username": "",
     "Password": ""
   },
+  "Jwt": {
+    "Issuer": "PSA.WebAPI",
+    "Audience": "PSA.WebApp",
+    "Key": "PSA-CostaRica-2026-Token-Signing-Key-Change-This",
+    "ExpiryMinutes": 480
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/PSA.WebApp/Controllers/AutenticacionController.cs
+++ b/PSA.WebApp/Controllers/AutenticacionController.cs
@@ -144,8 +144,13 @@ namespace PSA.WebApp.Controllers
                 new(ClaimTypes.NameIdentifier, respuesta.IdUsuario.ToString()),
                 new(ClaimTypes.Name, respuesta.NombreCompleto),
                 new(ClaimTypes.Email, respuesta.Email),
-                new(ClaimTypes.Role, respuesta.IdRol.ToString())
+                new(ClaimTypes.Role, respuesta.IdRol.ToString()),
+                new("psa_api_token", respuesta.TokenAcceso ?? string.Empty)
             };
+            foreach (var permiso in respuesta.Permisos.Where(x => !string.IsNullOrWhiteSpace(x)))
+            {
+                claims.Add(new Claim("perm", permiso));
+            }
             await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme)));
         }
 

--- a/PSA.WebApp/Controllers/FincasController.cs
+++ b/PSA.WebApp/Controllers/FincasController.cs
@@ -136,6 +136,17 @@ namespace PSA.WebApp.Controllers
             }
             ViewBag.Evidencias = evidencias;
 
+            EstadoRenovacionAnualDTO? estadoRenovacion = null;
+            try
+            {
+                estadoRenovacion = await client.GetFromJsonAsync<EstadoRenovacionAnualDTO>($"api/Fincas/{id}/renovacion-anual/estado");
+            }
+            catch
+            {
+                // No bloquea render; si falla, UI mantiene fallback conservador.
+            }
+            ViewBag.EstadoRenovacion = estadoRenovacion;
+
             return View(detalle);
         }
 
@@ -146,9 +157,25 @@ namespace PSA.WebApp.Controllers
         {
             var client = _httpClientFactory.CreateClient("AuthApi");
             var response = await client.PostAsync($"api/Fincas/{idFinca}/renovacion-anual", null);
+            var body = await response.Content.ReadAsStringAsync();
+            string? mensajeApi = null;
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(body);
+                    if (doc.RootElement.TryGetProperty("mensaje", out var m1)) mensajeApi = m1.GetString();
+                    if (string.IsNullOrWhiteSpace(mensajeApi) && doc.RootElement.TryGetProperty("Mensaje", out var m2)) mensajeApi = m2.GetString();
+                }
+                catch
+                {
+                    // Ignorado: fallback a mensaje estándar.
+                }
+            }
+
             TempData[response.IsSuccessStatusCode ? "MensajeExito" : "MensajeError"] = response.IsSuccessStatusCode
-                ? "Renovación anual solicitada correctamente."
-                : "No fue posible solicitar la renovación anual.";
+                ? (mensajeApi ?? "Renovación anual solicitada correctamente.")
+                : (mensajeApi ?? "No fue posible solicitar la renovación anual.");
             return RedirectToAction(nameof(DetalleFinca), new { id = idFinca });
         }
 

--- a/PSA.WebApp/Services/Security/ApiUserHeadersHandler.cs
+++ b/PSA.WebApp/Services/Security/ApiUserHeadersHandler.cs
@@ -4,8 +4,7 @@ namespace PSA.WebApp.Services.Security;
 
 public class ApiUserHeadersHandler : DelegatingHandler
 {
-    private const string HeaderUserId = "X-PSA-UserId";
-    private const string HeaderRole = "X-PSA-Role";
+    private const string ClaimApiToken = "psa_api_token";
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     public ApiUserHeadersHandler(IHttpContextAccessor httpContextAccessor)
@@ -18,19 +17,10 @@ public class ApiUserHeadersHandler : DelegatingHandler
         var user = _httpContextAccessor.HttpContext?.User;
         if (user?.Identity?.IsAuthenticated == true)
         {
-            var id = user.FindFirstValue(ClaimTypes.NameIdentifier);
-            var role = user.FindFirstValue(ClaimTypes.Role);
-
-            if (!string.IsNullOrWhiteSpace(id))
+            var token = user.FindFirst(ClaimApiToken)?.Value;
+            if (!string.IsNullOrWhiteSpace(token))
             {
-                request.Headers.Remove(HeaderUserId);
-                request.Headers.TryAddWithoutValidation(HeaderUserId, id);
-            }
-
-            if (!string.IsNullOrWhiteSpace(role))
-            {
-                request.Headers.Remove(HeaderRole);
-                request.Headers.TryAddWithoutValidation(HeaderRole, role);
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
         }
 

--- a/PSA.WebApp/Views/Fincas/DetalleFinca.cshtml
+++ b/PSA.WebApp/Views/Fincas/DetalleFinca.cshtml
@@ -7,6 +7,9 @@
     var latitudData = Model.Latitud.ToString(System.Globalization.CultureInfo.InvariantCulture);
     var longitudData = Model.Longitud.ToString(System.Globalization.CultureInfo.InvariantCulture);
     var evidencias = ViewBag.Evidencias as List<PSA.EntidadesDTO.DTOs.Fincas.FincaEvidenciaDTO> ?? new List<PSA.EntidadesDTO.DTOs.Fincas.FincaEvidenciaDTO>();
+    var estadoRenovacion = ViewBag.EstadoRenovacion as PSA.EntidadesDTO.DTOs.Fincas.EstadoRenovacionAnualDTO;
+    var puedeSolicitarRenovacion = estadoRenovacion?.PuedeRenovar ?? false;
+    var motivoRenovacion = estadoRenovacion?.Motivo ?? "La renovación anual está temporalmente no disponible para esta finca.";
 }
 
 <section class="seccion-pagina propietario-detalle-finca">
@@ -114,12 +117,18 @@
         </section>
 
         <div class="fila-acciones-formulario">
-
-            <form asp-controller="Fincas" asp-action="RenovacionAnual" method="post" class="d-inline">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="idFinca" value="@Model.IdFinca" />
-                <button type="submit" class="boton-primario">Solicitar renovación anual</button>
-            </form>
+            @if (puedeSolicitarRenovacion)
+            {
+                <form asp-controller="Fincas" asp-action="RenovacionAnual" method="post" class="d-inline">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="idFinca" value="@Model.IdFinca" />
+                    <button type="submit" class="boton-primario">Solicitar renovación anual</button>
+                </form>
+            }
+            else
+            {
+                <div class="texto-ayuda">@motivoRenovacion</div>
+            }
             <a class="boton-secundario" asp-controller="Fincas" asp-action="MisFincas">Volver</a>
         </div>
     </section>

--- a/PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml
+++ b/PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml
@@ -11,7 +11,7 @@
             <p>Registre cuentas para habilitar pagos y consulte su estado de validación.</p>
         </div>
         <div class="d-flex gap-2">
-            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalNuevaCuenta">Nueva Cuenta Bancaria</button>
+            <button type="button" class="boton-primario" data-bs-toggle="modal" data-bs-target="#modalNuevaCuenta">Nueva cuenta bancaria</button>
             <a class="boton-secundario" asp-controller="Pagos" asp-action="PlanesDueno">Ver planes</a>
         </div>
     </div>
@@ -52,28 +52,28 @@
     </section>
 </section>
 
-<div class="modal fade" id="modalNuevaCuenta" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
+<div class="modal fade" id="modalNuevaCuenta" tabindex="-1" aria-labelledby="modalNuevaCuentaTitulo" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content modal-sistema">
             <form asp-action="RegistrarCuentaBancaria" method="post">
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="IdUsuario" value="@cuentaNueva.IdUsuario" />
                 <div class="modal-header">
-                    <h5 class="modal-title">Nueva cuenta bancaria</h5>
+                    <h5 class="modal-title" id="modalNuevaCuentaTitulo">Nueva cuenta bancaria</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
                 </div>
                 <div class="modal-body">
-                    <div class="mb-3">
+                    <div class="campo-formulario mb-3">
                         <label class="form-label">Banco</label>
-                        <input class="form-control" name="Banco" required />
+                        <input name="Banco" required />
                     </div>
-                    <div class="mb-3">
+                    <div class="campo-formulario mb-3">
                         <label class="form-label">Número de cuenta</label>
-                        <input class="form-control" name="NumeroCuenta" required />
+                        <input name="NumeroCuenta" required />
                     </div>
-                    <div class="mb-3">
+                    <div class="campo-formulario mb-3">
                         <label class="form-label">Tipo de cuenta</label>
-                        <select class="form-select" name="TipoCuenta" required>
+                        <select name="TipoCuenta" required>
                             <option value="">Seleccione un tipo</option>
                             <option value="Ahorro">Ahorro</option>
                             <option value="Corriente">Corriente</option>
@@ -82,14 +82,14 @@
                             <option value="Otra">Otra</option>
                         </select>
                     </div>
-                    <div class="mb-3">
+                    <div class="campo-formulario mb-3">
                         <label class="form-label">Titular</label>
-                        <input class="form-control" name="Titular" required />
+                        <input name="Titular" required />
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="boton-secundario" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-primary">Registrar cuenta</button>
+                    <button type="submit" class="boton-primario">Registrar cuenta</button>
                 </div>
             </form>
         </div>

--- a/PSA.WebApp/Views/Shared/_Layout.cshtml
+++ b/PSA.WebApp/Views/Shared/_Layout.cshtml
@@ -4,7 +4,7 @@
     var usuarioAutenticado = User?.Identity?.IsAuthenticated ?? false;
 }
 <!DOCTYPE html>
-<html lang="es" data-tema="claro">
+<html lang="es" data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/PSA.WebApp/Views/Shared/_LayoutAutenticacion.cshtml
+++ b/PSA.WebApp/Views/Shared/_LayoutAutenticacion.cshtml
@@ -2,7 +2,7 @@
     var titulo = ViewBag.TituloPagina as string ?? ViewData["Title"]?.ToString() ?? "PSA Costa Rica";
 }
 <!DOCTYPE html>
-<html lang="es" data-tema="claro">
+<html lang="es" data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/PSA.WebApp/wwwroot/css/componentes.css
+++ b/PSA.WebApp/wwwroot/css/componentes.css
@@ -230,6 +230,32 @@
     border-left-color: var(--color-error);
 }
 
+.modal-sistema {
+    background: var(--color-superficie);
+    color: var(--color-texto-principal);
+    border: 1px solid var(--color-borde-suave);
+    border-radius: var(--radio-lg);
+    box-shadow: var(--sombra-md);
+}
+
+.modal-sistema .modal-header,
+.modal-sistema .modal-footer {
+    border-color: var(--color-borde-suave);
+}
+
+.modal-sistema .modal-title {
+    color: var(--color-texto-principal);
+    font-weight: 700;
+}
+
+.modal-sistema .btn-close {
+    filter: var(--icono-cerrar-filtro, none);
+}
+
+html[data-theme="dark"] .modal-sistema .btn-close {
+    --icono-cerrar-filtro: invert(1) grayscale(100%);
+}
+
 .migas-pan {
     display: flex;
     align-items: center;

--- a/PSA.WebApp/wwwroot/css/global.css
+++ b/PSA.WebApp/wwwroot/css/global.css
@@ -200,27 +200,27 @@ main {
     font-weight: var(--peso-seminegrita, 600);
 }
 
-html[data-tema="oscuro"] .notificacion-item {
+html[data-theme="dark"] .notificacion-item {
     background: color-mix(in srgb, var(--color-superficie-secundaria) 84%, #000 16%);
 }
 
-html[data-tema="oscuro"] .notificacion-item--success {
+html[data-theme="dark"] .notificacion-item--success {
     background: color-mix(in srgb, var(--color-exito) 16%, var(--color-superficie) 84%);
 }
 
-html[data-tema="oscuro"] .notificacion-item--warning {
+html[data-theme="dark"] .notificacion-item--warning {
     background: color-mix(in srgb, var(--color-advertencia) 18%, var(--color-superficie) 82%);
 }
 
-html[data-tema="oscuro"] .notificacion-item--error {
+html[data-theme="dark"] .notificacion-item--error {
     background: color-mix(in srgb, var(--color-error) 18%, var(--color-superficie) 82%);
 }
 
-html[data-tema="oscuro"] .notificacion-item--info {
+html[data-theme="dark"] .notificacion-item--info {
     background: color-mix(in srgb, var(--color-info) 16%, var(--color-superficie) 84%);
 }
 
-html[data-tema="oscuro"] .notificacion-fecha {
+html[data-theme="dark"] .notificacion-fecha {
     color: #7CF7A1;
 }
 

--- a/PSA.WebApp/wwwroot/css/variables.css
+++ b/PSA.WebApp/wwwroot/css/variables.css
@@ -54,7 +54,7 @@
     --disabled-text: color-mix(in srgb, var(--color-texto-secundario) 70%, #ffffff 30%);
 }
 
-html[data-tema="oscuro"] {
+html[data-theme="dark"] {
     --color-fondo: #07140B;
     --color-superficie: #173624;
     --color-superficie-secundaria: #1B412B;

--- a/PSA.WebApp/wwwroot/js/navegacion.js
+++ b/PSA.WebApp/wwwroot/js/navegacion.js
@@ -6,16 +6,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (botonTema) {
         botonTema.addEventListener("click", function () {
-            var temaActual = raizHtml.getAttribute("data-tema") || "claro";
-            var nuevoTema = temaActual === "claro" ? "oscuro" : "claro";
-            raizHtml.setAttribute("data-tema", nuevoTema);
+            var temaActual = raizHtml.getAttribute("data-theme") || "light";
+            var nuevoTema = temaActual === "light" ? "dark" : "light";
+            raizHtml.setAttribute("data-theme", nuevoTema);
             localStorage.setItem("psa-tema", nuevoTema);
         });
     }
 
     var temaGuardado = localStorage.getItem("psa-tema");
     if (temaGuardado) {
-        raizHtml.setAttribute("data-tema", temaGuardado);
+        raizHtml.setAttribute("data-theme", temaGuardado);
     }
 
     if (botonMenuLateral && barraLateral) {

--- a/PSA.WebApp/wwwroot/js/registro-finca.js
+++ b/PSA.WebApp/wwwroot/js/registro-finca.js
@@ -28,6 +28,7 @@ document.addEventListener("DOMContentLoaded", function () {
     var mapa = null;
     var marcador = null;
     var limitesCostaRica = null;
+    var centroSanJose = { lat: 9.9281, lng: -84.0907 };
 
     function obtenerMensajeValidacion(campo) {
         var nombreCampo = (campo.labels && campo.labels[0] && campo.labels[0].textContent)
@@ -203,7 +204,7 @@ document.addEventListener("DOMContentLoaded", function () {
             tap: false,
             maxBounds: limitesCostaRica,
             maxBoundsViscosity: 1.0
-        }).setView([9.9325, -84.0796], 12);
+        }).setView([centroSanJose.lat, centroSanJose.lng], 12);
 
         window.L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
             maxZoom: 19,
@@ -235,7 +236,20 @@ document.addEventListener("DOMContentLoaded", function () {
     sincronizarRecursosHidricos();
 
     if (latitudInput && longitudInput && latitudInput.value && longitudInput.value && mapa) {
-        colocarPin(Number(latitudInput.value), Number(longitudInput.value), true);
+        var latInicial = Number(latitudInput.value);
+        var lngInicial = Number(longitudInput.value);
+        var coordsInicialesValidas = Number.isFinite(latInicial)
+            && Number.isFinite(lngInicial)
+            && limitesCostaRica
+            && limitesCostaRica.contains(window.L.latLng(latInicial, lngInicial));
+
+        if (coordsInicialesValidas) {
+            colocarPin(latInicial, lngInicial, true);
+        } else {
+            if (latitudInput) latitudInput.value = "";
+            if (longitudInput) longitudInput.value = "";
+            mapa.setView([centroSanJose.lat, centroSanJose.lng], 12);
+        }
     }
 
     formulario.addEventListener("submit", function (evento) {

--- a/scripts/sql/20260420_segunda_pasada_cobertura.sql
+++ b/scripts/sql/20260420_segunda_pasada_cobertura.sql
@@ -1,0 +1,104 @@
+/*
+Segunda pasada de corrección orientada a cobertura funcional auditada (PSA Costa Rica)
+- Seguridad JWT + permisos funcionales
+- Estados de cuota: habilita Atrasada en BD
+- Estado inicial finca: PendienteEvaluacion
+- No retroactividad: unicidad finca+año en planes
+*/
+
+SET NOCOUNT ON;
+GO
+
+/* 1) Estados de cuota */
+IF EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_CuotasPago_Estado' AND parent_object_id = OBJECT_ID('dbo.CuotasPago'))
+BEGIN
+    ALTER TABLE dbo.CuotasPago DROP CONSTRAINT CK_CuotasPago_Estado;
+END
+GO
+
+ALTER TABLE dbo.CuotasPago
+ADD CONSTRAINT CK_CuotasPago_Estado
+CHECK (EstadoCuota IN ('Pendiente', 'Ejecutada', 'Notificada', 'Atrasada'));
+GO
+
+/* 2) Estado de finca alineado al proceso */
+IF EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_Fincas_Estado' AND parent_object_id = OBJECT_ID('dbo.Fincas'))
+BEGIN
+    ALTER TABLE dbo.Fincas DROP CONSTRAINT CK_Fincas_Estado;
+END
+GO
+
+ALTER TABLE dbo.Fincas
+ADD CONSTRAINT CK_Fincas_Estado
+CHECK (EstadoFinca IN ('Registrada', 'Pendiente', 'PendienteEvaluacion', 'EnRevision', 'En proceso', 'Aprobada', 'Rechazada', 'Suspendida', 'Inactiva'));
+GO
+
+UPDATE dbo.Fincas
+SET EstadoFinca = 'PendienteEvaluacion'
+WHERE EstadoFinca = 'Registrada';
+GO
+
+/* 3) No retroactividad de plan: una finca por año */
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'UX_PlanesPago_IdFinca_Anio'
+      AND object_id = OBJECT_ID('dbo.PlanesPago'))
+BEGIN
+    CREATE UNIQUE INDEX UX_PlanesPago_IdFinca_Anio
+        ON dbo.PlanesPago (IdFinca, Anio);
+END
+GO
+
+/* 4) Permisos funcionales para enforcement runtime */
+IF NOT EXISTS (SELECT 1 FROM dbo.Permisos WHERE Codigo = 'ADMIN_REPORTES_CONSULTAR')
+    INSERT INTO dbo.Permisos (Codigo, Nombre, Descripcion) VALUES ('ADMIN_REPORTES_CONSULTAR', 'Consultar reportes administrativos', 'Permite consultar reportes de administración');
+IF NOT EXISTS (SELECT 1 FROM dbo.Permisos WHERE Codigo = 'ING_PLAN_APROBAR')
+    INSERT INTO dbo.Permisos (Codigo, Nombre, Descripcion) VALUES ('ING_PLAN_APROBAR', 'Aprobar plan técnico', 'Permite aprobación final de planes por ingeniero');
+IF NOT EXISTS (SELECT 1 FROM dbo.Permisos WHERE Codigo = 'DUENO_FINCAS_RENOVAR')
+    INSERT INTO dbo.Permisos (Codigo, Nombre, Descripcion) VALUES ('DUENO_FINCAS_RENOVAR', 'Renovar finca', 'Permite solicitar renovación anual de finca');
+GO
+
+/* Asignaciones base por rol */
+DECLARE @IdRolAdmin INT = (SELECT TOP 1 IdRol FROM dbo.Roles WHERE Nombre = 'Administrador');
+DECLARE @IdRolIng INT = (SELECT TOP 1 IdRol FROM dbo.Roles WHERE Nombre = 'Ingeniero');
+DECLARE @IdRolDueno INT = (SELECT TOP 1 IdRol FROM dbo.Roles WHERE Nombre = 'Propietario');
+DECLARE @TablaRolPermisos SYSNAME = CASE
+    WHEN OBJECT_ID('dbo.RolesPermisos', 'U') IS NOT NULL THEN 'dbo.RolesPermisos'
+    WHEN OBJECT_ID('dbo.RolPermisos', 'U') IS NOT NULL THEN 'dbo.RolPermisos'
+    ELSE NULL
+END;
+
+IF @IdRolAdmin IS NOT NULL AND @TablaRolPermisos IS NOT NULL
+BEGIN
+    DECLARE @SqlAdmin NVARCHAR(MAX) = N'
+    INSERT INTO ' + @TablaRolPermisos + N' (IdRol, IdPermiso)
+    SELECT @IdRol, p.IdPermiso
+    FROM dbo.Permisos p
+    WHERE p.Codigo = @Codigo
+      AND NOT EXISTS (SELECT 1 FROM ' + @TablaRolPermisos + N' rp WHERE rp.IdRol = @IdRol AND rp.IdPermiso = p.IdPermiso);';
+    EXEC sp_executesql @SqlAdmin, N'@IdRol INT, @Codigo NVARCHAR(100)', @IdRolAdmin, N'ADMIN_REPORTES_CONSULTAR';
+END
+
+IF @IdRolIng IS NOT NULL AND @TablaRolPermisos IS NOT NULL
+BEGIN
+    DECLARE @SqlIng NVARCHAR(MAX) = N'
+    INSERT INTO ' + @TablaRolPermisos + N' (IdRol, IdPermiso)
+    SELECT @IdRol, p.IdPermiso
+    FROM dbo.Permisos p
+    WHERE p.Codigo = @Codigo
+      AND NOT EXISTS (SELECT 1 FROM ' + @TablaRolPermisos + N' rp WHERE rp.IdRol = @IdRol AND rp.IdPermiso = p.IdPermiso);';
+    EXEC sp_executesql @SqlIng, N'@IdRol INT, @Codigo NVARCHAR(100)', @IdRolIng, N'ING_PLAN_APROBAR';
+END
+
+IF @IdRolDueno IS NOT NULL AND @TablaRolPermisos IS NOT NULL
+BEGIN
+    DECLARE @SqlDueno NVARCHAR(MAX) = N'
+    INSERT INTO ' + @TablaRolPermisos + N' (IdRol, IdPermiso)
+    SELECT @IdRol, p.IdPermiso
+    FROM dbo.Permisos p
+    WHERE p.Codigo = @Codigo
+      AND NOT EXISTS (SELECT 1 FROM ' + @TablaRolPermisos + N' rp WHERE rp.IdRol = @IdRol AND rp.IdPermiso = p.IdPermiso);';
+    EXEC sp_executesql @SqlDueno, N'@IdRol INT, @Codigo NVARCHAR(100)', @IdRolDueno, N'DUENO_FINCAS_RENOVAR';
+END
+GO


### PR DESCRIPTION
### Motivation

- Introduce JWT-based authentication and attach user permissions to tokens for runtime authorization checks.
- Enforce fine-grained functional permissions for administrative and payment operations instead of relying only on role IDs.
- Provide a safe renewal workflow for annual finca renewal with eligibility checks and audit logging.
- Improve frontend UX for theme handling, renewal feedback and API token propagation.

### Description

- Implemented JWT support: added `JwtTokenService`, `PermissionAuthorization` handler, registration in `Program.cs`, JWT config in `appsettings.*`, and switched authentication to `JwtBearer` with token validation parameters.
- Propagated permission claims: extended `RespuestaInicioSesionDTO` with `Permisos` and `TokenAcceso`, populated permissions during login via `RolPermisoDAO.ObtenerCodigosPermisoPorRolAsync`, and issue token with permissions in `AutenticacionController` using `IJwtTokenService.CreateToken`.
- Authorization policies: defined application permissions in `AppPermissions`, registered policies in `Program.cs`, and applied `Authorize(Policy = ...)` attributes across controllers (`AdministracionController`, `PagosController`, `ReportesController`, `FincasController`) to protect endpoints.
- Finca renewal flow: added `EstadoRenovacionAnualDTO`, new `FincaDAO.ObtenerElegibilidadRenovacionAsync` DB reader, `FincaManager.ObtenerEstadoRenovacionAnualAsync` eligibility logic, validation for administrative location in `RegistrarFincaAsync`, audit logging on generated renewal via `AuditoriaLogDAO`, and wrapped API actions to return `BadRequest` on business validation failures.
- Data access and DB changes: added `RenovacionElegibilidadDbDTO`, parameterized SQL in `PlanPagoDAO.ArrastrarSaldosPendientesAsync` to use constants and avoid inline literals, and added `scripts/sql/20260420_segunda_pasada_cobertura.sql` for DB constraints, indexes and seed permission records.
- Role/permission utilities: added `RolPermisoDAO.ObtenerCodigosPermisoPorRolAsync` to fetch permission codes for token issuance.
- WebApp adjustments: store API JWT in cookie claims (`psa_api_token`) and send as `Authorization: Bearer` header via `ApiUserHeadersHandler`, show renewal state in `DetalleFinca` and conditionally render renewal UI, and surface API messages on renewal requests.
- UI and assets: renamed theme attribute from `data-tema` to `data-theme` and updated JS/CSS accordingly, added modal and form styling improvements, minor view and CSS adjustments, and included resource registrations in project files and package reference for `Microsoft.AspNetCore.Authentication.JwtBearer`.
- Tests: added unit tests in `PaymentCalculationServiceTests` covering negative hectares validation and trimming/percentage fallback behavior.

### Testing

- Built the solution with `dotnet build` successfully after the changes and dependency updates.
- Ran unit tests with `dotnet test`, including the new `PaymentCalculationServiceTests` cases, and all tests passed.
- Verified API controllers compile and authorization policies are resolvable during application startup in development environment with provided `appsettings.Development.json` JWT settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b5680a74832d8e45360ed2c7fbc9)