### PR TITLE
Harden owner renewal action input guards

### DIFF
--- a/PSA.WebApp/Controllers/FincasController.cs
+++ b/PSA.WebApp/Controllers/FincasController.cs
@@ -155,6 +155,14 @@ namespace PSA.WebApp.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> RenovacionAnual(int idFinca)
         {
+            var idPropietario = ObtenerIdUsuarioSesion();
+            if (idPropietario <= 0) return RedirectToAction("IniciarSesion", "Autenticacion");
+            if (idFinca <= 0)
+            {
+                TempData["MensajeError"] = "La finca indicada para renovación no es válida.";
+                return RedirectToAction(nameof(MisFincas));
+            }
+
             var client = _httpClientFactory.CreateClient("AuthApi");
             var response = await client.PostAsync($"api/Fincas/{idFinca}/renovacion-anual", null);
             var body = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
### Motivation
- Endurecer la acción de renovación anual del módulo de propietario para evitar llamadas al API con parámetros o sesiones inválidas y preservar la estabilidad de la rama estable.

### Description
- Se añadió en `PSA.WebApp/Controllers/FincasController.RenovacionAnual` la verificación de sesión de propietario y la validación de `idFinca > 0`, devolviendo `RedirectToAction("IniciarSesion", "Autenticacion")` si no hay sesión y redirigiendo a `MisFincas` con `TempData["MensajeError"]` si `idFinca` es inválido; cambio localizado y reversible (commit `5067616`).

### Testing
- Se verificó el diff y se hizo commit del archivo modificado y se realizó revisión de código local; `dotnet build` no pudo ejecutarse en este entorno porque el CLI `dotnet` no está disponible, por lo que no se completó la compilación automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7138499f4832d8f81a4069ce3e49b)