### PR TITLE
Add SMTP resolver and logging; harden password-recovery flow and improve webapp auth redirects

### DIFF
--- a/PSA.WebAPI/Controllers/RecuperacionContrasenaController.cs
+++ b/PSA.WebAPI/Controllers/RecuperacionContrasenaController.cs
@@ -10,10 +10,12 @@ namespace PSA.WebAPI.Controllers
     [ApiController]
     public class RecuperacionContrasenaController(
         RecuperacionContrasenaManager manager,
-        ISecurityThrottleService securityThrottleService) : BaseApiController
+        ISecurityThrottleService securityThrottleService,
+        ILogger<RecuperacionContrasenaController> logger) : BaseApiController
     {
         private readonly RecuperacionContrasenaManager _manager = manager;
         private readonly ISecurityThrottleService _securityThrottleService = securityThrottleService;
+        private readonly ILogger<RecuperacionContrasenaController> _logger = logger;
 
         [HttpPost("solicitar")]
         public async Task<IActionResult> SolicitarRecuperacion([FromBody] RecuperarContrasenaDTO dto)
@@ -44,11 +46,13 @@ namespace PSA.WebAPI.Controllers
             }
             catch (InvalidOperationException ex)
             {
+                _logger.LogWarning(ex, "Fallo controlado al solicitar recuperación para {Correo}", correo);
                 _securityThrottleService.RegisterFailure("password-recovery-request", key);
                 return ApiValidationError("No fue posible procesar la solicitud.", "Si el correo existe y está habilitado, recibirá instrucciones.", ex.Message);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Fallo no controlado al solicitar recuperación para {Correo}", correo);
                 _securityThrottleService.RegisterFailure("password-recovery-request", key);
                 return ApiError(StatusCodes.Status500InternalServerError, "internal_error", "Error al procesar la recuperación.");
             }
@@ -97,8 +101,9 @@ namespace PSA.WebAPI.Controllers
                     Mensaje = mensaje
                 });
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Fallo no controlado al validar token de recuperación para {Email}", email);
                 _securityThrottleService.RegisterFailure("password-recovery-validate", key);
                 return ApiError(StatusCodes.Status500InternalServerError, "internal_error", "Error al validar el token.");
             }
@@ -144,11 +149,13 @@ namespace PSA.WebAPI.Controllers
             }
             catch (InvalidOperationException ex)
             {
+                _logger.LogWarning(ex, "Fallo controlado al restablecer contraseña para {Email}", email);
                 _securityThrottleService.RegisterFailure("password-recovery-reset", key);
                 return ApiValidationError("No fue posible restablecer la contraseña.", ex.Message);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Fallo no controlado al restablecer contraseña para {Email}", email);
                 _securityThrottleService.RegisterFailure("password-recovery-reset", key);
                 return ApiError(StatusCodes.Status500InternalServerError, "internal_error", "Error al restablecer la contraseña.");
             }

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -29,6 +29,7 @@
     <Compile Include="Controllers\RecuperacionContrasenaController.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="CorreoService.cs" />
+    <Compile Include="Services\SmtpSettingsResolver.cs" />
     <Compile Include="Services\SmtpNotificationEmailSender.cs" />
     <Compile Include="Services\PasswordRecoveryServices.cs" />
     <Compile Include="Services\Security\JwtTokenService.cs" />

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -214,6 +214,13 @@ static void ValidarConfiguracionCritica(IConfiguration configuration, IHostEnvir
     {
         throw new InvalidOperationException("Falta configurar Cors:AllowedOrigins para ambiente Production.");
     }
+
+    var smtp = SmtpSettingsResolver.Resolve(configuration);
+    var missingSmtpKeys = SmtpSettingsResolver.GetMissingRequiredKeys(smtp);
+    if (missingSmtpKeys.Count > 0)
+    {
+        Console.Error.WriteLine($"[CONFIG] SMTP incompleto para Production. Variables faltantes: {string.Join(", ", missingSmtpKeys)}");
+    }
 }
 
 static void AsegurarCarpetasCarga(IHostEnvironment environment)

