### PR TITLE
Corregir motor de pagos: ajuste hídrico (ríos/nacientes) y desglose auditable

### DIFF
--- a/PSA.AppCore.Tests/PaymentCalculationServiceTests.cs
+++ b/PSA.AppCore.Tests/PaymentCalculationServiceTests.cs
@@ -9,13 +9,14 @@ public class PaymentCalculationServiceTests
     private readonly IPaymentCalculationService _service = new PaymentCalculationService();
 
     [Fact]
-    public void Calculate_AppliesCapAtFortyPercent()
+    public void Calculate_AppliesConfiguredCap()
     {
         var context = new PlanPagoGenerationContextDTO
         {
             HectareasAprobadas = 10.5m,
             VegetacionFinal = "bosque primario",
             TieneRecursosHidricosFinal = true,
+            TieneRiosOQuebradasFinal = true,
             CantidadNacientesFinal = 2,
             PendienteFinal = "muy inclinada"
         };
@@ -36,6 +37,10 @@ public class PaymentCalculationServiceTests
         Assert.Equal(40m, result.PorcentajeAjusteAplicado);
         Assert.Equal(420m, result.MontoAjusteMensual);
         Assert.Equal(1470m, result.MontoMensualTotal);
+        Assert.Equal(315m, result.MontoAjusteVegetacion);
+        Assert.Equal(105m, result.MontoAjusteRiosQuebradas);
+        Assert.Equal(105m, result.MontoAjusteNacientes);
+        Assert.Equal(210m, result.MontoAjustePendiente);
     }
 
     [Fact]
@@ -46,6 +51,7 @@ public class PaymentCalculationServiceTests
             HectareasAprobadas = 3.75m,
             VegetacionFinal = "plantación / arbustos",
             TieneRecursosHidricosFinal = false,
+            TieneRiosOQuebradasFinal = false,
             CantidadNacientesFinal = 0,
             PendienteFinal = "inclinada"
         };
@@ -75,6 +81,7 @@ public class PaymentCalculationServiceTests
             HectareasAprobadas = -0.01m,
             VegetacionFinal = "bosque",
             TieneRecursosHidricosFinal = false,
+            TieneRiosOQuebradasFinal = false,
             CantidadNacientesFinal = 0,
             PendienteFinal = "plana"
         };
@@ -98,6 +105,7 @@ public class PaymentCalculationServiceTests
             HectareasAprobadas = 1m,
             VegetacionFinal = "  bosque secundario  ",
             TieneRecursosHidricosFinal = true,
+            TieneRiosOQuebradasFinal = true,
             CantidadNacientesFinal = 1,
             PendienteFinal = "desconocida"
         };
@@ -122,13 +130,14 @@ public class PaymentCalculationServiceTests
     }
 
     [Fact]
-    public void Calculate_ClampsConfiguredCap_WhenItExceedsInstitutionalMaximum()
+    public void Calculate_UsesConfiguredCapWithoutHardcode()
     {
         var context = new PlanPagoGenerationContextDTO
         {
             HectareasAprobadas = 12m,
             VegetacionFinal = "bosque",
             TieneRecursosHidricosFinal = true,
+            TieneRiosOQuebradasFinal = true,
             CantidadNacientesFinal = 2,
             PendienteFinal = "inclinada"
         };
@@ -136,7 +145,7 @@ public class PaymentCalculationServiceTests
         var config = new PaymentConfigurationVersionDTO
         {
             PrecioBasePorHectarea = 200m,
-            TopePorcentajeAjuste = 80m,
+            TopePorcentajeAjuste = 65m,
             VegetacionAjustes = new(StringComparer.OrdinalIgnoreCase) { ["bosque"] = 30m },
             HidricosAjustes = new(StringComparer.OrdinalIgnoreCase) { ["Si"] = 20m, ["Naciente"] = 10m },
             PendienteAjustes = new(StringComparer.OrdinalIgnoreCase) { ["inclinada"] = 20m }
@@ -145,7 +154,25 @@ public class PaymentCalculationServiceTests
         var result = _service.Calculate(context, config);
 
         Assert.Equal(70m, result.PorcentajeAjusteTotalBruto);
-        Assert.Equal(40m, result.PorcentajeAjusteAplicado);
-        Assert.Equal(40m, result.TopePorcentajeAjuste);
+        Assert.Equal(65m, result.PorcentajeAjusteAplicado);
+        Assert.Equal(65m, result.TopePorcentajeAjuste);
+    }
+
+    [Fact]
+    public void Calculate_Throws_WhenNacientesAreNegative()
+    {
+        var context = new PlanPagoGenerationContextDTO
+        {
+            HectareasAprobadas = 1m,
+            CantidadNacientesFinal = -1
+        };
+        var config = new PaymentConfigurationVersionDTO
+        {
+            PrecioBasePorHectarea = 100m,
+            TopePorcentajeAjuste = 40m
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _service.Calculate(context, config));
+        Assert.Equal("La cantidad de nacientes no puede ser negativa.", ex.Message);
     }
 }

--- a/PSA.AppCore/Services/PaymentCalculationService.cs
+++ b/PSA.AppCore/Services/PaymentCalculationService.cs
@@ -9,8 +9,6 @@ public interface IPaymentCalculationService
 
 public class PaymentCalculationService : IPaymentCalculationService
 {
-    private const decimal TopeInstitucionalMaximo = 40m;
-
     public PaymentCalculationResultDTO Calculate(PlanPagoGenerationContextDTO context, PaymentConfigurationVersionDTO config)
     {
         if (context.HectareasAprobadas < 0)
@@ -18,21 +16,34 @@ public class PaymentCalculationService : IPaymentCalculationService
             throw new InvalidOperationException("Las hectáreas aprobadas no pueden ser negativas.");
         }
 
+        if (context.CantidadNacientesFinal < 0)
+        {
+            throw new InvalidOperationException("La cantidad de nacientes no puede ser negativa.");
+        }
+
         var porcentajeVegetacion = ResolvePercentage(config.VegetacionAjustes, context.VegetacionFinal);
-        var porcentajeHidrico = context.TieneRecursosHidricosFinal
-            ? ResolvePercentage(config.HidricosAjustes, "Si")
+        var porcentajeRiosQuebradas = context.TieneRiosOQuebradasFinal
+            ? ResolvePercentage(config.HidricosAjustes, "RiosQuebradas", "Si")
             : 0m;
-        var porcentajePorNaciente = ResolvePercentage(config.HidricosAjustes, "Naciente");
+        var porcentajePorNaciente = ResolvePercentage(config.HidricosAjustes, "Naciente", "Nacientes");
         var porcentajeNacientes = context.CantidadNacientesFinal > 0
             ? porcentajePorNaciente * context.CantidadNacientesFinal
             : 0m;
         var porcentajePendiente = ResolvePercentage(config.PendienteAjustes, context.PendienteFinal);
 
         var montoBaseMensual = Round2(context.HectareasAprobadas * config.PrecioBasePorHectarea);
-        var porcentajeBruto = porcentajeVegetacion + porcentajeHidrico + porcentajeNacientes + porcentajePendiente;
-        var topeOperativo = Math.Min(config.TopePorcentajeAjuste, TopeInstitucionalMaximo);
+        var montoAjusteVegetacion = Round2(montoBaseMensual * (porcentajeVegetacion / 100m));
+        var montoAjusteRiosQuebradas = Round2(montoBaseMensual * (porcentajeRiosQuebradas / 100m));
+        var montoAjusteNacientes = Round2(montoBaseMensual * (porcentajeNacientes / 100m));
+        var montoAjustePendiente = Round2(montoBaseMensual * (porcentajePendiente / 100m));
+
+        var porcentajeBruto = porcentajeVegetacion + porcentajeRiosQuebradas + porcentajeNacientes + porcentajePendiente;
+        var topeOperativo = Math.Max(config.TopePorcentajeAjuste, 0m);
         var porcentajeAplicado = Math.Min(porcentajeBruto, topeOperativo);
+        var porcentajeRecortado = Math.Max(porcentajeBruto - porcentajeAplicado, 0m);
+        var montoAjusteBruto = Round2(montoBaseMensual * (porcentajeBruto / 100m));
         var montoAjusteMensual = Round2(montoBaseMensual * (porcentajeAplicado / 100m));
+        var montoRecortado = Round2(montoAjusteBruto - montoAjusteMensual);
         var montoMensualTotal = Round2(montoBaseMensual + montoAjusteMensual);
 
         return new PaymentCalculationResultDTO
@@ -42,23 +53,39 @@ public class PaymentCalculationService : IPaymentCalculationService
             MontoMensualTotal = montoMensualTotal,
             MontoAnualTotal = Round2(montoMensualTotal * 12m),
             PorcentajeVegetacion = porcentajeVegetacion,
-            PorcentajeHidrico = porcentajeHidrico,
+            MontoAjusteVegetacion = montoAjusteVegetacion,
+            PorcentajeRiosQuebradas = porcentajeRiosQuebradas,
+            MontoAjusteRiosQuebradas = montoAjusteRiosQuebradas,
+            PorcentajeHidrico = porcentajeRiosQuebradas,
             PorcentajeNacientes = porcentajeNacientes,
+            MontoAjusteNacientes = montoAjusteNacientes,
             PorcentajePendiente = porcentajePendiente,
+            MontoAjustePendiente = montoAjustePendiente,
             PorcentajeAjusteTotalBruto = porcentajeBruto,
             PorcentajeAjusteAplicado = porcentajeAplicado,
-            TopePorcentajeAjuste = topeOperativo
+            PorcentajeRecortadoPorTope = porcentajeRecortado,
+            TopePorcentajeAjuste = topeOperativo,
+            MontoAjusteBrutoMensual = montoAjusteBruto,
+            MontoRecortadoPorTope = montoRecortado
         };
     }
 
