### PR TITLE
Enviar correo de bienvenida al crear usuario; añadir AppControllerBase y migas de pan; mejorar vista DetallePlanPago y manejo de JWT

### DIFF
--- a/PSA.AppCore/Managers/AdministracionManager.cs
+++ b/PSA.AppCore/Managers/AdministracionManager.cs
@@ -73,6 +73,15 @@ public class AdministracionManager
 
         var idCreado = await _usuarioDao.CrearUsuarioAsync(nuevo);
 
+        var nombreRol = await _usuarioDao.ObtenerNombreRolPorIdAsync(model.IdRol) ?? "Usuario";
+        await _notificationDispatcher.NotifyEmailAsync(
+            nuevo.Email,
+            "Bienvenido a PSA Costa Rica",
+            NotificationCatalog.EmailBienvenida(
+                nuevo.NombreCompleto,
+                nombreRol,
+                enlaceSistema: null));
+
         await _auditoriaLogDao.RegistrarEventoAsync(
             idUsuario: idAdmin,
             modulo: "Administracion",

--- a/PSA.AppCore/Managers/AutenticacionManager.cs
+++ b/PSA.AppCore/Managers/AutenticacionManager.cs
@@ -1,4 +1,5 @@
 using PSA.AppCore.Servicios;
+using PSA.AppCore.Services.Notifications;
 using PSA.AppCore.Services.Security;
 using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
@@ -13,17 +14,20 @@ namespace PSA.AppCore.Managers
         private readonly UsuarioDAO _usuarioDAO;
         private readonly AuditoriaLogDAO _auditoriaLogDAO;
         private readonly IPasswordPolicy _passwordPolicy;
+        private readonly INotificationDispatcher _notificationDispatcher;
 
         public AutenticacionManager(
             IServicioHashContrasena servicioHashContrasena,
             UsuarioDAO usuarioDAO,
             AuditoriaLogDAO auditoriaLogDAO,
-            IPasswordPolicy passwordPolicy)
+            IPasswordPolicy passwordPolicy,
+            INotificationDispatcher notificationDispatcher)
         {
             _servicioHashContrasena = servicioHashContrasena;
             _usuarioDAO = usuarioDAO;
             _auditoriaLogDAO = auditoriaLogDAO;
             _passwordPolicy = passwordPolicy;
+            _notificationDispatcher = notificationDispatcher;
         }
 
         public async Task<int> RegistrarUsuarioAsync(RegistrarUsuarioDTO dto)
@@ -65,7 +69,17 @@ namespace PSA.AppCore.Managers
                 UltimoAcceso = null
             };
 
-            return await _usuarioDAO.CrearUsuarioAsync(usuario);
+            var idUsuario = await _usuarioDAO.CrearUsuarioAsync(usuario);
+
+            await _notificationDispatcher.NotifyEmailAsync(
+                usuario.Email,
+                "Bienvenido a PSA Costa Rica",
+                NotificationCatalog.EmailBienvenida(
+                    usuario.NombreCompleto,
+                    "Propietario",
+                    enlaceSistema: null));
+
+            return idUsuario;
         }
 
         public async Task<RespuestaInicioSesionDTO> IniciarSesionAsync(InicioSesionDTO dto)

--- a/PSA.AppCore/Services/Notifications/NotificationCatalog.cs
+++ b/PSA.AppCore/Services/Notifications/NotificationCatalog.cs
@@ -6,7 +6,21 @@ public static class NotificationCatalog
     public const string TipoSuccess = "success";
     public const string TipoWarning = "warning";
 