--- a/PSA.WebAPI/Services/PasswordRecoveryServices.cs
+++ b/PSA.WebAPI/Services/PasswordRecoveryServices.cs
@@ -1,5 +1,6 @@
 using PSA.AppCore.Services.Security;
 using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
+using System.Net.Mail;
 
 namespace PSA.WebAPI.Services;
 
@@ -36,25 +37,11 @@ public class PasswordRecoveryEmailSender : IPasswordRecoveryEmailSender
 
     public async Task SendRecoveryEmailAsync(string destino, string nombreUsuario, string token, DateTime fechaExpiracion)
     {
-        var smtp = new SmtpSettingsDTO
+        var smtp = SmtpSettingsResolver.Resolve(_configuration);
+        var missingKeys = SmtpSettingsResolver.GetMissingRequiredKeys(smtp);
+        if (missingKeys.Count > 0)
         {
-            Host = _configuration["SmtpSettings:Host"] ?? string.Empty,
-            Port = int.TryParse(_configuration["SmtpSettings:Port"], out var port) ? port : 587,
-            EnableSsl = bool.TryParse(_configuration["SmtpSettings:EnableSsl"], out var ssl) ? ssl : true,
-            FromName = _configuration["SmtpSettings:FromName"] ?? string.Empty,
-            FromEmail = _configuration["SmtpSettings:FromEmail"] ?? string.Empty,
-            Username = _configuration["SmtpSettings:Username"] ?? string.Empty,
-            Password = _configuration["SmtpSettings:Password"] ?? string.Empty
-        };
-
-        var smtpConfigurado = !string.IsNullOrWhiteSpace(smtp.Host)
-            && !string.IsNullOrWhiteSpace(smtp.FromEmail)
-            && !string.IsNullOrWhiteSpace(smtp.Username)
-            && !string.IsNullOrWhiteSpace(smtp.Password);
-
-        if (!smtpConfigurado)
-        {
-            _logger.LogError("SMTP no configurado para recuperación de contraseña. Host/FromEmail/Username/Password son obligatorios.");
+            _logger.LogError("SMTP no configurado para recuperación de contraseña. Variables faltantes: {MissingKeys}", string.Join(", ", missingKeys));
             throw new InvalidOperationException("no se pudo enviar el correo de recuperación");
         }
 
@@ -62,6 +49,11 @@ public class PasswordRecoveryEmailSender : IPasswordRecoveryEmailSender
         {
             var correoService = new CorreoService(smtp);
             await correoService.EnviarCorreoRecuperacionAsync(destino, nombreUsuario, token, fechaExpiracion);
+        }
+        catch (SmtpException ex)
+        {
+            _logger.LogError(ex, "SMTP rechazó el correo de recuperación a {Destino}. SmtpStatusCode: {SmtpStatusCode}", destino, ex.StatusCode);
+            throw new InvalidOperationException("no se pudo enviar el correo de recuperación");
         }
         catch (Exception ex)
         {

--- a/PSA.WebAPI/Services/SmtpNotificationEmailSender.cs
+++ b/PSA.WebAPI/Services/SmtpNotificationEmailSender.cs
@@ -1,37 +1,25 @@
 using PSA.AppCore.Services.Notifications;
-using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
 
 namespace PSA.WebAPI.Services;
 
 public class SmtpNotificationEmailSender : INotificationEmailSender
 {
     private readonly IConfiguration _configuration;
+    private readonly ILogger<SmtpNotificationEmailSender> _logger;
 
-    public SmtpNotificationEmailSender(IConfiguration configuration)
+    public SmtpNotificationEmailSender(IConfiguration configuration, ILogger<SmtpNotificationEmailSender> logger)
     {
         _configuration = configuration;
+        _logger = logger;
     }
 
     public Task SendHtmlAsync(string destino, string asunto, string cuerpoHtml)
     {
-        var smtp = new SmtpSettingsDTO
+        var smtp = SmtpSettingsResolver.Resolve(_configuration);
+        var missingKeys = SmtpSettingsResolver.GetMissingRequiredKeys(smtp);
+        if (missingKeys.Count > 0)
         {
-            Host = _configuration["SmtpSettings:Host"] ?? string.Empty,
-            Port = int.TryParse(_configuration["SmtpSettings:Port"], out var port) ? port : 587,
-            EnableSsl = bool.TryParse(_configuration["SmtpSettings:EnableSsl"], out var ssl) ? ssl : true,
-            FromName = _configuration["SmtpSettings:FromName"] ?? string.Empty,
-            FromEmail = _configuration["SmtpSettings:FromEmail"] ?? string.Empty,
-            Username = _configuration["SmtpSettings:Username"] ?? string.Empty,
-            Password = _configuration["SmtpSettings:Password"] ?? string.Empty
-        };
-
-        var smtpConfigurado = !string.IsNullOrWhiteSpace(smtp.Host)
-            && !string.IsNullOrWhiteSpace(smtp.FromEmail)
-            && !string.IsNullOrWhiteSpace(smtp.Username)
-            && !string.IsNullOrWhiteSpace(smtp.Password);
-
-        if (!smtpConfigurado)
-        {
+            _logger.LogWarning("Notificación por correo omitida por configuración SMTP incompleta. Variables faltantes: {MissingKeys}", string.Join(", ", missingKeys));
             return Task.CompletedTask;
         }
 

--- a/PSA.WebAPI/Services/SmtpSettingsResolver.cs
+++ b/PSA.WebAPI/Services/SmtpSettingsResolver.cs
@@ -1,0 +1,62 @@
+using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
+
+namespace PSA.WebAPI.Services;
+
+public static class SmtpSettingsResolver
+{
+    public static SmtpSettingsDTO Resolve(IConfiguration configuration)
+    {
+        var hostRaw = Normalize(configuration["SmtpSettings:Host"]);
+        var portRaw = Normalize(configuration["SmtpSettings:Port"]);
+        var enableSslRaw = Normalize(configuration["SmtpSettings:EnableSsl"]);
+        var fromNameRaw = Normalize(configuration["SmtpSettings:FromName"]);
+        var fromEmailRaw = Normalize(configuration["SmtpSettings:FromEmail"]);
+        var usernameRaw = Normalize(configuration["SmtpSettings:Username"]);
+        var passwordRaw = Normalize(configuration["SmtpSettings:Password"]);
+
+        return new SmtpSettingsDTO
+        {
+            Host = hostRaw,
+            Port = int.TryParse(portRaw, out var port) ? port : 587,
+            EnableSsl = bool.TryParse(enableSslRaw, out var ssl) ? ssl : true,
+            FromName = fromNameRaw,
+            FromEmail = fromEmailRaw,
+            Username = usernameRaw,
+            Password = passwordRaw
+        };
+    }
+
+    public static List<string> GetMissingRequiredKeys(SmtpSettingsDTO smtp)
+    {
+        var missing = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(smtp.Host))
+            missing.Add("SmtpSettings__Host");
+        if (string.IsNullOrWhiteSpace(smtp.FromEmail))
+            missing.Add("SmtpSettings__FromEmail");
+        if (string.IsNullOrWhiteSpace(smtp.Username))
+            missing.Add("SmtpSettings__Username");
+        if (string.IsNullOrWhiteSpace(smtp.Password))
+            missing.Add("SmtpSettings__Password");
+
+        return missing;
+    }
+
+    private static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = value.Trim();
+
+        if ((trimmed.StartsWith('"') && trimmed.EndsWith('"'))
+            || (trimmed.StartsWith('\'') && trimmed.EndsWith('\'')))
+        {
+            trimmed = trimmed[1..^1].Trim();
+        }
+
+        return trimmed;
+    }
+}

--- a/PSA.WebApp/Controllers/AppControllerBase.cs
+++ b/PSA.WebApp/Controllers/AppControllerBase.cs
@@ -70,15 +70,37 @@ public abstract class AppControllerBase : Controller
         ViewBag.BreadcrumbItems = breadcrumbs;
     }
 
-    private string ResolverInicioPorRol()
+    protected bool UsuarioAutenticado => User?.Identity?.IsAuthenticated ?? false;
+
+    protected IActionResult RedirectToRoleDashboard()
     {
-        var rol = User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value;
-        return rol switch
+        return RedirectToAction(GetDashboardActionByRoleClaim(User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value), "Dashboard");
+    }
+
+    protected static string GetDashboardActionByRoleClaim(string? rolClaim)
+    {
+        return rolClaim switch
         {
             "1" => "Administrador",
             "3" => "Ingeniero",
             _ => "Dueno"
         };
+    }
+
+    protected static string GetDashboardActionByRoleId(int idRol)
+    {
+        return idRol switch
+        {
+            1 => "Administrador",
+            3 => "Ingeniero",
+            _ => "Dueno"
+        };
+    }
+
+    private string ResolverInicioPorRol()
+    {
+        var rol = User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value;
+        return GetDashboardActionByRoleClaim(rol);
     }
 
     private static string Humanizar(string texto)

--- a/PSA.WebApp/Controllers/AutenticacionController.cs
+++ b/PSA.WebApp/Controllers/AutenticacionController.cs
@@ -19,16 +19,35 @@ namespace PSA.WebApp.Controllers
             _httpClientFactory = httpClientFactory;
         }
 