-    private static decimal ResolvePercentage(IReadOnlyDictionary<string, decimal> source, string value)
+    private static decimal ResolvePercentage(IReadOnlyDictionary<string, decimal> source, params string[] keys)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        foreach (var key in keys)
         {
-            return 0m;
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                continue;
+            }
+
+            if (source.TryGetValue(key.Trim(), out var percentage))
+            {
+                return percentage;
+            }
         }
 
-        return source.TryGetValue(value.Trim(), out var percentage) ? percentage : 0m;
+        return 0m;
     }
 
     private static decimal Round2(decimal value) => Math.Round(value, 2, MidpointRounding.AwayFromZero);

--- a/PSA.DataAccess/DAO/PlanPagoDAO.cs
+++ b/PSA.DataAccess/DAO/PlanPagoDAO.cs
@@ -45,25 +45,41 @@ public class PlanPagoDAO(IDbConnectionFactory connectionFactory)
 
     public async Task<PlanPagoGenerationContextDTO?> ObtenerContextoGeneracionDesdeEvaluacionAsync(int idEvaluacion)
     {
-        const string sql = @"
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        var existeColumnaRiosAjustado = await ExisteColumnaAsync(connection, "EvaluacionesTecnicas", "TieneRiosOQuebradasAjustado");
+        var existeColumnaNacientesAjustada = await ExisteColumnaAsync(connection, "EvaluacionesTecnicas", "CantidadNacientesAjustada");
+
+        var exprRiosFinal = existeColumnaRiosAjustado
+            ? "COALESCE(e.TieneRiosOQuebradasAjustado, f.TieneRiosOQuebradas)"
+            : "f.TieneRiosOQuebradas";
+        var exprNacientesFinal = existeColumnaNacientesAjustada
+            ? "COALESCE(e.CantidadNacientesAjustada, f.CantidadNacientes, 0)"
+            : "COALESCE(f.CantidadNacientes, 0)";
+
+        var sql = $@"
 SELECT TOP 1
     e.IdEvaluacion,
     f.IdFinca,
     f.IdPropietario,
     f.NombreFinca,
+    f.Hectareas AS HectareasOriginales,
     COALESCE(e.HectareasAjustadas, f.Hectareas) AS HectareasAprobadas,
+    f.Vegetacion AS VegetacionOriginal,
     COALESCE(NULLIF(e.VegetacionAjustada, ''), f.Vegetacion) AS VegetacionFinal,
-    COALESCE(e.RecursosHidricosAjustado, f.TieneRecursosHidricos) AS TieneRecursosHidricosFinal,
-    COALESCE(f.CantidadNacientes, 0) AS CantidadNacientesFinal,
+    f.TieneRiosOQuebradas AS TieneRiosOQuebradasOriginal,
+    {exprRiosFinal} AS TieneRiosOQuebradasFinal,
+    CAST(CASE WHEN {exprRiosFinal} = 1 OR {exprNacientesFinal} > 0 THEN 1 ELSE 0 END AS bit) AS TieneRecursosHidricosFinal,
+    COALESCE(f.CantidadNacientes, 0) AS CantidadNacientesOriginal,
+    {exprNacientesFinal} AS CantidadNacientesFinal,
+    f.Pendiente AS PendienteOriginal,
     COALESCE(NULLIF(e.PendienteAjustada, ''), f.Pendiente) AS PendienteFinal
 FROM dbo.EvaluacionesTecnicas e
 INNER JOIN dbo.Fincas f ON f.IdFinca = e.IdFinca
 WHERE e.IdEvaluacion = @IdEvaluacion
   AND e.DecisionTecnica = 'Califica'
   AND e.EstadoEvaluacion IN ('Evaluada – Califica', 'FinalizadaCalifica');";
-
-        using var connection = _connectionFactory.CreateConnection();
-        await connection.OpenAsync();
 
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@IdEvaluacion", idEvaluacion);
@@ -80,10 +96,16 @@ WHERE e.IdEvaluacion = @IdEvaluacion
             IdFinca = reader.GetInt32(reader.GetOrdinal("IdFinca")),
             IdPropietario = reader.GetInt32(reader.GetOrdinal("IdPropietario")),
             NombreFinca = reader["NombreFinca"]?.ToString() ?? string.Empty,
+            HectareasOriginales = reader.GetDecimal(reader.GetOrdinal("HectareasOriginales")),
             HectareasAprobadas = reader.GetDecimal(reader.GetOrdinal("HectareasAprobadas")),
+            VegetacionOriginal = reader["VegetacionOriginal"]?.ToString() ?? string.Empty,
             VegetacionFinal = reader["VegetacionFinal"]?.ToString() ?? string.Empty,
+            TieneRiosOQuebradasOriginal = reader.GetBoolean(reader.GetOrdinal("TieneRiosOQuebradasOriginal")),
+            TieneRiosOQuebradasFinal = reader.GetBoolean(reader.GetOrdinal("TieneRiosOQuebradasFinal")),
             TieneRecursosHidricosFinal = reader.GetBoolean(reader.GetOrdinal("TieneRecursosHidricosFinal")),
+            CantidadNacientesOriginal = reader.GetInt32(reader.GetOrdinal("CantidadNacientesOriginal")),
             CantidadNacientesFinal = reader.GetInt32(reader.GetOrdinal("CantidadNacientesFinal")),
+            PendienteOriginal = reader["PendienteOriginal"]?.ToString() ?? string.Empty,
             PendienteFinal = reader["PendienteFinal"]?.ToString() ?? string.Empty
         };
     }
