### PR TITLE
Improve login flow resilience and error handling in AutenticacionController

### DIFF
--- a/PSA.WebAPI/Controllers/AutenticacionController.cs
+++ b/PSA.WebAPI/Controllers/AutenticacionController.cs
@@ -61,13 +61,42 @@ namespace PSA.WebAPI.Controllers
                 return ApiError(StatusCodes.Status429TooManyRequests, "rate_limited", $"Demasiados intentos. Intente nuevamente en {Math.Max(1, (int)Math.Ceiling(retryAfter.TotalMinutes))} minuto(s).");
             }
 
+            RespuestaInicioSesionDTO respuesta;
             try
             {
-                var respuesta = await _autenticacionManager.IniciarSesionAsync(dto);
+                respuesta = await _autenticacionManager.IniciarSesionAsync(dto);
                 _securityThrottleService.RegisterSuccess("login", compositeKey);
-                var permisos = await _rolPermisoDao.ObtenerCodigosPermisoPorRolAsync(respuesta.IdRol);
-                respuesta.Permisos = permisos;
-                var nombreRol = await _usuarioDao.ObtenerNombreRolPorIdAsync(respuesta.IdRol);
+            }
+            catch (Exception ex)
+            {
+                _securityThrottleService.RegisterFailure("login", compositeKey);
+                return ApiValidationError("Credenciales inválidas.", ex.Message);
+            }
+
+            var permisos = new List<string>();
+            try
+            {
+                permisos = await _rolPermisoDao.ObtenerCodigosPermisoPorRolAsync(respuesta.IdRol) ?? [];
+            }
+            catch
+            {
+                // Fallback a lista vacía para no bloquear el inicio de sesión.
+            }
+
+            respuesta.Permisos = permisos;
+
+            string? nombreRol = null;
+            try
+            {
+                nombreRol = await _usuarioDao.ObtenerNombreRolPorIdAsync(respuesta.IdRol);
+            }
+            catch
+            {
+                // El nombre de rol es opcional en el token.
+            }
+
+            try
+            {
                 respuesta.TokenAcceso = _jwtTokenService.CreateToken(
                     respuesta.IdUsuario,
                     respuesta.IdRol,
@@ -75,13 +104,14 @@ namespace PSA.WebAPI.Controllers
                     respuesta.NombreCompleto,
                     permisos,
                     nombreRol);
-                return ApiOk(respuesta, "Inicio de sesión exitoso.");
             }
-            catch (Exception ex)
+            catch
             {
-                _securityThrottleService.RegisterFailure("login", compositeKey);
-                return ApiValidationError("Credenciales inválidas.", ex.Message);
+                // No se bloquea el login web por falla de token API.
+                respuesta.TokenAcceso = string.Empty;
             }
+
+            return ApiOk(respuesta, "Inicio de sesión exitoso.");
         }
 
         [Authorize(Roles = "1")]


### PR DESCRIPTION
### Motivation
- Reduce failed login side-effects and improve resilience when auxiliary services (permission/role lookups or token generation) fail during login. 
- Ensure rate-limiting behavior remains correct while avoiding blocking a valid authentication when non-critical downstream operations fail.

### Description
- Refactored `IniciarSesion` in `AutenticacionController.cs` to separate authentication success from subsequent permission/role lookups and token generation. 
- Introduced an outer `RespuestaInicioSesionDTO` variable and moved the `RegisterFailure` call to the appropriate exception path, while keeping `RegisterSuccess` when authentication succeeds. 
- Wrapped permission retrieval (`ObtenerCodigosPermisoPorRolAsync`) and role-name retrieval (`ObtenerNombreRolPorIdAsync`) in `try/catch` blocks and fall back to an empty permissions list or `null` role name to avoid blocking login on auxiliary failures. 
- Made token creation resilient by catching token generation failures and assigning an empty access token instead of treating it as an authentication failure. 
- Moved the final `ApiOk` response to the end of the method so the response is returned after all optional steps complete or gracefully fall back.

### Testing
- Ran backend unit tests related to authentication and controller behavior, and they passed. 
- Ran authentication integration tests exercising successful login, failed login, and throttling scenarios, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7305a0860832d96365569639225f4)