-        [HttpGet] public IActionResult IniciarSesion() => View(new InicioSesionDTO());
-        [HttpGet] public IActionResult RegistroUsuario() => View(new RegistrarUsuarioDTO());
-        [HttpGet] public IActionResult RecuperarContrasena() => View(new RecuperarContrasenaDTO());
+        [HttpGet]
+        public IActionResult IniciarSesion(string? returnUrl = null)
+        {
+            if (UsuarioAutenticado)
+            {
+                return RedirectToRoleDashboard();
+            }
+
+            ViewBag.ReturnUrl = returnUrl;
+            return View(new InicioSesionDTO());
+        }
+
+        [HttpGet]
+        public IActionResult RegistroUsuario()
+            => UsuarioAutenticado ? RedirectToRoleDashboard() : View(new RegistrarUsuarioDTO());
+
+        [HttpGet]
+        public IActionResult RecuperarContrasena()
+            => UsuarioAutenticado ? RedirectToRoleDashboard() : View(new RecuperarContrasenaDTO());
+
         [HttpGet]
         public IActionResult ValidarTokenRecuperacion(string? email = null)
-            => View(new ValidarTokenRecuperacionDTO { Email = email ?? string.Empty });
+            => UsuarioAutenticado
+                ? RedirectToRoleDashboard()
+                : View(new ValidarTokenRecuperacionDTO { Email = email ?? string.Empty });
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> IniciarSesion(InicioSesionDTO dto)
+        public async Task<IActionResult> IniciarSesion(InicioSesionDTO dto, string? returnUrl = null)
         {
             if (!ModelState.IsValid) return View(dto);
 
@@ -51,7 +70,11 @@ namespace PSA.WebApp.Controllers
                 }
 
                 await IniciarSesionWebAsync(respuesta);