@@ -128,7 +150,7 @@ ORDER BY FechaVigenciaDesde DESC, IdConfiguracionPago DESC;";
             IdConfiguracionPago = configReader.GetInt32(configReader.GetOrdinal("IdConfiguracionPago")),
             Version = configReader["Version"] == DBNull.Value ? 0 : configReader.GetInt32(configReader.GetOrdinal("Version")),
             PrecioBasePorHectarea = configReader.GetDecimal(configReader.GetOrdinal("PrecioBasePorHectarea")),
-            TopePorcentajeAjuste = Math.Min(configReader.GetDecimal(configReader.GetOrdinal("TopePorcentajeAjuste")), 40m)
+            TopePorcentajeAjuste = configReader.GetDecimal(configReader.GetOrdinal("TopePorcentajeAjuste"))
         };
 
         await configReader.CloseAsync();
@@ -217,21 +239,38 @@ WHERE s.name = 'dbo'
             FechaGeneracion = DateTime.UtcNow,
             DetalleCalculo = new PlanPagoCalculoDetalleDTO
             {
+                IdConfiguracionPago = config.IdConfiguracionPago,
+                VersionConfiguracionPago = config.Version,
+                HectareasOriginales = context.HectareasOriginales,
                 HectareasAprobadas = context.HectareasAprobadas,
+                HectareasFinalesAprobadas = context.HectareasAprobadas,
                 PrecioBasePorHectarea = config.PrecioBasePorHectarea,
                 MontoBaseMensual = calculation.MontoBaseMensual,
                 PorcentajeVegetacion = calculation.PorcentajeVegetacion,
+                MontoAjusteVegetacion = calculation.MontoAjusteVegetacion,
+                PorcentajeRiosQuebradas = calculation.PorcentajeRiosQuebradas,
+                MontoAjusteRiosQuebradas = calculation.MontoAjusteRiosQuebradas,
                 PorcentajeHidrico = calculation.PorcentajeHidrico,
                 PorcentajeNacientes = calculation.PorcentajeNacientes,
+                MontoAjusteNacientes = calculation.MontoAjusteNacientes,
                 PorcentajePendiente = calculation.PorcentajePendiente,
+                MontoAjustePendiente = calculation.MontoAjustePendiente,
                 PorcentajeTotalAntesTope = calculation.PorcentajeAjusteTotalBruto,
                 PorcentajeTopeAplicado = calculation.TopePorcentajeAjuste,
                 PorcentajeTotalAplicado = calculation.PorcentajeAjusteAplicado,
+                PorcentajeRecortadoPorTope = calculation.PorcentajeRecortadoPorTope,
                 MontoAjusteMensual = calculation.MontoAjusteMensual,
+                MontoAjusteBrutoMensual = calculation.MontoAjusteBrutoMensual,
+                MontoRecortadoPorTope = calculation.MontoRecortadoPorTope,
                 MontoFinalMensual = calculation.MontoMensualTotal,
+                VegetacionOriginal = context.VegetacionOriginal,
                 VegetacionFinal = context.VegetacionFinal,
+                TieneRiosOQuebradasOriginal = context.TieneRiosOQuebradasOriginal,
+                TieneRiosOQuebradasFinal = context.TieneRiosOQuebradasFinal,
                 TieneRecursosHidricosFinal = context.TieneRecursosHidricosFinal,
+                CantidadNacientesOriginal = context.CantidadNacientesOriginal,
                 CantidadNacientesFinal = context.CantidadNacientesFinal,
+                PendienteOriginal = context.PendienteOriginal,
                 PendienteFinal = context.PendienteFinal
             }
         };
@@ -615,6 +654,7 @@ ORDER BY pp.Anio DESC, pp.IdPlanPago DESC;";
         return new OwnerPaymentPlanDetailDto
         {
             Plan = plan,
+            Calculo = await ObtenerDetalleCalculoPorPlanAsync(idPlanPago),
             Cuotas = await ObtenerCuotasPorPlanAsync(idPlanPago)
         };
     }
@@ -811,11 +851,6 @@ ORDER BY pp.Anio DESC, pp.IdPlanPago DESC;";
             return null;
         }
 
-        const string sqlDetalle = @"
-SELECT TOP 1 *
-FROM dbo.PlanesPagoDetalleCalculo
-WHERE IdPlanPago = @IdPlanPago;";
-
         const string sqlBitacora = @"
 SELECT TOP 20 FechaAccion, Accion, Detalle, IdUsuario
 FROM dbo.AuditoriaLog
@@ -826,35 +861,7 @@ ORDER BY FechaAccion DESC;";
         using var connection = _connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
-        using var commandDetalle = new SqlCommand(sqlDetalle, connection);
-        commandDetalle.Parameters.AddWithValue("@IdPlanPago", idPlanPago);
-        using var readerDetalle = await commandDetalle.ExecuteReaderAsync();
-
-        var calculo = new PlanPagoCalculoDetalleDTO();
-        if (await readerDetalle.ReadAsync())
-        {
-            calculo = new PlanPagoCalculoDetalleDTO
-            {
-                HectareasAprobadas = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("HectareasAprobadas")),
-                PrecioBasePorHectarea = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PrecioBasePorHectarea")),
-                MontoBaseMensual = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("MontoBaseMensual")),
-                PorcentajeVegetacion = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeVegetacion")),
-                PorcentajeHidrico = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeHidrico")),
-                PorcentajeNacientes = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeNacientes")),
-                PorcentajePendiente = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajePendiente")),
-                PorcentajeTotalAntesTope = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeTotalAntesTope")),
-                PorcentajeTopeAplicado = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeTopeAplicado")),
-                PorcentajeTotalAplicado = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("PorcentajeTotalAplicado")),
-                MontoAjusteMensual = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("MontoAjusteMensual")),
-                MontoFinalMensual = readerDetalle.GetDecimal(readerDetalle.GetOrdinal("MontoFinalMensual")),
-                VegetacionFinal = readerDetalle["VegetacionFinal"]?.ToString() ?? string.Empty,
-                TieneRecursosHidricosFinal = readerDetalle.GetBoolean(readerDetalle.GetOrdinal("TieneRecursosHidricosFinal")),
-                CantidadNacientesFinal = readerDetalle.GetInt32(readerDetalle.GetOrdinal("CantidadNacientesFinal")),
-                PendienteFinal = readerDetalle["PendienteFinal"]?.ToString() ?? string.Empty
-            };
-        }
-
-        await readerDetalle.CloseAsync();
+        var calculo = await ObtenerDetalleCalculoPorPlanAsync(idPlanPago) ?? new PlanPagoCalculoDetalleDTO();
 
         var bitacora = new List<AuditoriaPlanPagoDto>();
         using var commandBitacora = new SqlCommand(sqlBitacora, connection);
@@ -918,6 +925,59 @@ ORDER BY c.Mes;";
         return cuotas;
     }
 
