### PR TITLE
docs: guía paso a paso para reactivar correos SMTP en Azure

### DIFF
--- a/docs/deploy-azure-cicd.md
+++ b/docs/deploy-azure-cicd.md
@@ -159,3 +159,13 @@ Si alguno viene `NULL`, re-ejecutar `Azure/01_creacion_tablas_azure_safe.sql` y 
 - **WebApp no consume API**: `ApiSettings__BaseUrl` incorrecta.
 - **Error SQL al arrancar**: cadena `ConnectionStrings__PSAConnection` inválida o firewall SQL.
 - **Deploy falla en Actions**: publish profile vencido o secreto mal nombrado.
+
+
+## 9) Reactivación de correos SMTP en app ya publicada
+
+Si la app ya está desplegada pero olvidaste SMTP, sigue la guía operativa:
+
+- `docs/reactivar-servicio-correos-azure.md`
+
+Resumen rápido: configurar `SmtpSettings__*` en el App Service de **PSA.WebAPI**, reiniciar y validar flujo de recuperación.
+

--- a/docs/reactivar-servicio-correos-azure.md
+++ b/docs/reactivar-servicio-correos-azure.md
@@ -1,0 +1,89 @@
+# Reactivar servicio de correos en Azure (PSA Costa Rica)
+
+Esta guía está orientada a un escenario donde la app ya está publicada en Azure App Service, pero faltó configurar SMTP.
+
+## 1) Confirmar qué componente envía correos
+
+En este repositorio, el envío de recuperación de contraseña ocurre en **PSA.WebAPI** usando `SmtpSettings`.
+
+- Si faltan `Host`, `FromEmail`, `Username` o `Password`, la API lanza error y no envía correos.
+
+## 2) Recolectar datos SMTP del proveedor
+
+Necesitas estos valores antes de tocar Azure:
+
+- Host SMTP
+- Puerto (`587` recomendado con TLS)
+- SSL/TLS habilitado (`true`)
+- Correo remitente (`FromEmail`)
+- Nombre remitente (`FromName`)
+- Usuario SMTP
+- Contraseña SMTP
+
+> Recomendación: usar un remitente del dominio verificado en tu proveedor SMTP.
+
+## 3) Configurar App Settings en Azure App Service de la API
+
+En el portal de Azure:
+
+1. Ir a **App Services**.
+2. Abrir la app de la API (por ejemplo `app-psa-api-prod` o equivalente).
+3. Entrar a **Settings > Environment variables** (o **Configuration** según UI).
+4. En **Application settings**, crear/actualizar:
+
+- `SmtpSettings__Host`
+- `SmtpSettings__Port`
+- `SmtpSettings__EnableSsl`
+- `SmtpSettings__FromName`
+- `SmtpSettings__FromEmail`
+- `SmtpSettings__Username`
+- `SmtpSettings__Password`
+
+5. Guardar cambios (Azure solicitará reinicio).
+
+## 4) Reiniciar la API
+
+Aunque Azure suele reiniciar automáticamente, haz un **Restart** manual del App Service para asegurar carga de variables.
+
+## 5) Validar que la API esté arriba
+
+Validaciones rápidas:
+
+- `GET https://<tu-api>/health`
+- `GET https://<tu-api>/swagger`
+
+Si esto falla, resuelve disponibilidad primero antes de probar correos.
+
+## 6) Probar flujo real de recuperación
+
+1. Desde WebApp, ejecutar “Olvidé mi contraseña”.
+2. Ingresar un correo de usuario existente.
+3. Confirmar recepción del correo.
+4. Validar token y restablecer contraseña.
+
+## 7) Diagnóstico si sigue sin llegar correo
+
+Revisar en **Log stream** de la API:
+
+- Error de SMTP no configurado (faltan claves obligatorias).
+- Error de autenticación SMTP (usuario/clave inválidos).
+- Error TLS/SSL (puerto o política TLS incorrecta).
+
+Checklist rápido:
+
+- `SmtpSettings__Host` correcto.
+- Puerto compatible con tu proveedor (`587` TLS o el que indique).
+- Credenciales vigentes.
+- Remitente autorizado/verificado por el proveedor.
+- No hay reglas anti-spam bloqueando el envío.
+
+## 8) Endurecimiento recomendado (post-reactivación)
+
+- Guardar secretos SMTP en **Azure Key Vault** y referenciarlos desde App Settings.
+- Definir alertas de error de envío (Application Insights).
+- Evitar usar sandbox de correo en producción.
+- Crear un correo técnico de pruebas para smoke test después de cada despliegue.
+
+## 9) Nota de arquitectura de este repositorio
+
+Actualmente los correos salen desde **PSA.WebAPI** (no desde PSA.WebApp en Azure para recuperación de contraseña). Por eso la configuración SMTP crítica debe vivir en el App Service de la API.


### PR DESCRIPTION
### Motivation
- Reactivar el envío de correos cuando la aplicación ya está publicada en Azure pero no se configuraron las credenciales SMTP durante el despliegue.
- Reflejar en la documentación la arquitectura actual donde los correos de recuperación salen desde `PSA.WebAPI` y dependen de `SmtpSettings` en App Settings.

### Description
- Agrega `docs/reactivar-servicio-correos-azure.md` con un procedimiento operativo paso a paso para reactivar SMTP en un App Service publicado.
- Actualiza `docs/deploy-azure-cicd.md` añadiendo una sección que referencia la nueva guía de reactivación.
- La guía documenta las claves necesarias (`SmtpSettings__Host`, `SmtpSettings__Port`, `SmtpSettings__EnableSsl`, `SmtpSettings__FromName`, `SmtpSettings__FromEmail`, `SmtpSettings__Username`, `SmtpSettings__Password`), pasos para reiniciar el App Service y validaciones (`/health`, `/swagger`) y diagnóstico en logs.

### Testing
- No se ejecutaron pruebas automatizadas porque el cambio es únicamente documental.
- Se validó el cambio con inspecciones de repo (`rg`/`git diff`) y el commit fue realizado correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab1a31ac4832d945a9047e16eb1e9)