-                return RedirectToAction(GetDashboardActionByRole(respuesta.IdRol), "Dashboard");
+                if (!string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
+                {
+                    return LocalRedirect(returnUrl);
+                }
+                return RedirectToAction(GetDashboardActionByRoleId(respuesta.IdRol), "Dashboard");
             }
             catch (HttpRequestException)
             {
@@ -95,9 +118,29 @@ namespace PSA.WebApp.Controllers
         public async Task<IActionResult> RecuperarContrasena(RecuperarContrasenaDTO dto)
         {
             if (!ModelState.IsValid) return View(dto);
-            var response = await _httpClientFactory.CreateClient("AuthApi").PostAsJsonAsync("api/RecuperacionContrasena/solicitar", dto);
-            TempData[response.IsSuccessStatusCode ? "MensajeExito" : "MensajeError"] = response.IsSuccessStatusCode ? "Se procesó la solicitud de recuperación." : "No fue posible procesar la solicitud.";
-            return RedirectToAction(nameof(ValidarTokenRecuperacion), new { email = dto.Email });
+            try
+            {
+                var response = await _httpClientFactory.CreateClient("AuthApi").PostAsJsonAsync("api/RecuperacionContrasena/solicitar", dto);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorBody = await response.Content.ReadAsStringAsync();
+                    ModelState.AddModelError(string.Empty, TryReadErrorMessage(errorBody));
+                    return View(dto);
+                }
+
+                TempData["MensajeExito"] = "Si el correo existe y está habilitado, recibirá instrucciones.";
+                return RedirectToAction(nameof(ValidarTokenRecuperacion), new { email = dto.Email });
+            }
+            catch (HttpRequestException)
+            {
+                ModelState.AddModelError(string.Empty, "No se pudo conectar con el API. Verifique la disponibilidad de PSA.WebAPI.");
+                return View(dto);
+            }
+            catch (TaskCanceledException)
+            {
+                ModelState.AddModelError(string.Empty, "El API tardó demasiado en responder. Intente nuevamente.");
+                return View(dto);
+            }
         }
 
         [HttpPost]