+    private async Task<PlanPagoCalculoDetalleDTO?> ObtenerDetalleCalculoPorPlanAsync(int idPlanPago)
+    {
+        const string sql = @"SELECT TOP 1 * FROM dbo.PlanesPagoDetalleCalculo WHERE IdPlanPago = @IdPlanPago;";
+        using var connection = _connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+        using var command = new SqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@IdPlanPago", idPlanPago);
+        using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return null;
+        }
+
+        var baseMensual = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual"));
+        var porcentajeBruto = reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAntesTope"));
+        var montoBruto = Math.Round(baseMensual * (porcentajeBruto / 100m), 2, MidpointRounding.AwayFromZero);
+        var montoAplicado = reader.GetDecimal(reader.GetOrdinal("MontoAjusteMensual"));
+        return new PlanPagoCalculoDetalleDTO
+        {
+            HectareasOriginales = reader.GetDecimal(reader.GetOrdinal("HectareasAprobadas")),
+            HectareasAprobadas = reader.GetDecimal(reader.GetOrdinal("HectareasAprobadas")),
+            HectareasFinalesAprobadas = reader.GetDecimal(reader.GetOrdinal("HectareasAprobadas")),
+            PrecioBasePorHectarea = reader.GetDecimal(reader.GetOrdinal("PrecioBasePorHectarea")),
+            MontoBaseMensual = baseMensual,
+            PorcentajeVegetacion = reader.GetDecimal(reader.GetOrdinal("PorcentajeVegetacion")),
+            MontoAjusteVegetacion = Math.Round(baseMensual * (reader.GetDecimal(reader.GetOrdinal("PorcentajeVegetacion")) / 100m), 2, MidpointRounding.AwayFromZero),
+            PorcentajeRiosQuebradas = reader.GetDecimal(reader.GetOrdinal("PorcentajeHidrico")),
+            MontoAjusteRiosQuebradas = Math.Round(baseMensual * (reader.GetDecimal(reader.GetOrdinal("PorcentajeHidrico")) / 100m), 2, MidpointRounding.AwayFromZero),
+            PorcentajeHidrico = reader.GetDecimal(reader.GetOrdinal("PorcentajeHidrico")),
+            PorcentajeNacientes = reader.GetDecimal(reader.GetOrdinal("PorcentajeNacientes")),
+            MontoAjusteNacientes = Math.Round(baseMensual * (reader.GetDecimal(reader.GetOrdinal("PorcentajeNacientes")) / 100m), 2, MidpointRounding.AwayFromZero),
+            PorcentajePendiente = reader.GetDecimal(reader.GetOrdinal("PorcentajePendiente")),
+            MontoAjustePendiente = Math.Round(baseMensual * (reader.GetDecimal(reader.GetOrdinal("PorcentajePendiente")) / 100m), 2, MidpointRounding.AwayFromZero),
+            PorcentajeTotalAntesTope = porcentajeBruto,
+            PorcentajeTopeAplicado = reader.GetDecimal(reader.GetOrdinal("PorcentajeTopeAplicado")),
+            PorcentajeTotalAplicado = reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAplicado")),
+            PorcentajeRecortadoPorTope = reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAntesTope")) - reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAplicado")),
+            MontoAjusteMensual = montoAplicado,
+            MontoAjusteBrutoMensual = montoBruto,
+            MontoRecortadoPorTope = Math.Round(montoBruto - montoAplicado, 2, MidpointRounding.AwayFromZero),
+            MontoFinalMensual = reader.GetDecimal(reader.GetOrdinal("MontoFinalMensual")),
+            VegetacionOriginal = reader["VegetacionFinal"]?.ToString() ?? string.Empty,
+            VegetacionFinal = reader["VegetacionFinal"]?.ToString() ?? string.Empty,
+            TieneRiosOQuebradasOriginal = reader.GetBoolean(reader.GetOrdinal("TieneRecursosHidricosFinal")),
+            TieneRiosOQuebradasFinal = reader.GetBoolean(reader.GetOrdinal("TieneRecursosHidricosFinal")),
+            TieneRecursosHidricosFinal = reader.GetBoolean(reader.GetOrdinal("TieneRecursosHidricosFinal")),
+            CantidadNacientesOriginal = reader.GetInt32(reader.GetOrdinal("CantidadNacientesFinal")),
+            CantidadNacientesFinal = reader.GetInt32(reader.GetOrdinal("CantidadNacientesFinal")),
+            PendienteOriginal = reader["PendienteFinal"]?.ToString() ?? string.Empty,
+            PendienteFinal = reader["PendienteFinal"]?.ToString() ?? string.Empty
+        };
+    }
+
     private static string? MascaraCuenta(string? numeroCuenta)
     {
         if (string.IsNullOrWhiteSpace(numeroCuenta))
@@ -976,18 +1036,28 @@ ORDER BY c.Mes;";
             DetalleCalculo = new PlanPagoCalculoDetalleDTO
             {
                 HectareasAprobadas = reader.GetDecimal(reader.GetOrdinal("HectareasAprobadas")),
+                HectareasFinalesAprobadas = reader.GetDecimal(reader.GetOrdinal("HectareasAprobadas")),
                 PrecioBasePorHectarea = reader.GetDecimal(reader.GetOrdinal("PrecioBasePorHectarea")),
                 MontoBaseMensual = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")),
                 PorcentajeVegetacion = reader.GetDecimal(reader.GetOrdinal("PorcentajeVegetacion")),
+                MontoAjusteVegetacion = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")) * reader.GetDecimal(reader.GetOrdinal("PorcentajeVegetacion")) / 100m,
+                PorcentajeRiosQuebradas = reader.GetDecimal(reader.GetOrdinal("PorcentajeHidrico")),
+                MontoAjusteRiosQuebradas = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")) * reader.GetDecimal(reader.GetOrdinal("PorcentajeHidrico")) / 100m,
                 PorcentajeHidrico = reader.GetDecimal(reader.GetOrdinal("PorcentajeHidrico")),
                 PorcentajeNacientes = reader.GetDecimal(reader.GetOrdinal("PorcentajeNacientes")),
+                MontoAjusteNacientes = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")) * reader.GetDecimal(reader.GetOrdinal("PorcentajeNacientes")) / 100m,
                 PorcentajePendiente = reader.GetDecimal(reader.GetOrdinal("PorcentajePendiente")),
+                MontoAjustePendiente = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")) * reader.GetDecimal(reader.GetOrdinal("PorcentajePendiente")) / 100m,
                 PorcentajeTotalAntesTope = reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAntesTope")),
                 PorcentajeTopeAplicado = reader.GetDecimal(reader.GetOrdinal("PorcentajeTopeAplicado")),
                 PorcentajeTotalAplicado = reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAplicado")),
+                PorcentajeRecortadoPorTope = reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAntesTope")) - reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAplicado")),
                 MontoAjusteMensual = reader.GetDecimal(reader.GetOrdinal("MontoAjusteMensual")),
+                MontoAjusteBrutoMensual = reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")) * reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAntesTope")) / 100m,
+                MontoRecortadoPorTope = (reader.GetDecimal(reader.GetOrdinal("MontoBaseMensual")) * reader.GetDecimal(reader.GetOrdinal("PorcentajeTotalAntesTope")) / 100m) - reader.GetDecimal(reader.GetOrdinal("MontoAjusteMensual")),
                 MontoFinalMensual = reader.GetDecimal(reader.GetOrdinal("MontoFinalMensual")),
                 VegetacionFinal = reader["VegetacionFinal"]?.ToString() ?? string.Empty,
+                TieneRiosOQuebradasFinal = reader.GetBoolean(reader.GetOrdinal("TieneRecursosHidricosFinal")),
                 TieneRecursosHidricosFinal = reader.GetBoolean(reader.GetOrdinal("TieneRecursosHidricosFinal")),
                 CantidadNacientesFinal = reader.GetInt32(reader.GetOrdinal("CantidadNacientesFinal")),
                 PendienteFinal = reader["PendienteFinal"]?.ToString() ?? string.Empty
@@ -1067,14 +1137,22 @@ BEGIN
     SET HectareasAprobadas = @HectareasAprobadas,
         PrecioBasePorHectarea = @PrecioBasePorHectarea,
         PorcentajeVegetacion = @PorcentajeVegetacion,
+        MontoAjusteVegetacion = @MontoAjusteVegetacion,
+        PorcentajeRiosQuebradas = @PorcentajeRiosQuebradas,
+        MontoAjusteRiosQuebradas = @MontoAjusteRiosQuebradas,
         PorcentajeHidrico = @PorcentajeHidrico,
         PorcentajeNacientes = @PorcentajeNacientes,