-    public static string EmailResultadoEvaluacion(string nombreUsuario, string nombreFinca, string decision, DateTime fecha, string? observaciones, string? resumenCambios, string? enlaceSistema)
+    
+    public static string EmailBienvenida(string nombreUsuario, string rol, string? enlaceSistema)
+        => ConstruirPlantillaMarca(
+            "Registro de cuenta confirmado",
+            $"""
+<p>Hola {nombreUsuario},</p>
+<p>Tu cuenta en PSA Costa Rica fue creada correctamente.</p>
+<p><strong>Rol asignado:</strong> {rol}</p>
+<p>Ya puedes ingresar al sistema para registrar fincas y dar seguimiento a tus procesos.</p>
+{ConstruirBloqueEnlace(enlaceSistema)}
+<p style='font-size:13px;color:#4b5563;'>Si no realizaste este registro, por favor comunícate con el administrador del sistema.</p>
+<p>PSA Costa Rica</p>
+""");
+
+public static string EmailResultadoEvaluacion(string nombreUsuario, string nombreFinca, string decision, DateTime fecha, string? observaciones, string? resumenCambios, string? enlaceSistema)
     {
         var observacionesTexto = string.IsNullOrWhiteSpace(observaciones) ? "Sin observaciones adicionales." : observaciones.Trim();
         var resumenTexto = string.IsNullOrWhiteSpace(resumenCambios) ? "No se registraron ajustes adicionales." : resumenCambios.Trim();

--- a/PSA.WebAPI/Controllers/AutenticacionController.cs
+++ b/PSA.WebAPI/Controllers/AutenticacionController.cs
@@ -5,7 +5,6 @@ using PSA.DataAccess.DAO;
 using PSA.EntidadesDTO.DTOs;
 using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
 using PSA.EntidadesDTO.DTOs.Usuarios;
-using PSA.WebAPI.Services;
 using PSA.WebAPI.Services.Security;
 
 namespace PSA.WebAPI.Controllers
@@ -14,14 +13,12 @@ namespace PSA.WebAPI.Controllers
     [Route("api/[controller]")]
     public class AutenticacionController(
         AutenticacionManager autenticacionManager,
-        IConfiguration configuration,
         RolPermisoDAO rolPermisoDao,
         UsuarioDAO usuarioDao,
         IJwtTokenService jwtTokenService,
         ISecurityThrottleService securityThrottleService) : BaseApiController
     {
         private readonly AutenticacionManager _autenticacionManager = autenticacionManager;
-        private readonly IConfiguration _configuration = configuration;
         private readonly RolPermisoDAO _rolPermisoDao = rolPermisoDao;
         private readonly UsuarioDAO _usuarioDao = usuarioDao;
         private readonly IJwtTokenService _jwtTokenService = jwtTokenService;
@@ -34,7 +31,6 @@ namespace PSA.WebAPI.Controllers
             try
             {
                 var idUsuario = await _autenticacionManager.RegistrarUsuarioAsync(dto);
-                await IntentarEnviarCorreoBienvenidaAsync(dto);
 
                 return ApiCreated(new
                 {
@@ -166,60 +162,6 @@ namespace PSA.WebAPI.Controllers
             {
                 return ApiValidationError("No fue posible asignar el rol.", ex.Message);
             }
-        }
-
-        private Task IntentarEnviarCorreoBienvenidaAsync(RegistrarUsuarioDTO dto)
-        {
-            try
-            {
-                if (string.IsNullOrWhiteSpace(dto.Email))
-                {
-                    return Task.CompletedTask;
-                }
-
-                var smtp = new SmtpSettingsDTO
-                {
-                    Host = _configuration["SmtpSettings:Host"] ?? string.Empty,
-                    Port = int.TryParse(_configuration["SmtpSettings:Port"], out var port) ? port : 587,
-                    EnableSsl = !bool.TryParse(_configuration["SmtpSettings:EnableSsl"], out var ssl) || ssl,
-                    FromName = _configuration["SmtpSettings:FromName"] ?? string.Empty,
-                    FromEmail = _configuration["SmtpSettings:FromEmail"] ?? string.Empty,
-                    Username = _configuration["SmtpSettings:Username"] ?? string.Empty,
-                    Password = _configuration["SmtpSettings:Password"] ?? string.Empty
-                };
-
-                var smtpConfigurado = !string.IsNullOrWhiteSpace(smtp.Host)
-                    && !string.IsNullOrWhiteSpace(smtp.FromEmail)
-                    && !string.IsNullOrWhiteSpace(smtp.Username)
-                    && !string.IsNullOrWhiteSpace(smtp.Password);
-
-                if (!smtpConfigurado)
-                {
-                    return Task.CompletedTask;
-                }
-
-                var webAppBaseUrl = _configuration["AppSettings:WebAppBaseUrl"]?.TrimEnd('/');
-                var baseUrl = string.IsNullOrWhiteSpace(webAppBaseUrl)
-                    ? "https://localhost:59664"
-                    : webAppBaseUrl;
-                var urlLogin = $"{baseUrl}/Autenticacion/IniciarSesion";
-                var nombreUsuario = string.IsNullOrWhiteSpace(dto.NombreCompleto) ? "usuario" : dto.NombreCompleto.Trim();
-                var rol = "Dueño de finca";
-
-                var correoService = new CorreoService(smtp);
-                correoService.EnviarCorreoBienvenida(
-                    dto.Email.Trim(),
-                    nombreUsuario,
-                    rol,
-                    urlLogin
-                );
-            }
-            catch
-            {
-                // No se bloquea el registro si falla el correo de bienvenida.
-            }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -52,7 +52,7 @@ builder.Services.AddAuthentication(options =>
         jwtKey = "development-placeholder-key-not-for-production";
     }
 
-    var keyBytes = Encoding.UTF8.GetBytes(jwtKey);
+    var keyBytes = Encoding.UTF8.GetBytes(jwtKey ?? string.Empty);
     options.TokenValidationParameters = new TokenValidationParameters
     {
         ValidateIssuerSigningKey = true,

--- a/PSA.WebApp/Controllers/AdministracionController.cs
+++ b/PSA.WebApp/Controllers/AdministracionController.cs
@@ -8,7 +8,7 @@ using PSA.WebApp.Services;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "1")]
-    public class AdministracionController : Controller
+    public class AdministracionController : AppControllerBase
     {
         private readonly HttpClientService _httpClientService;
 

--- a/PSA.WebApp/Controllers/AppControllerBase.cs
+++ b/PSA.WebApp/Controllers/AppControllerBase.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using PSA.WebApp.Models;
+
+namespace PSA.WebApp.Controllers;
+
+public abstract class AppControllerBase : Controller
+{
+    private static readonly Dictionary<string, (string Label, string Action)> Modulos = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Administracion"] = ("Administración", "GestionUsuarios"),
+        ["Fincas"] = ("Fincas", "MisFincas"),
+        ["Evaluaciones"] = ("Evaluaciones", "Pendientes"),
+        ["Pagos"] = ("Pagos", "PlanesPago"),
+        ["Reportes"] = ("Reportes", "Index"),
+        ["MiPerfil"] = ("Mi perfil", "Index"),
+        ["Notificaciones"] = ("Notificaciones", "Index")
+    };
+
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        base.OnActionExecuting(context);
+
+        if (!(User?.Identity?.IsAuthenticated ?? false))
+        {
+            return;
+        }
+
+        var controller = (context.RouteData.Values["controller"]?.ToString() ?? string.Empty).Trim();
+        var action = (context.RouteData.Values["action"]?.ToString() ?? string.Empty).Trim();
+
+        var titulo = ViewBag.TituloPagina as string
+            ?? ViewBag.BreadcrumbActual as string
+            ?? ViewData["Title"]?.ToString()
+            ?? Humanizar(action);
+
+        ViewBag.TituloPagina = titulo;
+
+        var inicioAccion = ViewBag.BreadcrumbInicioAccion as string ?? ResolverInicioPorRol();
+        var inicioControlador = ViewBag.BreadcrumbInicioControlador as string ?? "Dashboard";
+        var inicioTexto = ViewBag.BreadcrumbInicioTexto as string ?? "Inicio";
+
+        var breadcrumbs = new List<BreadcrumbItemViewModel>
+        {
+            new() { Label = inicioTexto, Url = Url.Action(inicioAccion, inicioControlador) }
+        };
+
+        var padreTexto = (ViewBag.BreadcrumbPadreTexto as string)?.Trim();
+        var padreUrl = (ViewBag.BreadcrumbPadreUrl as string)?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(padreTexto))
+        {
+            breadcrumbs.Add(new BreadcrumbItemViewModel { Label = padreTexto, Url = padreUrl });
+        }
+        else if (Modulos.TryGetValue(controller, out var modulo) && !controller.Equals("Dashboard", StringComparison.OrdinalIgnoreCase))
+        {
+            breadcrumbs.Add(new BreadcrumbItemViewModel
+            {
+                Label = modulo.Label,
+                Url = Url.Action(modulo.Action, controller)
+            });
+        }
+
+        breadcrumbs.Add(new BreadcrumbItemViewModel
+        {
+            Label = (ViewBag.BreadcrumbActual as string ?? titulo).Trim(),
+            IsCurrent = true
+        });
+
+        ViewBag.BreadcrumbItems = breadcrumbs;
+    }
+
+    private string ResolverInicioPorRol()
+    {
+        var rol = User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value;
+        return rol switch
+        {
+            "1" => "Administrador",
+            "3" => "Ingeniero",
+            _ => "Dueno"
+        };
+    }
+
+    private static string Humanizar(string texto)
+    {
+        if (string.IsNullOrWhiteSpace(texto))
+        {
+            return "Página";
+        }
+
+        return string.Concat(texto.Select((c, i) => i > 0 && char.IsUpper(c) ? $" {c}" : c.ToString())).Trim();
+    }
+}

--- a/PSA.WebApp/Controllers/AutenticacionController.cs
+++ b/PSA.WebApp/Controllers/AutenticacionController.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization;
 
 namespace PSA.WebApp.Controllers
 {
-    public class AutenticacionController : Controller
+    public class AutenticacionController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/AuthController.cs
+++ b/PSA.WebApp/Controllers/AuthController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace PSA.WebApp.Controllers
 {
-    public class AuthController : Controller
+    public class AuthController : AppControllerBase
     {
         [HttpGet]
         public IActionResult Login()

--- a/PSA.WebApp/Controllers/DashboardController.cs
+++ b/PSA.WebApp/Controllers/DashboardController.cs
@@ -8,7 +8,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers
 {
     [Authorize]
-    public class DashboardController : Controller
+    public class DashboardController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -12,7 +12,7 @@ using System.Text.Json;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "3")]
-    public class EvaluacionesController : Controller
+    public class EvaluacionesController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/FincasController.cs
+++ b/PSA.WebApp/Controllers/FincasController.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "2")]
-    public class FincasController : Controller
+    public class FincasController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/HomeController.cs
+++ b/PSA.WebApp/Controllers/HomeController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace PSA.WebApp.Controllers
 {
-    public class HomeController : Controller
+    public class HomeController : AppControllerBase
     {
         public IActionResult Index()
         {

--- a/PSA.WebApp/Controllers/MiPerfilController.cs
+++ b/PSA.WebApp/Controllers/MiPerfilController.cs
@@ -8,7 +8,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "1,2,3")]
-    public class MiPerfilController : Controller
+    public class MiPerfilController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/NotificacionesController.cs
+++ b/PSA.WebApp/Controllers/NotificacionesController.cs
@@ -8,7 +8,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers
 {
     [Authorize(Roles = "1,2,3")]
-    public class NotificacionesController : Controller
+    public class NotificacionesController : AppControllerBase
     {
         private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Controllers/PagosController.cs
+++ b/PSA.WebApp/Controllers/PagosController.cs
@@ -7,7 +7,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers
 {
     [Authorize]
-    public class PagosController : Controller
+    public class PagosController : AppControllerBase
     {
         private readonly HttpClientService _httpClientService;
 

--- a/PSA.WebApp/Controllers/ReportesController.cs
+++ b/PSA.WebApp/Controllers/ReportesController.cs
@@ -7,7 +7,7 @@ using System.Security.Claims;
 namespace PSA.WebApp.Controllers;
 
 [Authorize(Roles = "1,2,3")]
-public class ReportesController : Controller
+public class ReportesController : AppControllerBase
 {
     private readonly IHttpClientFactory _httpClientFactory;
 

--- a/PSA.WebApp/Models/BreadcrumbItemViewModel.cs
+++ b/PSA.WebApp/Models/BreadcrumbItemViewModel.cs
@@ -1,0 +1,8 @@
+namespace PSA.WebApp.Models;
+
+public class BreadcrumbItemViewModel
+{
+    public required string Label { get; init; }
+    public string? Url { get; init; }
+    public bool IsCurrent { get; init; }
+}

--- a/PSA.WebApp/PSA.WebApp.csproj
+++ b/PSA.WebApp/PSA.WebApp.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Remove="bin\**\*.cs;obj\**\*.cs" />
+    <Compile Include="Controllers\AppControllerBase.cs" />
     <Compile Include="Controllers\AdministracionController.cs" />
     <Compile Include="Controllers\AutenticacionController.cs" />
     <Compile Include="Controllers\DashboardController.cs" />
@@ -22,6 +23,7 @@
     <Compile Include="Controllers\ReportesController.cs" />
     <Compile Include="Models\DashboardViewModels.cs" />
     <Compile Include="Models\AdministracionViewModels.cs" />
+    <Compile Include="Models\BreadcrumbItemViewModel.cs" />
     <Compile Include="Models\MiPerfilViewModel.cs" />
     <Compile Include="Models\EvaluacionesViewModels.cs" />
     <Compile Include="Models\ReportesViewModels.cs" />

--- a/PSA.WebApp/Views/Pagos/DetallePlanPagoAdmin.cshtml
+++ b/PSA.WebApp/Views/Pagos/DetallePlanPagoAdmin.cshtml
@@ -1,9 +1,159 @@
 @model PSA.EntidadesDTO.DTOs.Pagos.AdminPaymentPlanDetailDto
-@{ ViewData["Title"] = "Detalle del plan"; var c = Model.Calculo; }
+@{
+    ViewData["Title"] = "Detalle del plan";
+    var c = Model.Calculo;
+    var subtotalBruto = c.MontoBaseMensual + c.MontoAjusteBrutoMensual;
+}
+
 <section class="seccion-pagina">
-<div class="cabecera-pagina"><div><span class="eyebrow">Plan #@Model.Plan.IdPlanPago</span><h2>@Model.Plan.NombreFinca (@Model.Plan.Anio)</h2></div><a class="boton-secundario" asp-action="PlanesPago">Volver</a></div>
-<section class="tarjeta-panel"><h3>Sección 1 — Datos base</h3><ul class="lista-timeline"><li>Finca: @Model.Plan.NombreFinca</li><li>Propietario: @Model.Plan.Propietario</li><li>Estado plan: @Model.Plan.EstadoPlan</li><li>Ingeniero: @Model.Plan.Ingeniero</li><li>Estado bancario: @Model.Plan.EstadoBancario (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</li></ul></section>
-<section class="tarjeta-panel"><h3>Sección 2 — Datos aplicados</h3><ul class="lista-timeline"><li>Hectáreas aprobadas: @c.HectareasAprobadas.ToString("N2")</li><li>Vegetación final: @c.VegetacionFinal</li><li>Ríos/quebradas: @(c.TieneRiosOQuebradasFinal?"Sí":"No")</li><li>Nacientes: @c.CantidadNacientesFinal</li><li>Pendiente final: @c.PendienteFinal</li><li>Precio base por hectárea: ₡@c.PrecioBasePorHectarea.ToString("N2")</li></ul></section>
-<section class="tarjeta-panel"><h3>Sección 3 — Desglose técnico</h3><ul class="lista-timeline"><li>Base: ₡@c.MontoBaseMensual.ToString("N2")</li><li>Vegetación (@c.PorcentajeVegetacion.ToString("N2")%): ₡@c.MontoAjusteVegetacion.ToString("N2")</li><li>Ríos/quebradas (@c.PorcentajeRiosQuebradas.ToString("N2")%): ₡@c.MontoAjusteRiosQuebradas.ToString("N2")</li><li>Nacientes (@c.CantidadNacientesFinal × 5% = @c.PorcentajeNacientes.ToString("N2")%): ₡@c.MontoAjusteNacientes.ToString("N2")</li><li>Pendiente (@c.PorcentajePendiente.ToString("N2")%): ₡@c.MontoAjustePendiente.ToString("N2")</li><li>Porcentaje bruto: @c.PorcentajeTotalAntesTope.ToString("N2")%</li><li>Tope: @c.PorcentajeTopeAplicado.ToString("N2")%</li><li>Aplicado: @c.PorcentajeTotalAplicado.ToString("N2")%</li><li><strong>Total mensual: ₡@c.MontoFinalMensual.ToString("N2")</strong></li></ul></section>
-<section class="tarjeta-panel"><h3>Sección 4 — Trazabilidad</h3><ul class="lista-timeline"><li>Vegetación original/final: @c.VegetacionOriginal / @c.VegetacionFinal</li><li>Ríos original/final: @(c.TieneRiosOQuebradasOriginal?"Sí":"No") / @(c.TieneRiosOQuebradasFinal?"Sí":"No")</li><li>Nacientes original/final: @c.CantidadNacientesOriginal / @c.CantidadNacientesFinal</li><li>Pendiente original/final: @c.PendienteOriginal / @c.PendienteFinal</li></ul></section>
+    <div class="cabecera-pagina">
+        <div>
+            <span class="eyebrow">Plan #@Model.Plan.IdPlanPago</span>
+            <h2>@Model.Plan.NombreFinca (@Model.Plan.Anio)</h2>
+            <p class="texto-secundario">Detalle administrativo y técnico del cálculo aplicado al plan.</p>
+        </div>
+        <a class="boton-secundario" asp-action="PlanesPago">Volver</a>
+    </div>
+
+    <section class="tarjeta-panel">
+        <h3>Datos base del plan</h3>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Rubro</th>
+                        <th>Valor</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td>Finca</td><td>@Model.Plan.NombreFinca</td></tr>
+                    <tr><td>Propietario</td><td>@Model.Plan.Propietario</td></tr>
+                    <tr><td>Ingeniero</td><td>@Model.Plan.Ingeniero</td></tr>
+                    <tr><td>Estado del plan</td><td>@Model.Plan.EstadoPlan</td></tr>
+                    <tr><td>Estado bancario</td><td>@Model.Plan.EstadoBancario (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</td></tr>
+                    <tr><td>Monto mensual</td><td>₡@Model.Plan.MontoMensual.ToString("N2")</td></tr>
+                    <tr><td>Monto anual</td><td>₡@Model.Plan.MontoAnual.ToString("N2")</td></tr>
+                    <tr><td>Versión de configuración</td><td>@Model.Plan.VersionConfiguracion</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="tarjeta-panel">
+        <h3>Datos usados para cálculo</h3>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Rubro</th>
+                        <th>Valor original</th>
+                        <th>Valor aplicado</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td>Hectáreas</td><td>@c.HectareasOriginales.ToString("N2")</td><td>@c.HectareasAprobadas.ToString("N2")</td></tr>
+                    <tr><td>Vegetación</td><td>@c.VegetacionOriginal</td><td>@c.VegetacionFinal</td></tr>
+                    <tr><td>Ríos/quebradas</td><td>@(c.TieneRiosOQuebradasOriginal ? "Sí" : "No")</td><td>@(c.TieneRiosOQuebradasFinal ? "Sí" : "No")</td></tr>
+                    <tr><td>Nacientes</td><td>@c.CantidadNacientesOriginal</td><td>@c.CantidadNacientesFinal</td></tr>
+                    <tr><td>Pendiente</td><td>@c.PendienteOriginal</td><td>@c.PendienteFinal</td></tr>
+                    <tr><td>Precio base por hectárea</td><td>-</td><td>₡@c.PrecioBasePorHectarea.ToString("N2")</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="tarjeta-panel">
+        <h3>Desglose progresivo del cálculo</h3>
+        <p class="texto-secundario">Los ajustes se aplican sobre el monto base mensual, calculado como <strong>hectáreas aprobadas × precio base por hectárea</strong>.</p>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Rubro</th>
+                        <th>Detalle</th>
+                        <th>Monto</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td>Base por hectáreas</td><td>@c.HectareasAprobadas.ToString("N2") × ₡@c.PrecioBasePorHectarea.ToString("N2")</td><td>₡@c.MontoBaseMensual.ToString("N2")</td></tr>
+                    <tr><td>Ajuste por vegetación</td><td>@c.PorcentajeVegetacion.ToString("N2")%</td><td>₡@c.MontoAjusteVegetacion.ToString("N2")</td></tr>
+                    <tr><td>Ajuste por ríos/quebradas</td><td>@c.PorcentajeRiosQuebradas.ToString("N2")%</td><td>₡@c.MontoAjusteRiosQuebradas.ToString("N2")</td></tr>
+                    <tr><td>Ajuste por nacientes</td><td>@c.CantidadNacientesFinal × 5% = @c.PorcentajeNacientes.ToString("N2")%</td><td>₡@c.MontoAjusteNacientes.ToString("N2")</td></tr>
+                    <tr><td>Ajuste por pendiente</td><td>@c.PorcentajePendiente.ToString("N2")%</td><td>₡@c.MontoAjustePendiente.ToString("N2")</td></tr>
+                    <tr><td><strong>Subtotal con ajuste bruto</strong></td><td>@c.PorcentajeTotalAntesTope.ToString("N2")% sobre base</td><td><strong>₡@subtotalBruto.ToString("N2")</strong></td></tr>
+                    @if (c.PorcentajeTotalAntesTope > c.PorcentajeTotalAplicado)
+                    {
+                        <tr><td>Aplicación de tope administrativo</td><td>Bruto @c.PorcentajeTotalAntesTope.ToString("N2")% limitado a @c.PorcentajeTotalAplicado.ToString("N2")%</td><td>-₡@c.MontoRecortadoPorTope.ToString("N2")</td></tr>
+                    }
+                    <tr><td><strong>Total mensual calculado</strong></td><td>Ajuste aplicado @c.PorcentajeTotalAplicado.ToString("N2")%</td><td><strong>₡@c.MontoFinalMensual.ToString("N2")</strong></td></tr>
+                    <tr><td>Equivalente anual estimado</td><td>12 cuotas mensuales</td><td>₡@Model.Plan.MontoAnual.ToString("N2")</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="tarjeta-panel">
+        <h3>Cuotas mensuales</h3>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Periodo</th>
+                        <th>Estado</th>
+                        <th>Programada</th>
+                        <th>Ejecución</th>
+                        <th>Monto</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var cuota in Model.Cuotas)
+                    {
+                        <tr>
+                            <td>@Model.Plan.Anio-@cuota.Mes.ToString("00")</td>
+                            <td>@cuota.EstadoCuota</td>
+                            <td>@cuota.FechaProgramada.ToString("dd/MM/yyyy")</td>
+                            <td>@(cuota.FechaPago?.ToString("dd/MM/yyyy") ?? "Pendiente")</td>
+                            <td>₡@cuota.MontoProgramado.ToString("N2")</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="tarjeta-panel">
+        <h3>Bitácora reciente</h3>
+        <div class="tabla-responsive">
+            <table class="tabla-base">
+                <thead>
+                    <tr>
+                        <th>Fecha</th>
+                        <th>Acción</th>
+                        <th>Detalle</th>
+                        <th>Usuario</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if (Model.Bitacora.Any())
+                    {
+                        @foreach (var evento in Model.Bitacora)
+                        {
+                            <tr>
+                                <td>@evento.FechaAccion.ToString("dd/MM/yyyy HH:mm")</td>
+                                <td>@evento.Accion</td>
+                                <td>@(string.IsNullOrWhiteSpace(evento.Detalle) ? "Sin detalle" : evento.Detalle)</td>
+                                <td>@(evento.IdUsuario?.ToString() ?? "N/D")</td>
+                            </tr>
+                        }
+                    }
+                    else
+                    {
+                        <tr>
+                            <td colspan="4" class="texto-secundario">No hay eventos de auditoría para este plan.</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </section>
 </section>

--- a/PSA.WebApp/Views/Shared/_MigasPan.cshtml
+++ b/PSA.WebApp/Views/Shared/_MigasPan.cshtml
@@ -1,18 +1,45 @@
+@using PSA.WebApp.Models
 @{
-    var inicioTexto = ViewBag.BreadcrumbInicioTexto as string ?? "Inicio";
-    var inicioControlador = ViewBag.BreadcrumbInicioControlador as string ?? "Dashboard";
-    var inicioAccion = ViewBag.BreadcrumbInicioAccion as string ?? "Index";
-    var padreTexto = ViewBag.BreadcrumbPadreTexto as string;
-    var padreUrl = ViewBag.BreadcrumbPadreUrl as string;
-    var actual = ViewBag.BreadcrumbActual as string ?? ViewBag.TituloPagina as string ?? "Página";
-}
-<nav class="migas-pan" aria-label="Migas de pan">
-    <a asp-controller="@inicioControlador" asp-action="@inicioAccion">@inicioTexto</a>
-    @if (!string.IsNullOrWhiteSpace(padreTexto) && !string.IsNullOrWhiteSpace(padreUrl))
+    var items = ViewBag.BreadcrumbItems as IEnumerable<BreadcrumbItemViewModel>;
+
+    if (items == null || !items.Any())
     {
-        <span>/</span>
-        <a href="@padreUrl">@padreTexto</a>
+        var inicioTexto = ViewBag.BreadcrumbInicioTexto as string ?? "Inicio";
+        var inicioControlador = ViewBag.BreadcrumbInicioControlador as string ?? "Dashboard";
+        var inicioAccion = ViewBag.BreadcrumbInicioAccion as string ?? "Index";
+        var padreTexto = ViewBag.BreadcrumbPadreTexto as string;
+        var padreUrl = ViewBag.BreadcrumbPadreUrl as string;
+        var actual = ViewBag.BreadcrumbActual as string ?? ViewBag.TituloPagina as string ?? "Página";
+
+        var fallback = new List<BreadcrumbItemViewModel>
+        {
+            new() { Label = inicioTexto, Url = Url.Action(inicioAccion, inicioControlador) }
+        };
+
+        if (!string.IsNullOrWhiteSpace(padreTexto))
+        {
+            fallback.Add(new BreadcrumbItemViewModel { Label = padreTexto, Url = padreUrl });
+        }
+
+        fallback.Add(new BreadcrumbItemViewModel { Label = actual, IsCurrent = true });
+        items = fallback;
     }
-    <span>/</span>
-    <span class="actual">@actual</span>
+}
+
+<nav class="migas-pan" aria-label="Migas de pan">
+    <ol class="migas-pan__lista">
+        @foreach (var item in items)
+        {
+            <li class="migas-pan__item @(item.IsCurrent ? "actual" : string.Empty)">
+                @if (!item.IsCurrent && !string.IsNullOrWhiteSpace(item.Url))
+                {
+                    <a href="@item.Url">@item.Label</a>
+                }
+                else
+                {
+                    <span aria-current="@(item.IsCurrent ? "page" : null)">@item.Label</span>
+                }
+            </li>
+        }
+    </ol>
 </nav>

--- a/PSA.WebApp/wwwroot/css/componentes.css
+++ b/PSA.WebApp/wwwroot/css/componentes.css
@@ -257,18 +257,45 @@ html[data-theme="dark"] .modal-sistema .btn-close {
 }
 
 .migas-pan {
-    display: flex;
-    align-items: center;
-    gap: var(--espacio-2);
     margin-bottom: var(--espacio-5);
     color: var(--color-texto-secundario);
     font-size: 0.92rem;
 }
 
-    .migas-pan .actual {
-        color: var(--color-texto-principal);
-        font-weight: 700;
-    }
+.migas-pan__lista {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--espacio-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.migas-pan__item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--espacio-2);
+}
+
+.migas-pan__item + .migas-pan__item::before {
+    content: "/";
+    color: var(--color-texto-secundario);
+}
+
+.migas-pan__item a {
+    color: var(--color-primario);
+    text-decoration: none;
+}
+
+.migas-pan__item a:hover {
+    text-decoration: underline;
+}
+
+.migas-pan__item.actual {
+    color: var(--color-texto-principal);
+    font-weight: 700;
+}
 
 .estado-vacio,
 .estado-vacio-inline {


### PR DESCRIPTION
### Motivation
- Enviar notificaciones por correo al crear usuarios para mejorar la experiencia de registro y centralizar plantillas de notificación.
- Centralizar la lógica común de controladores de la WebApp (títulos y migas de pan) para reducir duplicación y facilitar la construcción de breadcrumbs.
- Modernizar la vista de detalle de planes de pago y asegurar manejo seguro del `jwtKey` al inicializar la autenticación.

### Description
- Agrega envío de correo de bienvenida usando `INotificationDispatcher` en `AutenticacionManager.RegistrarUsuarioAsync` y en `AdministracionManager.CrearUsuarioAsync`, y añade la plantilla `NotificationCatalog.EmailBienvenida` para el contenido del correo.
- Introduce `INotificationDispatcher` en los constructores y registra las notificaciones desde los managers, eliminando la implementación local de SMTP removida de `AutenticacionController`.
- Crea `AppControllerBase` con lógica de generación de `ViewBag` y breadcrumbs, añade `BreadcrumbItemViewModel`, actualiza varios controladores para heredar de `AppControllerBase`, y adapta `_MigasPan.cshtml` y estilos CSS en `componentes.css` para soportar la nueva estructura de migas de pan.
- Reescribe la vista `DetallePlanPagoAdmin.cshtml` para presentar un desglose más claro y tablas responsivas del cálculo y bitácora, y actualiza el `.csproj` para incluir los nuevos archivos.
- Ajusta `Program.cs` para convertir el `jwtKey` a bytes de forma segura con `Encoding.UTF8.GetBytes(jwtKey ?? string.Empty)` evitando potenciales `null`.

### Testing
- Ejecuté compilación del repositorio con `dotnet build`, la cual finalizó correctamente.
- Ejecuté los tests automatizados con `dotnet test` (si existen) y la tarea completó sin errores.
- Realicé un arranque de humo local de la WebApp (`dotnet run`) y verifiqué que las páginas principales y la nueva vista de detalle de plan se renderizan sin excepciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9667379f8832db0a018c66e010a8d)