@@ -106,13 +149,20 @@ namespace PSA.WebApp.Controllers
         {
             if (!ModelState.IsValid) return View(dto);
             var response = await _httpClientFactory.CreateClient("AuthApi").PostAsJsonAsync("api/RecuperacionContrasena/validar-token", dto);
-            if (!response.IsSuccessStatusCode) { ModelState.AddModelError(string.Empty, "Token inválido."); return View(dto); }
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync();
+                ModelState.AddModelError(string.Empty, TryReadErrorMessage(errorBody));
+                return View(dto);
+            }
             return RedirectToAction(nameof(RestablecerContrasena), new { tokenRecuperacion = dto.Token, email = dto.Email });
         }
 
         [HttpGet]
         public IActionResult RestablecerContrasena(string? tokenRecuperacion = null, string? email = null)
-            => View(new RestablecerContrasenaDTO { Token = tokenRecuperacion ?? string.Empty, Email = email ?? string.Empty });
+            => UsuarioAutenticado
+                ? RedirectToRoleDashboard()
+                : View(new RestablecerContrasenaDTO { Token = tokenRecuperacion ?? string.Empty, Email = email ?? string.Empty });
 
         [HttpPost]
         [ValidateAntiForgeryToken]
@@ -137,8 +187,6 @@ namespace PSA.WebApp.Controllers
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
             return RedirectToAction("Producto", "Home");
         }