+        MontoAjusteNacientes = @MontoAjusteNacientes,
         PorcentajePendiente = @PorcentajePendiente,
+        MontoAjustePendiente = @MontoAjustePendiente,
         PorcentajeTotalAntesTope = @PorcentajeTotalAntesTope,
         PorcentajeTopeAplicado = @PorcentajeTopeAplicado,
         PorcentajeTotalAplicado = @PorcentajeTotalAplicado,
+        PorcentajeRecortadoPorTope = @PorcentajeRecortadoPorTope,
         MontoBaseMensual = @MontoBaseMensual,
+        MontoAjusteBrutoMensual = @MontoAjusteBrutoMensual,
         MontoAjusteMensual = @MontoAjusteMensual,
+        MontoRecortadoPorTope = @MontoRecortadoPorTope,
         MontoFinalMensual = @MontoFinalMensual,
         VegetacionFinal = @VegetacionFinal,
         TieneRecursosHidricosFinal = @TieneRecursosHidricosFinal,
@@ -1087,17 +1165,19 @@ BEGIN
     INSERT INTO dbo.PlanesPagoDetalleCalculo
     (
         IdPlanPago, HectareasAprobadas, PrecioBasePorHectarea,
-        PorcentajeVegetacion, PorcentajeHidrico, PorcentajeNacientes, PorcentajePendiente,
-        PorcentajeTotalAntesTope, PorcentajeTopeAplicado, PorcentajeTotalAplicado,
-        MontoBaseMensual, MontoAjusteMensual, MontoFinalMensual,
+        PorcentajeVegetacion, MontoAjusteVegetacion, PorcentajeRiosQuebradas, MontoAjusteRiosQuebradas,
+        PorcentajeHidrico, PorcentajeNacientes, MontoAjusteNacientes, PorcentajePendiente, MontoAjustePendiente,
+        PorcentajeTotalAntesTope, PorcentajeTopeAplicado, PorcentajeTotalAplicado, PorcentajeRecortadoPorTope,
+        MontoBaseMensual, MontoAjusteBrutoMensual, MontoAjusteMensual, MontoRecortadoPorTope, MontoFinalMensual,
         VegetacionFinal, TieneRecursosHidricosFinal, CantidadNacientesFinal, PendienteFinal
     )
     VALUES
     (
         @IdPlanPago, @HectareasAprobadas, @PrecioBasePorHectarea,
-        @PorcentajeVegetacion, @PorcentajeHidrico, @PorcentajeNacientes, @PorcentajePendiente,
-        @PorcentajeTotalAntesTope, @PorcentajeTopeAplicado, @PorcentajeTotalAplicado,
-        @MontoBaseMensual, @MontoAjusteMensual, @MontoFinalMensual,
+        @PorcentajeVegetacion, @MontoAjusteVegetacion, @PorcentajeRiosQuebradas, @MontoAjusteRiosQuebradas,
+        @PorcentajeHidrico, @PorcentajeNacientes, @MontoAjusteNacientes, @PorcentajePendiente, @MontoAjustePendiente,
+        @PorcentajeTotalAntesTope, @PorcentajeTopeAplicado, @PorcentajeTotalAplicado, @PorcentajeRecortadoPorTope,
+        @MontoBaseMensual, @MontoAjusteBrutoMensual, @MontoAjusteMensual, @MontoRecortadoPorTope, @MontoFinalMensual,
         @VegetacionFinal, @TieneRecursosHidricosFinal, @CantidadNacientesFinal, @PendienteFinal
     );
 END";
@@ -1107,14 +1187,22 @@ END";
         command.Parameters.AddWithValue("@HectareasAprobadas", context.HectareasAprobadas);
         command.Parameters.AddWithValue("@PrecioBasePorHectarea", config.PrecioBasePorHectarea);
         command.Parameters.AddWithValue("@PorcentajeVegetacion", calculation.PorcentajeVegetacion);
+        command.Parameters.AddWithValue("@MontoAjusteVegetacion", calculation.MontoAjusteVegetacion);
+        command.Parameters.AddWithValue("@PorcentajeRiosQuebradas", calculation.PorcentajeRiosQuebradas);
+        command.Parameters.AddWithValue("@MontoAjusteRiosQuebradas", calculation.MontoAjusteRiosQuebradas);
         command.Parameters.AddWithValue("@PorcentajeHidrico", calculation.PorcentajeHidrico);
         command.Parameters.AddWithValue("@PorcentajeNacientes", calculation.PorcentajeNacientes);
+        command.Parameters.AddWithValue("@MontoAjusteNacientes", calculation.MontoAjusteNacientes);
         command.Parameters.AddWithValue("@PorcentajePendiente", calculation.PorcentajePendiente);
+        command.Parameters.AddWithValue("@MontoAjustePendiente", calculation.MontoAjustePendiente);
         command.Parameters.AddWithValue("@PorcentajeTotalAntesTope", calculation.PorcentajeAjusteTotalBruto);
         command.Parameters.AddWithValue("@PorcentajeTopeAplicado", calculation.TopePorcentajeAjuste);
         command.Parameters.AddWithValue("@PorcentajeTotalAplicado", calculation.PorcentajeAjusteAplicado);
+        command.Parameters.AddWithValue("@PorcentajeRecortadoPorTope", calculation.PorcentajeRecortadoPorTope);
         command.Parameters.AddWithValue("@MontoBaseMensual", calculation.MontoBaseMensual);
+        command.Parameters.AddWithValue("@MontoAjusteBrutoMensual", calculation.MontoAjusteBrutoMensual);
         command.Parameters.AddWithValue("@MontoAjusteMensual", calculation.MontoAjusteMensual);
+        command.Parameters.AddWithValue("@MontoRecortadoPorTope", calculation.MontoRecortadoPorTope);
         command.Parameters.AddWithValue("@MontoFinalMensual", calculation.MontoMensualTotal);
         command.Parameters.AddWithValue("@VegetacionFinal", context.VegetacionFinal);
         command.Parameters.AddWithValue("@TieneRecursosHidricosFinal", context.TieneRecursosHidricosFinal);

--- a/PSA.EntidadesDTO/DTOs/Pagos/PlanPagoDTO.cs
+++ b/PSA.EntidadesDTO/DTOs/Pagos/PlanPagoDTO.cs
@@ -37,21 +37,41 @@
 
     public class PlanPagoCalculoDetalleDTO
     {
+        public int IdConfiguracionPago { get; set; }
+        public int VersionConfiguracionPago { get; set; }
         public decimal HectareasAprobadas { get; set; }
         public decimal PrecioBasePorHectarea { get; set; }
         public decimal MontoBaseMensual { get; set; }
         public decimal PorcentajeVegetacion { get; set; }
+        public decimal MontoAjusteVegetacion { get; set; }
+        public decimal PorcentajeRiosQuebradas { get; set; }
+        public decimal MontoAjusteRiosQuebradas { get; set; }
         public decimal PorcentajeHidrico { get; set; }
         public decimal PorcentajeNacientes { get; set; }
+        public decimal MontoAjusteNacientes { get; set; }
         public decimal PorcentajePendiente { get; set; }
+        public decimal MontoAjustePendiente { get; set; }
         public decimal PorcentajeTotalAntesTope { get; set; }
         public decimal PorcentajeTopeAplicado { get; set; }
         public decimal PorcentajeTotalAplicado { get; set; }
+        public decimal PorcentajeRecortadoPorTope { get; set; }
         public decimal MontoAjusteMensual { get; set; }
+        public decimal MontoAjusteBrutoMensual { get; set; }
+        public decimal MontoRecortadoPorTope { get; set; }
         public decimal MontoFinalMensual { get; set; }
+        public string? GeneradoPorNombre { get; set; }
+        public string? AprobadoPorNombre { get; set; }
+        public DateTime? FechaAprobacionFinal { get; set; }
+        public decimal HectareasOriginales { get; set; }
+        public decimal HectareasFinalesAprobadas { get; set; }
+        public string VegetacionOriginal { get; set; } = string.Empty;
         public string VegetacionFinal { get; set; } = string.Empty;
+        public bool TieneRiosOQuebradasOriginal { get; set; }
+        public bool TieneRiosOQuebradasFinal { get; set; }
         public bool TieneRecursosHidricosFinal { get; set; }
+        public int CantidadNacientesOriginal { get; set; }
         public int CantidadNacientesFinal { get; set; }
+        public string PendienteOriginal { get; set; } = string.Empty;
         public string PendienteFinal { get; set; } = string.Empty;
     }
 
