### PR TITLE
Enviar correo de bienvenida al crear usuario desde Admin y unificar migas de pan

### DIFF
--- a/PSA.AppCore/Managers/AdministracionManager.cs
+++ b/PSA.AppCore/Managers/AdministracionManager.cs
@@ -73,6 +73,15 @@ public class AdministracionManager
 
         var idCreado = await _usuarioDao.CrearUsuarioAsync(nuevo);
 
+        var nombreRol = await _usuarioDao.ObtenerNombreRolPorIdAsync(model.IdRol) ?? "Usuario";
+        await _notificationDispatcher.NotifyEmailAsync(
+            nuevo.Email,
+            "Bienvenido a PSA Costa Rica",
+            NotificationCatalog.EmailBienvenida(
+                nuevo.NombreCompleto,
+                nombreRol,
+                enlaceSistema: null));
+
         await _auditoriaLogDao.RegistrarEventoAsync(
             idUsuario: idAdmin,
             modulo: "Administracion",

--- a/PSA.AppCore/Managers/AutenticacionManager.cs
+++ b/PSA.AppCore/Managers/AutenticacionManager.cs
@@ -1,4 +1,5 @@
 using PSA.AppCore.Servicios;
+using PSA.AppCore.Services.Notifications;
 using PSA.AppCore.Services.Security;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
@@ -13,17 +14,20 @@ namespace PSA.AppCore.Managers
         private readonly UsuarioDAO _usuarioDAO;
         private readonly AuditoriaLogDAO _auditoriaLogDAO;
         private readonly IPasswordPolicy _passwordPolicy;
+        private readonly INotificationDispatcher _notificationDispatcher;
 
         public AutenticacionManager(
             IServicioHashContrasena servicioHashContrasena,
             UsuarioDAO usuarioDAO,
             AuditoriaLogDAO auditoriaLogDAO,
-            IPasswordPolicy passwordPolicy)
+            IPasswordPolicy passwordPolicy,
+            INotificationDispatcher notificationDispatcher)
         {
             _servicioHashContrasena = servicioHashContrasena;
             _usuarioDAO = usuarioDAO;
             _auditoriaLogDAO = auditoriaLogDAO;
             _passwordPolicy = passwordPolicy;
+            _notificationDispatcher = notificationDispatcher;
         }
 
         public async Task<int> RegistrarUsuarioAsync(RegistrarUsuarioDTO dto)
@@ -65,7 +69,17 @@ namespace PSA.AppCore.Managers
                 UltimoAcceso = null
             };
 
-            return await _usuarioDAO.CrearUsuarioAsync(usuario);
+            var idUsuario = await _usuarioDAO.CrearUsuarioAsync(usuario);
+
+            await _notificationDispatcher.NotifyEmailAsync(
+                usuario.Email,
+                "Bienvenido a PSA Costa Rica",
+                NotificationCatalog.EmailBienvenida(
+                    usuario.NombreCompleto,
+                    "Propietario",
+                    enlaceSistema: null));
+
+            return idUsuario;
         }
 
         public async Task<RespuestaInicioSesionDTO> IniciarSesionAsync(InicioSesionDTO dto)

--- a/PSA.AppCore/Services/Notifications/NotificationCatalog.cs
+++ b/PSA.AppCore/Services/Notifications/NotificationCatalog.cs
@@ -6,7 +6,21 @@ public static class NotificationCatalog
     public const string TipoSuccess = "success";
     public const string TipoWarning = "warning";
 
