### PR TITLE
Separar validación de credenciales y preparación de sesión en AutenticacionController

### DIFF
--- a/PSA.WebAPI/Controllers/AutenticacionController.cs
+++ b/PSA.WebAPI/Controllers/AutenticacionController.cs
@@ -61,11 +61,21 @@ namespace PSA.WebAPI.Controllers
                 return ApiError(StatusCodes.Status429TooManyRequests, "rate_limited", $"Demasiados intentos. Intente nuevamente en {Math.Max(1, (int)Math.Ceiling(retryAfter.TotalMinutes))} minuto(s).");
             }
 
+            RespuestaInicioSesionDTO respuesta;
             try
             {
-                var respuesta = await _autenticacionManager.IniciarSesionAsync(dto);
+                respuesta = await _autenticacionManager.IniciarSesionAsync(dto);
                 _securityThrottleService.RegisterSuccess("login", compositeKey);
-                var permisos = await _rolPermisoDao.ObtenerCodigosPermisoPorRolAsync(respuesta.IdRol);
+            }
+            catch (Exception ex)
+            {
+                _securityThrottleService.RegisterFailure("login", compositeKey);
+                return ApiValidationError("Credenciales inválidas.", ex.Message);
+            }
+
+            try
+            {
+                var permisos = await _rolPermisoDao.ObtenerCodigosPermisoPorRolAsync(respuesta.IdRol) ?? [];
                 respuesta.Permisos = permisos;
                 var nombreRol = await _usuarioDao.ObtenerNombreRolPorIdAsync(respuesta.IdRol);
                 respuesta.TokenAcceso = _jwtTokenService.CreateToken(
@@ -79,8 +89,11 @@ namespace PSA.WebAPI.Controllers
             }
             catch (Exception ex)
             {
-                _securityThrottleService.RegisterFailure("login", compositeKey);
-                return ApiValidationError("Credenciales inválidas.", ex.Message);
+                return ApiError(
+                    StatusCodes.Status500InternalServerError,
+                    "login_session_error",
+                    "El usuario fue validado, pero ocurrió un error al preparar la sesión.",
+                    ex.Message);
             }
         }
 


### PR DESCRIPTION
### Motivation
- Corregir la contradicción donde el sistema registraba `LOGIN_EXITOSO` en auditoría pero el frontend recibía "Credenciales inválidas" por excepciones ocurridas después de validar el usuario.
- Evitar que errores en la preparación de la sesión (carga de permisos, obtención de rol o creación de JWT) sean reportados como fallos de autenticación.
- Prevenir excepciones por `null` al asignar permisos al preparar la sesión del usuario.

### Description
- Se separó el flujo de `IniciarSesion` en `PSA.WebAPI/Controllers/AutenticacionController.cs` en dos etapas con `try` independientes para distinguir validación de credenciales y preparación de sesión.
- Ahora solo se retorna `ApiValidationError("Credenciales inválidas.")` cuando falla la validación de usuario/contraseña dentro de `AutenticacionManager.IniciarSesionAsync` y se registra la falla en el throttle.
- Se añadió un manejo específico para fallos posteriores a la validación que devuelve `500` con código `login_session_error` y mensaje claro cuando ocurre un error al cargar permisos, rol o generar el token JWT.
- Se añadió un fallback para la lista de permisos (`?? []`) al obtener permisos por rol para reducir riesgo de `null` durante la preparación de la sesión.

### Testing
- Intenté compilar el proyecto con `dotnet build PSA.WebAPI/PSA.WebAPI.csproj`, pero la ejecución falló porque `dotnet` no está disponible en el entorno (`/bin/bash: line 1: dotnet: command not found`).
- No se pudieron ejecutar pruebas automatizadas debido a la ausencia de la herramienta `dotnet` en este entorno, por lo que solo se validó el cambio de código y el commit localmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7305a0860832d96365569639225f4)