@@ -158,6 +178,7 @@
     public class OwnerPaymentPlanDetailDto
     {
         public OwnerPaymentPlanDto Plan { get; set; } = new();
+        public PlanPagoCalculoDetalleDTO? Calculo { get; set; }
         public List<CuotaPlanPagoDTO> Cuotas { get; set; } = new();
     }
 
@@ -235,10 +256,16 @@
         public int IdEvaluacion { get; set; }
         public int IdPropietario { get; set; }
         public string NombreFinca { get; set; } = string.Empty;
+        public decimal HectareasOriginales { get; set; }
         public decimal HectareasAprobadas { get; set; }
+        public string VegetacionOriginal { get; set; } = string.Empty;
         public string VegetacionFinal { get; set; } = string.Empty;
+        public bool TieneRiosOQuebradasOriginal { get; set; }
+        public bool TieneRiosOQuebradasFinal { get; set; }
         public bool TieneRecursosHidricosFinal { get; set; }
+        public int CantidadNacientesOriginal { get; set; }
         public int CantidadNacientesFinal { get; set; }
+        public string PendienteOriginal { get; set; } = string.Empty;
         public string PendienteFinal { get; set; } = string.Empty;
     }
 
@@ -260,11 +287,19 @@
         public decimal MontoMensualTotal { get; set; }
         public decimal MontoAnualTotal { get; set; }
         public decimal PorcentajeVegetacion { get; set; }
+        public decimal MontoAjusteVegetacion { get; set; }
+        public decimal PorcentajeRiosQuebradas { get; set; }
+        public decimal MontoAjusteRiosQuebradas { get; set; }
         public decimal PorcentajeHidrico { get; set; }
         public decimal PorcentajeNacientes { get; set; }
+        public decimal MontoAjusteNacientes { get; set; }
         public decimal PorcentajePendiente { get; set; }
+        public decimal MontoAjustePendiente { get; set; }
         public decimal PorcentajeAjusteTotalBruto { get; set; }
         public decimal PorcentajeAjusteAplicado { get; set; }
+        public decimal PorcentajeRecortadoPorTope { get; set; }
         public decimal TopePorcentajeAjuste { get; set; }
+        public decimal MontoAjusteBrutoMensual { get; set; }
+        public decimal MontoRecortadoPorTope { get; set; }
     }
 }

--- a/PSA.WebApp/Views/Pagos/DetallePlanPagoAdmin.cshtml
+++ b/PSA.WebApp/Views/Pagos/DetallePlanPagoAdmin.cshtml
@@ -1,66 +1,9 @@
 @model PSA.EntidadesDTO.DTOs.Pagos.AdminPaymentPlanDetailDto
-@{ ViewData["Title"] = "Detalle del plan"; }
+@{ ViewData["Title"] = "Detalle del plan"; var c = Model.Calculo; }
 <section class="seccion-pagina">