-    public static string EmailResultadoEvaluacion(string nombreUsuario, string nombreFinca, string decision, DateTime fecha, string? observaciones, string? resumenCambios, string? enlaceSistema)
+    
+    public static string EmailBienvenida(string nombreUsuario, string rol, string? enlaceSistema)
+        => ConstruirPlantillaMarca(
+            "Registro de cuenta confirmado",
+            $"""
+<p>Hola {nombreUsuario},</p>
+<p>Tu cuenta en PSA Costa Rica fue creada correctamente.</p>
+<p><strong>Rol asignado:</strong> {rol}</p>
+<p>Ya puedes ingresar al sistema para registrar fincas y dar seguimiento a tus procesos.</p>
+{ConstruirBloqueEnlace(enlaceSistema)}
+<p style='font-size:13px;color:#4b5563;'>Si no realizaste este registro, por favor comunícate con el administrador del sistema.</p>
+<p>PSA Costa Rica</p>
+""");
+
+public static string EmailResultadoEvaluacion(string nombreUsuario, string nombreFinca, string decision, DateTime fecha, string? observaciones, string? resumenCambios, string? enlaceSistema)
     {
         var observacionesTexto = string.IsNullOrWhiteSpace(observaciones) ? "Sin observaciones adicionales." : observaciones.Trim();
         var resumenTexto = string.IsNullOrWhiteSpace(resumenCambios) ? "No se registraron ajustes adicionales." : resumenCambios.Trim();

--- a/PSA.WebAPI/Controllers/AutenticacionController.cs
+++ b/PSA.WebAPI/Controllers/AutenticacionController.cs
@@ -5,7 +5,6 @@ using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
 using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
 using PSA.EntidadesDTO.DTOs.Usuarios;
-using PSA.WebAPI.Services;
 using PSA.WebAPI.Services.Security;
 
 namespace PSA.WebAPI.Controllers
@@ -14,14 +13,12 @@ namespace PSA.WebAPI.Controllers
     [Route("api/[controller]")]
     public class AutenticacionController(
         AutenticacionManager autenticacionManager,
-        IConfiguration configuration,
         RolPermisoDAO rolPermisoDao,
         UsuarioDAO usuarioDao,
         IJwtTokenService jwtTokenService,
         ISecurityThrottleService securityThrottleService) : BaseApiController
     {
         private readonly AutenticacionManager _autenticacionManager = autenticacionManager;
-        private readonly IConfiguration _configuration = configuration;
         private readonly RolPermisoDAO _rolPermisoDao = rolPermisoDao;
         private readonly UsuarioDAO _usuarioDao = usuarioDao;
         private readonly IJwtTokenService _jwtTokenService = jwtTokenService;
@@ -34,7 +31,6 @@ namespace PSA.WebAPI.Controllers
             try
             {
                 var idUsuario = await _autenticacionManager.RegistrarUsuarioAsync(dto);
-                await IntentarEnviarCorreoBienvenidaAsync(dto);
 
                 return ApiCreated(new
                 {
@@ -166,60 +162,6 @@ namespace PSA.WebAPI.Controllers
             {
                 return ApiValidationError("No fue posible asignar el rol.", ex.Message);
             }
-        }
-
-        private Task IntentarEnviarCorreoBienvenidaAsync(RegistrarUsuarioDTO dto)
-        {
-            try
-            {
-                if (string.IsNullOrWhiteSpace(dto.Email))
-                {
-                    return Task.CompletedTask;
-                }
-
-                var smtp = new SmtpSettingsDTO
-                {
-                    Host = _configuration["SmtpSettings:Host"] ?? string.Empty,
-                    Port = int.TryParse(_configuration["SmtpSettings:Port"], out var port) ? port : 587,
-                    EnableSsl = !bool.TryParse(_configuration["SmtpSettings:EnableSsl"], out var ssl) || ssl,
-                    FromName = _configuration["SmtpSettings:FromName"] ?? string.Empty,
-                    FromEmail = _configuration["SmtpSettings:FromEmail"] ?? string.Empty,
-                    Username = _configuration["SmtpSettings:Username"] ?? string.Empty,
-                    Password = _configuration["SmtpSettings:Password"] ?? string.Empty
-                };
-
-                var smtpConfigurado = !string.IsNullOrWhiteSpace(smtp.Host)
-                    && !string.IsNullOrWhiteSpace(smtp.FromEmail)
-                    && !string.IsNullOrWhiteSpace(smtp.Username)
-                    && !string.IsNullOrWhiteSpace(smtp.Password);
-
-                if (!smtpConfigurado)
-                {
-                    return Task.CompletedTask;
-                }
-
-                var webAppBaseUrl = _configuration["AppSettings:WebAppBaseUrl"]?.TrimEnd('/');
-                var baseUrl = string.IsNullOrWhiteSpace(webAppBaseUrl)
-                    ? "https://localhost:59664"
-                    : webAppBaseUrl;
-                var urlLogin = $"{baseUrl}/Autenticacion/IniciarSesion";
-                var nombreUsuario = string.IsNullOrWhiteSpace(dto.NombreCompleto) ? "usuario" : dto.NombreCompleto.Trim();
-                var rol = "Dueño de finca";
-
-                var correoService = new CorreoService(smtp);
-                correoService.EnviarCorreoBienvenida(
-                    dto.Email.Trim(),
-                    nombreUsuario,
-                    rol,
-                    urlLogin
-                );
-            }
-            catch
-            {
-                // No se bloquea el registro si falla el correo de bienvenida.
-            }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/PSA.WebApp/Controllers/AdministracionController.cs
+++ b/PSA.WebApp/Controllers/AdministracionController.cs
@@ -8,7 +8,7 @@ using PSA.WebApp.Services;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "1")]
-    public class AdministracionController : Controller
+    public class AdministracionController : AppControllerBase
     {
         private readonly HttpClientService _httpClientService;
 

--- a/PSA.WebApp/Controllers/AppControllerBase.cs
+++ b/PSA.WebApp/Controllers/AppControllerBase.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using PSA.WebApp.Models;
+
+namespace PSA.WebApp.Controllers;
+
+public abstract class AppControllerBase : Controller
+{
+    private static readonly Dictionary<string, (string Label, string Action)> Modulos = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Administracion"] = ("Administración", "GestionUsuarios"),
+        ["Fincas"] = ("Fincas", "MisFincas"),
+        ["Evaluaciones"] = ("Evaluaciones", "Pendientes"),
+        ["Pagos"] = ("Pagos", "PlanesPago"),
+        ["Reportes"] = ("Reportes", "Index"),
+        ["MiPerfil"] = ("Mi perfil", "Index"),
+        ["Notificaciones"] = ("Notificaciones", "Index")
+    };
+
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        base.OnActionExecuting(context);
+
+        if (!(User?.Identity?.IsAuthenticated ?? false))
+        {
+            return;
+        }
+
+        var controller = (context.RouteData.Values["controller"]?.ToString() ?? string.Empty).Trim();
+        var action = (context.RouteData.Values["action"]?.ToString() ?? string.Empty).Trim();
+
+        var titulo = ViewBag.TituloPagina as string
+            ?? ViewBag.BreadcrumbActual as string
+            ?? ViewData["Title"]?.ToString()
+            ?? Humanizar(action);
+
+        ViewBag.TituloPagina = titulo;
+
+        var inicioAccion = ViewBag.BreadcrumbInicioAccion as string ?? ResolverInicioPorRol();
+        var inicioControlador = ViewBag.BreadcrumbInicioControlador as string ?? "Dashboard";
+        var inicioTexto = ViewBag.BreadcrumbInicioTexto as string ?? "Inicio";
+
+        var breadcrumbs = new List<BreadcrumbItemViewModel>
+        {
+            new() { Label = inicioTexto, Url = Url.Action(inicioAccion, inicioControlador) }
+        };
+
+        var padreTexto = (ViewBag.BreadcrumbPadreTexto as string)?.Trim();
+        var padreUrl = (ViewBag.BreadcrumbPadreUrl as string)?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(padreTexto))
+        {
+            breadcrumbs.Add(new BreadcrumbItemViewModel { Label = padreTexto, Url = padreUrl });
+        }
+        else if (Modulos.TryGetValue(controller, out var modulo) && !controller.Equals("Dashboard", StringComparison.OrdinalIgnoreCase))
+        {
+            breadcrumbs.Add(new BreadcrumbItemViewModel
+            {
+                Label = modulo.Label,
+                Url = Url.Action(modulo.Action, controller)
+            });
+        }
+
+        breadcrumbs.Add(new BreadcrumbItemViewModel
+        {
+            Label = (ViewBag.BreadcrumbActual as string ?? titulo).Trim(),
+            IsCurrent = true
+        });
+
+        ViewBag.BreadcrumbItems = breadcrumbs;
+    }
+
+    private string ResolverInicioPorRol()
+    {
+        var rol = User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value;
+        return rol switch
+        {
+            "1" => "Administrador",
+            "3" => "Ingeniero",
+            _ => "Dueno"
+        };
+    }
+
+    private static string Humanizar(string texto)
+    {
+        if (string.IsNullOrWhiteSpace(texto))
+        {
+            return "Página";
+        }
+
+        return string.Concat(texto.Select((c, i) => i > 0 && char.IsUpper(c) ? $" {c}" : c.ToString())).Trim();
+    }
+}

--- a/PSA.WebApp/Controllers/AutenticacionController.cs
+++ b/PSA.WebApp/Controllers/AutenticacionController.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization;
 
 namespace PSA.WebApp.Controllers
 {
-    public class AutenticacionController : Controller
+    public class AutenticacionController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/AuthController.cs
+++ b/PSA.WebApp/Controllers/AuthController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace PSA.WebApp.Controllers
 {
-    public class AuthController : Controller
+    public class AuthController : AppControllerBase
     {
         [HttpGet]
         public IActionResult Login()

--- a/PSA.WebApp/Controllers/DashboardController.cs
+++ b/PSA.WebApp/Controllers/DashboardController.cs
@@ -8,7 +8,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers
 {
     [Authorize]
-    public class DashboardController : Controller
+    public class DashboardController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -12,7 +12,7 @@ using System.Text.Json;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "3")]
-    public class EvaluacionesController : Controller
+    public class EvaluacionesController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/FincasController.cs
+++ b/PSA.WebApp/Controllers/FincasController.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "2")]
-    public class FincasController : Controller
+    public class FincasController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/HomeController.cs
+++ b/PSA.WebApp/Controllers/HomeController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace PSA.WebApp.Controllers
 {
-    public class HomeController : Controller
+    public class HomeController : AppControllerBase
     {
         public IActionResult Index()
         {

--- a/PSA.WebApp/Controllers/MiPerfilController.cs
+++ b/PSA.WebApp/Controllers/MiPerfilController.cs
@@ -8,7 +8,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "1,2,3")]
-    public class MiPerfilController : Controller
+    public class MiPerfilController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/NotificacionesController.cs
+++ b/PSA.WebApp/Controllers/NotificacionesController.cs
@@ -8,7 +8,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "1,2,3")]
-    public class NotificacionesController : Controller
+    public class NotificacionesController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/PagosController.cs
+++ b/PSA.WebApp/Controllers/PagosController.cs
@@ -7,7 +7,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers
 {
     [Authorize]
-    public class PagosController : Controller
+    public class PagosController : AppControllerBase
     {
         private readonly HttpClientService _httpClientService;
 

--- a/PSA.WebApp/Controllers/ReportesController.cs
+++ b/PSA.WebApp/Controllers/ReportesController.cs
@@ -7,7 +7,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers;
 
 [Authorize(Roles = "1,2,3")]
-public class ReportesController : Controller
+public class ReportesController : AppControllerBase
 {
     private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Models/BreadcrumbItemViewModel.cs
+++ b/PSA.WebApp/Models/BreadcrumbItemViewModel.cs
@@ -1,0 +1,8 @@
+namespace PSA.WebApp.Models;
+
+public class BreadcrumbItemViewModel
+{
+    public required string Label { get; init; }
+    public string? Url { get; init; }
+    public bool IsCurrent { get; init; }
+}

--- a/PSA.WebApp/Views/Shared/_MigasPan.cshtml
+++ b/PSA.WebApp/Views/Shared/_MigasPan.cshtml
@@ -1,18 +1,45 @@
+@using PSA.WebApp.Models
 @{
-    var inicioTexto = ViewBag.BreadcrumbInicioTexto as string ?? "Inicio";
-    var inicioControlador = ViewBag.BreadcrumbInicioControlador as string ?? "Dashboard";
-    var inicioAccion = ViewBag.BreadcrumbInicioAccion as string ?? "Index";
-    var padreTexto = ViewBag.BreadcrumbPadreTexto as string;
-    var padreUrl = ViewBag.BreadcrumbPadreUrl as string;
-    var actual = ViewBag.BreadcrumbActual as string ?? ViewBag.TituloPagina as string ?? "Página";
-}
-<nav class="migas-pan" aria-label="Migas de pan">
-    <a asp-controller="@inicioControlador" asp-action="@inicioAccion">@inicioTexto</a>
-    @if (!string.IsNullOrWhiteSpace(padreTexto) && !string.IsNullOrWhiteSpace(padreUrl))
+    var items = ViewBag.BreadcrumbItems as IEnumerable<BreadcrumbItemViewModel>;
+
+    if (items == null || !items.Any())
     {
-        <span>/</span>
-        <a href="@padreUrl">@padreTexto</a>
+        var inicioTexto = ViewBag.BreadcrumbInicioTexto as string ?? "Inicio";
+        var inicioControlador = ViewBag.BreadcrumbInicioControlador as string ?? "Dashboard";
+        var inicioAccion = ViewBag.BreadcrumbInicioAccion as string ?? "Index";
+        var padreTexto = ViewBag.BreadcrumbPadreTexto as string;
+        var padreUrl = ViewBag.BreadcrumbPadreUrl as string;
+        var actual = ViewBag.BreadcrumbActual as string ?? ViewBag.TituloPagina as string ?? "Página";
+
+        var fallback = new List<BreadcrumbItemViewModel>
+        {
+            new() { Label = inicioTexto, Url = Url.Action(inicioAccion, inicioControlador) }
+        };
+
+        if (!string.IsNullOrWhiteSpace(padreTexto))
+        {
+            fallback.Add(new BreadcrumbItemViewModel { Label = padreTexto, Url = padreUrl });
+        }
+
+        fallback.Add(new BreadcrumbItemViewModel { Label = actual, IsCurrent = true });
+        items = fallback;
     }
-    <span>/</span>
-    <span class="actual">@actual</span>
+}
+
+<nav class="migas-pan" aria-label="Migas de pan">
+    <ol class="migas-pan__lista">
+        @foreach (var item in items)
+        {
+            <li class="migas-pan__item @(item.IsCurrent ? "actual" : string.Empty)">
+                @if (!item.IsCurrent && !string.IsNullOrWhiteSpace(item.Url))
+                {
+                    <a href="@item.Url">@item.Label</a>
+                }
+                else
+                {
+                    <span aria-current="@(item.IsCurrent ? "page" : null)">@item.Label</span>
+                }
+            </li>
+        }
+    </ol>
 </nav>

--- a/PSA.WebApp/wwwroot/css/componentes.css
+++ b/PSA.WebApp/wwwroot/css/componentes.css
@@ -257,18 +257,45 @@ html[data-theme="dark"] .modal-sistema .btn-close {
 }
 
 .migas-pan {
-    display: flex;
-    align-items: center;
-    gap: var(--espacio-2);
     margin-bottom: var(--espacio-5);
     color: var(--color-texto-secundario);
     font-size: 0.92rem;
 }
 
-    .migas-pan .actual {
-        color: var(--color-texto-principal);
-        font-weight: 700;
-    }
+.migas-pan__lista {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--espacio-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.migas-pan__item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--espacio-2);
+}
+
+.migas-pan__item + .migas-pan__item::before {
+    content: "/";
+    color: var(--color-texto-secundario);
+}
+
+.migas-pan__item a {
+    color: var(--color-primario);
+    text-decoration: none;
+}
+
+.migas-pan__item a:hover {
+    text-decoration: underline;
+}
+
+.migas-pan__item.actual {
+    color: var(--color-texto-principal);
+    font-weight: 700;
+}
 
 .estado-vacio,
 .estado-vacio-inline {


### PR DESCRIPTION
### Motivation
- Corregir la inconsistencia donde el flujo de autoregistro enviaba correo de bienvenida pero la creación de usuarios desde el módulo de administración no lo hacía, reutilizando la lógica existente sin duplicarla.
- Normalizar la experiencia de navegación centralizando la generación y el renderizado de las migas de pan para evitar variantes visuales y estructurales entre módulos.

### Description
- Centralicé el envío de notificaciones de bienvenida en la capa de aplicación usando `INotificationDispatcher` y un template común `NotificationCatalog.EmailBienvenida`, y eliminé el envío ad-hoc desde el controller API para evitar duplicidad y divergencia de comportamiento.
- Integré el envío de correo en `AutenticacionManager.RegistrarUsuarioAsync` y en `AdministracionManager.CrearUsuarioAsync` para que ambos flujos usen el mismo mecanismo no bloqueante (errores de envío no interrumpen la persistencia gracias a `NotificationDispatcher`).
- Introduje un sistema de breadcrumbs centralizado con `AppControllerBase` que construye `ViewBag.BreadcrumbItems`, el modelo `BreadcrumbItemViewModel`, y reescribí el parcial `_MigasPan` y estilos en `componentes.css` para un render y estilo uniforme; además migré los controladores MVC para heredar de `AppControllerBase`.
- Archivos principales modificados: `PSA.AppCore/Managers/AdministracionManager.cs`, `PSA.AppCore/Managers/AutenticacionManager.cs`, `PSA.AppCore/Services/Notifications/NotificationCatalog.cs`, `PSA.WebAPI/Controllers/AutenticacionController.cs`, `PSA.WebApp/Controllers/AppControllerBase.cs`, `PSA.WebApp/Models/BreadcrumbItemViewModel.cs`, `PSA.WebApp/Views/Shared/_MigasPan.cshtml`, `PSA.WebApp/wwwroot/css/componentes.css`, y varios controladores MVC actualizados para heredar `AppControllerBase` (`AdministracionController.cs`, `AutenticacionController.cs`, `AuthController.cs`, `DashboardController.cs`, `EvaluacionesController.cs`, `FincasController.cs`, `HomeController.cs`, `MiPerfilController.cs`, `NotificacionesController.cs`, `PagosController.cs`, `ReportesController.cs`).

### Testing
- Intenté compilar la solución con `dotnet build /workspace/HummingBird_Solutions/psa-costa-rica.slnLaunch`, pero la ejecución falló por limitación del entorno (`dotnet: command not found`).
- Ejecuté búsquedas de código (`rg`) y revisiones de archivos para verificar que las invocaciones de envío de correo fueron centralizadas y que los controladores ahora heredan de `AppControllerBase`; estas inspecciones mostraron los cambios esperados.
- Se realizó el commit de los cambios (`Fix welcome email on admin user creation and unify breadcrumbs`) y no se ejecutaron tests unitarios automáticos por falta de runtime en el entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9667379f8832db0a018c66e010a8d)