-
-        private static string GetDashboardActionByRole(int idRol) => idRol switch { 1 => "Administrador", 2 => "Dueno", 3 => "Ingeniero", _ => "Dueno" };
 
         private async Task IniciarSesionWebAsync(RespuestaInicioSesionDTO respuesta)
         {

--- a/PSA.WebApp/Controllers/HomeController.cs
+++ b/PSA.WebApp/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace PSA.WebApp.Controllers
 {
@@ -6,21 +7,44 @@ namespace PSA.WebApp.Controllers
     {
         public IActionResult Index()
         {
+            if (UsuarioAutenticado)
+            {
+                return RedirectToRoleDashboard();
+            }
+
             return View();
         }
 
         public IActionResult Equipo()
         {
+            if (UsuarioAutenticado)
+            {
+                return RedirectToRoleDashboard();
+            }
+
             return View();
         }
 
         public IActionResult Producto()
         {
+            if (UsuarioAutenticado)
+            {
+                return RedirectToRoleDashboard();
+            }
+
             return View();
         }
 
-        public IActionResult AccessDenied()
+        [Authorize]
+        public IActionResult AccessDenied(string? returnUrl = null)
         {
+            if (!UsuarioAutenticado)
+            {
+                return RedirectToAction("IniciarSesion", "Autenticacion", new { returnUrl });
+            }
+
+            ViewBag.DashboardAction = GetDashboardActionByRoleClaim(User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value);
+            ViewBag.ReturnUrl = returnUrl;
             return View();
         }
     }

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -64,6 +64,17 @@ app.UseStaticFiles();
 app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
+app.Use(async (context, next) =>
+{
+    await next();
+
+    if (context.User.Identity?.IsAuthenticated == true)
+    {
+        context.Response.Headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0";
+        context.Response.Headers["Pragma"] = "no-cache";
+        context.Response.Headers["Expires"] = "0";
+    }
+});
 
 app.MapControllerRoute(
     name: "default",

--- a/PSA.WebApp/Views/Autenticacion/IniciarSesion.cshtml
+++ b/PSA.WebApp/Views/Autenticacion/IniciarSesion.cshtml
@@ -3,6 +3,7 @@
 @{
     Layout = "~/Views/Shared/_LayoutAutenticacion.cshtml";
     ViewData["Title"] = "Iniciar sesión";
+    var returnUrl = ViewBag.ReturnUrl as string;
 }
 <div class="tarjeta-autenticacion">
     @if (TempData["MensajeExito"] is string mensajeExito && !string.IsNullOrWhiteSpace(mensajeExito))
@@ -22,6 +23,10 @@
 
     <form class="formulario-base" id="formularioIniciarSesion" novalidate method="post" asp-controller="Autenticacion" asp-action="IniciarSesion">
         @Html.AntiForgeryToken()
+        @if (!string.IsNullOrWhiteSpace(returnUrl))
+        {
+            <input type="hidden" name="returnUrl" value="@returnUrl" />
+        }
         <div class="campo-formulario">
             <label asp-for="Email">Correo electrónico</label>
             <input asp-for="Email" type="email" placeholder="usuario@correo.com" />

--- a/PSA.WebApp/Views/Home/AccessDenied.cshtml
+++ b/PSA.WebApp/Views/Home/AccessDenied.cshtml
@@ -1,5 +1,6 @@
 @{
     ViewData["Title"] = "Acceso denegado";
+    var dashboardAction = ViewBag.DashboardAction as string ?? "Dueno";
 }
 
 <section class="container py-5">
@@ -7,5 +8,5 @@
         <h2 class="h4 mb-2">Acceso denegado</h2>
         <p class="mb-0">Su sesión está activa, pero su rol actual no tiene permisos para acceder a esta pantalla.</p>
     </div>
-    <a asp-controller="Home" asp-action="Index" class="btn btn-primary">Volver al inicio</a>
+    <a asp-controller="Dashboard" asp-action="@dashboardAction" class="btn btn-primary">Ir a mi inicio</a>
 </section>


### PR DESCRIPTION
### Motivation
- Ensure SMTP configuration is normalized and validated so email features fail fast with informative logs when misconfigured.
- Improve observability and error handling for password recovery operations by adding structured logging and specific handling of controlled and SMTP errors.
- Prevent authenticated users from accessing auth pages and preserve `returnUrl` to improve UX after login.
- Harden production startup checks by warning about missing SMTP keys and prevent caching of authenticated pages.

### Description
- Added `SmtpSettingsResolver` to normalize configuration values and report missing required SMTP keys, and included it in the project file via `PSA.WebAPI.csproj`.
- Updated `PasswordRecoveryEmailSender` to use `SmtpSettingsResolver`, log missing keys, throw on misconfiguration, and handle `SmtpException` with an error log and consistent `InvalidOperationException` response.
- Updated `SmtpNotificationEmailSender` to use the resolver, inject an `ILogger`, and skip sending with a warning when SMTP configuration is incomplete.
- Added `ILogger` to `RecuperacionContrasenaController` and added warning/error logs for controlled and unexpected exceptions in the recovery flows, while maintaining throttle registration and existing API responses.
- Enhanced `Program.cs` to emit a production-time warning to `Console.Error` if SMTP settings are incomplete via `SmtpSettingsResolver.Resolve` and `GetMissingRequiredKeys`.
- Web app changes: added `UsuarioAutenticado`, `RedirectToRoleDashboard`, `GetDashboardActionByRoleClaim`/`GetDashboardActionByRoleId` helpers in `AppControllerBase`; prevent authenticated users from seeing login/registration/recovery pages; added `returnUrl` support to login flow and form; added cache-control headers for authenticated responses in `PSA.WebApp` pipeline; updated `AccessDenied` to require authentication and link to role dashboard.

### Testing
- Built the projects with `dotnet build` for `PSA.WebAPI` and `PSA.WebApp`, and the build completed successfully.
- Ran `dotnet test` for the solution and no automated tests were discovered to execute (no test failures reported).
- Verified the solution compiles and the code paths for missing SMTP configuration log warnings as expected during application startup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eade376d18832d853be39b2ab91ad8)