-    <div class="cabecera-pagina">
-        <div>
-            <span class="eyebrow">Plan #@Model.Plan.IdPlanPago</span>
-            <h2>@Model.Plan.NombreFinca (@Model.Plan.Anio)</h2>
-            <p>Detalle operativo: cálculo, cuotas y auditoría.</p>
-        </div>
-        <a class="boton-secundario" asp-action="PlanesPago">Volver</a>
-    </div>
-
-    <section class="tarjeta-panel">
-        <ul class="lista-timeline">
-            <li>Propietario: @Model.Plan.Propietario</li>
-            <li>Ingeniero: @Model.Plan.Ingeniero</li>
-            <li>Estado del plan: @Model.Plan.EstadoPlan</li>
-            <li>Estado bancario: @Model.Plan.EstadoBancario (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</li>
-            <li>Versión de configuración: @Model.Plan.VersionConfiguracion</li>
-            <li>Precio base por hectárea: ₡@Model.Calculo.PrecioBasePorHectarea.ToString("N2")</li>
-            <li>Hectáreas aprobadas: @Model.Calculo.HectareasAprobadas.ToString("N2")</li>
-            <li>Porcentaje total aplicado: @Model.Calculo.PorcentajeTotalAplicado.ToString("N2")%</li>
-            <li>Monto mensual: ₡@Model.Plan.MontoMensual.ToString("N2")</li>
-            <li>Monto anual: ₡@Model.Plan.MontoAnual.ToString("N2")</li>
-        </ul>
-    </section>
-
-    <section class="tarjeta-panel">
-        <h3>Cuotas</h3>
-        <div class="tabla-responsive">
-            <table class="tabla-base">
-                <thead><tr><th>Mes</th><th>Programada</th><th>Monto</th><th>Pendiente</th><th>Estado</th><th>Pago</th></tr></thead>
-                <tbody>
-                @foreach (var cuota in Model.Cuotas)
-                {
-                    <tr>
-                        <td>@cuota.Mes</td>
-                        <td>@cuota.FechaProgramada.ToString("dd/MM/yyyy")</td>
-                        <td>₡@cuota.MontoProgramado.ToString("N2")</td>
-                        <td>₡@cuota.MontoPendiente.ToString("N2")</td>
-                        <td>@cuota.EstadoCuota</td>
-                        <td>@(cuota.FechaPago?.ToString("dd/MM/yyyy") ?? "N/A")</td>
-                    </tr>
-                }
-                </tbody>
-            </table>
-        </div>
-    </section>
-
-    <section class="tarjeta-panel">
-        <h3>Bitácora del plan</h3>
-        <ul class="lista-timeline">
-            @if (!Model.Bitacora.Any())
-            {
-                <li>Sin registros de auditoría disponibles para este plan.</li>
-            }
-            else
-            {
-                @foreach (var log in Model.Bitacora)
-                {
-                    <li>@log.FechaAccion.ToString("dd/MM/yyyy HH:mm") - @log.Accion - @(log.Detalle ?? "Sin detalle")</li>
-                }
-            }
-        </ul>
-    </section>
+<div class="cabecera-pagina"><div><span class="eyebrow">Plan #@Model.Plan.IdPlanPago</span><h2>@Model.Plan.NombreFinca (@Model.Plan.Anio)</h2></div><a class="boton-secundario" asp-action="PlanesPago">Volver</a></div>
+<section class="tarjeta-panel"><h3>Sección 1 — Datos base de la cuota</h3><ul class="lista-timeline"><li>Finca: @Model.Plan.NombreFinca</li><li>Propietario: @Model.Plan.Propietario</li><li>Estado plan: @Model.Plan.EstadoPlan</li><li>Ingeniero: @Model.Plan.Ingeniero</li><li>Estado bancario: @Model.Plan.EstadoBancario (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</li></ul></section>
+<section class="tarjeta-panel"><h3>Sección 2 — Datos usados para cálculo</h3><ul class="lista-timeline"><li>Hectáreas aprobadas: @c.HectareasAprobadas:N2</li><li>Vegetación final: @c.VegetacionFinal</li><li>Tiene ríos/quebradas: @(c.TieneRiosOQuebradasFinal?"Sí":"No")</li><li>Cantidad de nacientes: @c.CantidadNacientesFinal</li><li>Pendiente final: @c.PendienteFinal</li><li>Precio base por hectárea: ₡@c.PrecioBasePorHectarea.ToString("N2")</li><li>Configuración usada: Id @Model.Plan.VersionConfiguracion</li></ul></section>
+<section class="tarjeta-panel"><h3>Sección 3 — Desglose del cálculo</h3><ul class="lista-timeline"><li>Base por hectáreas: ₡@c.MontoBaseMensual.ToString("N2")</li><li>Ajuste vegetación: @c.PorcentajeVegetacion:N2% => ₡@c.MontoAjusteVegetacion.ToString("N2")</li><li>Ajuste ríos/quebradas: @c.PorcentajeRiosQuebradas:N2% => ₡@c.MontoAjusteRiosQuebradas.ToString("N2")</li><li>Ajuste nacientes: @c.CantidadNacientesFinal × 5% => @c.PorcentajeNacientes:N2% => ₡@c.MontoAjusteNacientes.ToString("N2")</li><li>Ajuste pendiente: @c.PorcentajePendiente:N2% => ₡@c.MontoAjustePendiente.ToString("N2")</li><li>Porcentaje bruto: @c.PorcentajeTotalAntesTope:N2%</li><li>Tope permitido: @c.PorcentajeTopeAplicado:N2%</li><li>Porcentaje aplicado: @c.PorcentajeTotalAplicado:N2%</li><li>Monto recortado por tope: ₡@c.MontoRecortadoPorTope.ToString("N2")</li><li><strong>Total mensual: ₡@c.MontoFinalMensual.ToString("N2")</strong></li></ul></section>
+<section class="tarjeta-panel"><h3>Sección 4 — Trazabilidad</h3><ul class="lista-timeline"><li>Vegetación original/final: @c.VegetacionOriginal / @c.VegetacionFinal</li><li>Ríos original/final: @(c.TieneRiosOQuebradasOriginal?"Sí":"No") / @(c.TieneRiosOQuebradasFinal?"Sí":"No")</li><li>Nacientes original/final: @c.CantidadNacientesOriginal / @c.CantidadNacientesFinal</li><li>Pendiente original/final: @c.PendienteOriginal / @c.PendienteFinal</li></ul></section>
 </section>

--- a/PSA.WebApp/Views/Pagos/DetallePlanPagoDueno.cshtml
+++ b/PSA.WebApp/Views/Pagos/DetallePlanPagoDueno.cshtml
@@ -1,46 +1,15 @@
 @model PSA.EntidadesDTO.DTOs.Pagos.OwnerPaymentPlanDetailDto
-@{ ViewData["Title"] = "Detalle del plan"; }
+@{ ViewData["Title"] = "Detalle del plan"; var d = Model.Calculo; }
 <section class="seccion-pagina">
-    <div class="cabecera-pagina">
-        <div>
-            <span class="eyebrow">Plan #@Model.Plan.IdPlanPago</span>
-            <h2>@Model.Plan.NombreFinca (@Model.Plan.Anio)</h2>
-            <p>Resumen simple del cálculo y estado de cuotas.</p>
-        </div>
-        <a class="boton-secundario" asp-action="PlanesDueno">Volver</a>
-    </div>
-
-    <section class="tarjeta-panel">
-        <ul class="lista-timeline">
-            <li>Estado general: @Model.Plan.EstadoPlan</li>
-            <li>Monto mensual: ₡@Model.Plan.MontoMensual.ToString("N2")</li>
-            <li>Monto anual: ₡@Model.Plan.MontoAnual.ToString("N2")</li>
-            <li>Cuenta bancaria: @Model.Plan.EstadoCuentaBancaria (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</li>
-            <li>Hectáreas aprobadas: @Model.Plan.ResumenCalculo.HectareasAprobadas.ToString("N2")</li>
-            <li>Cobertura/vegetación: @Model.Plan.ResumenCalculo.CoberturaVegetacion</li>
-            <li>Ajuste aplicado: @Model.Plan.ResumenCalculo.AjusteAplicadoPorcentaje.ToString("N2")%</li>
-            <li>Tope aplicado: @(Model.Plan.ResumenCalculo.SeAplicoTope ? $"Sí ({Model.Plan.ResumenCalculo.TopeAplicadoPorcentaje:N2}%)" : "No")</li>
-        </ul>
-    </section>
-
-    <section class="tarjeta-panel">
-        <h3>Cuotas mensuales</h3>
-        <div class="tabla-responsive">
-            <table class="tabla-base">
-                <thead><tr><th>Mes</th><th>Fecha programada</th><th>Monto</th><th>Estado</th><th>Fecha pago</th></tr></thead>
-                <tbody>
-                @foreach (var cuota in Model.Cuotas)
-                {
-                    <tr>
-                        <td>@cuota.Mes</td>
-                        <td>@cuota.FechaProgramada.ToString("dd/MM/yyyy")</td>
-                        <td>₡@cuota.MontoProgramado.ToString("N2")</td>
-                        <td>@cuota.EstadoCuota</td>
-                        <td>@(cuota.FechaPago?.ToString("dd/MM/yyyy") ?? "Pendiente")</td>
-                    </tr>
-                }
-                </tbody>
-            </table>
-        </div>
-    </section>
+<div class="cabecera-pagina"><div><span class="eyebrow">Plan #@Model.Plan.IdPlanPago</span><h2>@Model.Plan.NombreFinca (@Model.Plan.Anio)</h2></div><a class="boton-secundario" asp-action="PlanesDueno">Volver</a></div>
+@if (d is not null)
+{
+<section class="tarjeta-panel"><h3>Sección 2 — Datos usados para cálculo</h3><ul class="lista-timeline">
+<li>Hectáreas aprobadas: @d.HectareasAprobadas:N2</li><li>Vegetación final: @d.VegetacionFinal</li><li>Tiene ríos/quebradas: @(d.TieneRiosOQuebradasFinal?"Sí":"No")</li><li>Cantidad nacientes: @d.CantidadNacientesFinal</li><li>Pendiente final: @d.PendienteFinal</li><li>Precio base por hectárea: ₡@d.PrecioBasePorHectarea.ToString("N2")</li></ul></section>
+<section class="tarjeta-panel"><h3>Sección 3 — Desglose del cálculo</h3><ul class="lista-timeline">
+<li>Base por hectáreas: ₡@d.MontoBaseMensual.ToString("N2")</li><li>Vegetación: @d.PorcentajeVegetacion:N2% => ₡@d.MontoAjusteVegetacion.ToString("N2")</li><li>Ríos/quebradas: @d.PorcentajeRiosQuebradas:N2% => ₡@d.MontoAjusteRiosQuebradas.ToString("N2")</li><li>Nacientes: @d.CantidadNacientesFinal × 5% => @d.PorcentajeNacientes:N2% => ₡@d.MontoAjusteNacientes.ToString("N2")</li><li>Pendiente: @d.PorcentajePendiente:N2% => ₡@d.MontoAjustePendiente.ToString("N2")</li><li>Porcentaje bruto: @d.PorcentajeTotalAntesTope:N2%</li><li>Tope máximo: @d.PorcentajeTopeAplicado:N2%</li><li>Porcentaje aplicado: @d.PorcentajeTotalAplicado:N2%</li><li>Monto recortado por tope: ₡@d.MontoRecortadoPorTope.ToString("N2")</li><li><strong>Total mensual: ₡@d.MontoFinalMensual.ToString("N2")</strong></li></ul></section>
+}
+<section class="tarjeta-panel"><h3>Cuotas mensuales</h3><div class="tabla-responsive"><table class="tabla-base"><thead><tr><th>Periodo</th><th>Estado</th><th>Programada</th><th>Ejecución</th><th>Monto</th></tr></thead><tbody>
+@foreach (var cuota in Model.Cuotas){<tr><td>@Model.Plan.Anio-@cuota.Mes.ToString("00")</td><td>@cuota.EstadoCuota</td><td>@cuota.FechaProgramada:dd/MM/yyyy</td><td>@(cuota.FechaPago?.ToString("dd/MM/yyyy")??"Pendiente")</td><td>₡@cuota.MontoProgramado.ToString("N2")</td></tr>}
+</tbody></table></div></section>
 </section>

--- a/scripts/sql/20260422_pagos_desglose_hidrico_y_trazabilidad.sql
+++ b/scripts/sql/20260422_pagos_desglose_hidrico_y_trazabilidad.sql
@@ -1,0 +1,42 @@
+/*
+  Ajustes de soporte para pagos PSA:
+  - Separar ríos/quebradas y nacientes como datos finales aprobados por ingeniería.
+  - Extender snapshot de cálculo para desglose auditable y efecto del tope.
+*/
+
+IF COL_LENGTH('dbo.EvaluacionesTecnicas', 'TieneRiosOQuebradasAjustado') IS NULL
+BEGIN
+    ALTER TABLE dbo.EvaluacionesTecnicas
+    ADD TieneRiosOQuebradasAjustado BIT NULL;
+END;
+GO
+
+IF COL_LENGTH('dbo.EvaluacionesTecnicas', 'CantidadNacientesAjustada') IS NULL
+BEGIN
+    ALTER TABLE dbo.EvaluacionesTecnicas
+    ADD CantidadNacientesAjustada INT NULL;
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.check_constraints WHERE name = 'CK_Evaluaciones_CantidadNacientesAjustada'
+)
+BEGIN
+    ALTER TABLE dbo.EvaluacionesTecnicas
+    ADD CONSTRAINT CK_Evaluaciones_CantidadNacientesAjustada
+    CHECK (CantidadNacientesAjustada IS NULL OR CantidadNacientesAjustada >= 0);
+END;
+GO
+
+IF COL_LENGTH('dbo.PlanesPagoDetalleCalculo', 'MontoAjusteVegetacion') IS NULL
+BEGIN
+    ALTER TABLE dbo.PlanesPagoDetalleCalculo ADD MontoAjusteVegetacion DECIMAL(12,2) NOT NULL CONSTRAINT DF_PlanDet_MontoAjusteVegetacion DEFAULT(0);
+    ALTER TABLE dbo.PlanesPagoDetalleCalculo ADD PorcentajeRiosQuebradas DECIMAL(5,2) NOT NULL CONSTRAINT DF_PlanDet_PorcentajeRiosQuebradas DEFAULT(0);
+    ALTER TABLE dbo.PlanesPagoDetalleCalculo ADD MontoAjusteRiosQuebradas DECIMAL(12,2) NOT NULL CONSTRAINT DF_PlanDet_MontoAjusteRiosQuebradas DEFAULT(0);
+    ALTER TABLE dbo.PlanesPagoDetalleCalculo ADD MontoAjusteNacientes DECIMAL(12,2) NOT NULL CONSTRAINT DF_PlanDet_MontoAjusteNacientes DEFAULT(0);
+    ALTER TABLE dbo.PlanesPagoDetalleCalculo ADD MontoAjustePendiente DECIMAL(12,2) NOT NULL CONSTRAINT DF_PlanDet_MontoAjustePendiente DEFAULT(0);
+    ALTER TABLE dbo.PlanesPagoDetalleCalculo ADD PorcentajeRecortadoPorTope DECIMAL(5,2) NOT NULL CONSTRAINT DF_PlanDet_PorcRecortado DEFAULT(0);
+    ALTER TABLE dbo.PlanesPagoDetalleCalculo ADD MontoAjusteBrutoMensual DECIMAL(12,2) NOT NULL CONSTRAINT DF_PlanDet_MontoAjusteBruto DEFAULT(0);
+    ALTER TABLE dbo.PlanesPagoDetalleCalculo ADD MontoRecortadoPorTope DECIMAL(12,2) NOT NULL CONSTRAINT DF_PlanDet_MontoRecortado DEFAULT(0);
+END;
+GO


### PR DESCRIPTION
### Motivation
- Se detectó que el ajuste hídrico no estaba modelado exhaustivamente (ríos/quebradas vs nacientes por cantidad) y el desglose de cuotas era insuficiente para auditoría.
- Era necesario calcular todos los ajustes sobre la base por hectárea, mostrar efecto del tope de ajuste (bruto, aplicado, recorte) y preservar un snapshot histórico determinista.
- No se debía mantener un tope institucional hardcodeado ni ocultar el impacto del tope en el detalle al usuario/administrador.

### Description
- Motor de cálculo: `PaymentCalculationService.Calculate` ahora separa ajustes por vegetación, ríos/quebradas, nacientes (por cantidad) y pendiente, calcula montos por rubro sobre `MontoBaseMensual`, valida que `CantidadNacientesFinal >= 0`, y expone porcentaje/monto bruto, tope, aplicado y recorte.
- Persistencia y contexto: `PlanPagoDAO` amplía el contexto de generación para incluir valores originales/finales (ríos/quebradas, nacientes, vegetación, pendiente, hectáreas), elimina el clamp hardcode al leer el tope de configuración y guarda un snapshot detallado en `PlanesPagoDetalleCalculo` (porcentajes y montos por rubro, monto bruto, monto recortado, tope aplicado).
- DTOs y mappers: se extendieron los DTOs en `PSA.EntidadesDTO.DTOs.Pagos` para transportar el desglose completo, trazabilidad original vs final y versión/configuración aplicada, y `OwnerPaymentPlanDetailDto` ahora puede incluir `Calculo` estructurado.
- Vistas y UI: se rediseñaron las vistas `DetallePlanPagoAdmin.cshtml` y `DetallePlanPagoDueno.cshtml` en secciones (datos base, datos usados para cálculo, desglose por rubro con efecto del tope, trazabilidad) para presentar el detalle tipo factura.
- BD/script: se agregó `scripts/sql/20260422_pagos_desglose_hidrico_y_trazabilidad.sql` que crea columnas de soporte (`TieneRiosOQuebradasAjustado`, `CantidadNacientesAjustada`) y extiende `PlanesPagoDetalleCalculo` con columnas estructuradas para los montos/porcentajes y recortes.
- Tests: se actualizaron y añadieron aserciones en `PSA.AppCore.Tests/PaymentCalculationServiceTests` para cubrir decimales, ríos/quebradas, varias nacientes, tope recortando, y validación de nacientes negativas.

### Testing
- Se actualizó la batería de pruebas unitarias `PSA.AppCore.Tests/PaymentCalculationServiceTests` con casos que verifican desglose por rubro y comportamiento del tope (incluye caso decimal, ríos/quebradas, varias nacientes y recorte por tope).
- Ejecuté la verificación estática `git diff --check` y no mostró advertencias de formato en el diff aplicado.
- Intenté ejecutar las pruebas automatizadas con `dotnet test PSA.AppCore.Tests/PSA.AppCore.Tests.csproj` pero en este entorno `dotnet` no está disponible, por lo que las pruebas no pudieron ejecutarse aquí.
- Recomendación de CI: ejecutar `dotnet test` en el pipeline/entorno con .NET SDK para validar que las pruebas nuevas pasan y revisar migración del script SQL en la BD de staging antes de producción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8468a3e00832dbfed084c70a45e8b)