### PR TITLE
Add SMTP resolver & logging, status formatting helper, and auth/caching UX improvements

### DIFF
--- a/PSA.WebAPI/Controllers/RecuperacionContrasenaController.cs
+++ b/PSA.WebAPI/Controllers/RecuperacionContrasenaController.cs
@@ -10,10 +10,12 @@ namespace PSA.WebAPI.Controllers
     [ApiController]
     public class RecuperacionContrasenaController(
         RecuperacionContrasenaManager manager,
-        ISecurityThrottleService securityThrottleService) : BaseApiController
+        ISecurityThrottleService securityThrottleService,
+        ILogger<RecuperacionContrasenaController> logger) : BaseApiController
     {
         private readonly RecuperacionContrasenaManager _manager = manager;
         private readonly ISecurityThrottleService _securityThrottleService = securityThrottleService;
+        private readonly ILogger<RecuperacionContrasenaController> _logger = logger;
 
         [HttpPost("solicitar")]
         public async Task<IActionResult> SolicitarRecuperacion([FromBody] RecuperarContrasenaDTO dto)
@@ -44,11 +46,13 @@ namespace PSA.WebAPI.Controllers
             }
             catch (InvalidOperationException ex)
             {
+                _logger.LogWarning(ex, "Fallo controlado al solicitar recuperación para {Correo}", correo);
                 _securityThrottleService.RegisterFailure("password-recovery-request", key);
                 return ApiValidationError("No fue posible procesar la solicitud.", "Si el correo existe y está habilitado, recibirá instrucciones.", ex.Message);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Fallo no controlado al solicitar recuperación para {Correo}", correo);
                 _securityThrottleService.RegisterFailure("password-recovery-request", key);
                 return ApiError(StatusCodes.Status500InternalServerError, "internal_error", "Error al procesar la recuperación.");
             }
@@ -97,8 +101,9 @@ namespace PSA.WebAPI.Controllers
                     Mensaje = mensaje
                 });
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Fallo no controlado al validar token de recuperación para {Email}", email);
                 _securityThrottleService.RegisterFailure("password-recovery-validate", key);
                 return ApiError(StatusCodes.Status500InternalServerError, "internal_error", "Error al validar el token.");
             }
@@ -144,11 +149,13 @@ namespace PSA.WebAPI.Controllers
             }
             catch (InvalidOperationException ex)
             {
+                _logger.LogWarning(ex, "Fallo controlado al restablecer contraseña para {Email}", email);
                 _securityThrottleService.RegisterFailure("password-recovery-reset", key);
                 return ApiValidationError("No fue posible restablecer la contraseña.", ex.Message);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Fallo no controlado al restablecer contraseña para {Email}", email);
                 _securityThrottleService.RegisterFailure("password-recovery-reset", key);
                 return ApiError(StatusCodes.Status500InternalServerError, "internal_error", "Error al restablecer la contraseña.");
             }

--- a/PSA.WebAPI/PSA.WebAPI.csproj
+++ b/PSA.WebAPI/PSA.WebAPI.csproj
@@ -29,6 +29,7 @@
     <Compile Include="Controllers\RecuperacionContrasenaController.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="CorreoService.cs" />
+    <Compile Include="Services\SmtpSettingsResolver.cs" />
     <Compile Include="Services\SmtpNotificationEmailSender.cs" />
     <Compile Include="Services\PasswordRecoveryServices.cs" />
     <Compile Include="Services\Security\JwtTokenService.cs" />

--- a/PSA.WebAPI/Program.cs
+++ b/PSA.WebAPI/Program.cs
@@ -214,6 +214,13 @@ static void ValidarConfiguracionCritica(IConfiguration configuration, IHostEnvir
     {
         throw new InvalidOperationException("Falta configurar Cors:AllowedOrigins para ambiente Production.");
     }
+
+    var smtp = SmtpSettingsResolver.Resolve(configuration);
+    var missingSmtpKeys = SmtpSettingsResolver.GetMissingRequiredKeys(smtp);
+    if (missingSmtpKeys.Count > 0)
+    {
+        Console.Error.WriteLine($"[CONFIG] SMTP incompleto para Production. Variables faltantes: {string.Join(", ", missingSmtpKeys)}");
+    }
 }
 
 static void AsegurarCarpetasCarga(IHostEnvironment environment)

--- a/PSA.WebAPI/Services/PasswordRecoveryServices.cs
+++ b/PSA.WebAPI/Services/PasswordRecoveryServices.cs
@@ -1,5 +1,6 @@
 using PSA.AppCore.Services.Security;
 using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
+using System.Net.Mail;
 
 namespace PSA.WebAPI.Services;
 
@@ -36,25 +37,11 @@ public class PasswordRecoveryEmailSender : IPasswordRecoveryEmailSender
 
     public async Task SendRecoveryEmailAsync(string destino, string nombreUsuario, string token, DateTime fechaExpiracion)
     {
-        var smtp = new SmtpSettingsDTO
+        var smtp = SmtpSettingsResolver.Resolve(_configuration);
+        var missingKeys = SmtpSettingsResolver.GetMissingRequiredKeys(smtp);
+        if (missingKeys.Count > 0)
         {
-            Host = _configuration["SmtpSettings:Host"] ?? string.Empty,
-            Port = int.TryParse(_configuration["SmtpSettings:Port"], out var port) ? port : 587,
-            EnableSsl = bool.TryParse(_configuration["SmtpSettings:EnableSsl"], out var ssl) ? ssl : true,
-            FromName = _configuration["SmtpSettings:FromName"] ?? string.Empty,
-            FromEmail = _configuration["SmtpSettings:FromEmail"] ?? string.Empty,
-            Username = _configuration["SmtpSettings:Username"] ?? string.Empty,
-            Password = _configuration["SmtpSettings:Password"] ?? string.Empty
-        };
-
-        var smtpConfigurado = !string.IsNullOrWhiteSpace(smtp.Host)
-            && !string.IsNullOrWhiteSpace(smtp.FromEmail)
-            && !string.IsNullOrWhiteSpace(smtp.Username)
-            && !string.IsNullOrWhiteSpace(smtp.Password);
-
-        if (!smtpConfigurado)
-        {
-            _logger.LogError("SMTP no configurado para recuperación de contraseña. Host/FromEmail/Username/Password son obligatorios.");
+            _logger.LogError("SMTP no configurado para recuperación de contraseña. Variables faltantes: {MissingKeys}", string.Join(", ", missingKeys));
             throw new InvalidOperationException("no se pudo enviar el correo de recuperación");
         }
 
@@ -62,6 +49,11 @@ public class PasswordRecoveryEmailSender : IPasswordRecoveryEmailSender
         {
             var correoService = new CorreoService(smtp);
             await correoService.EnviarCorreoRecuperacionAsync(destino, nombreUsuario, token, fechaExpiracion);
+        }
+        catch (SmtpException ex)
+        {
+            _logger.LogError(ex, "SMTP rechazó el correo de recuperación a {Destino}. SmtpStatusCode: {SmtpStatusCode}", destino, ex.StatusCode);
+            throw new InvalidOperationException("no se pudo enviar el correo de recuperación");
         }
         catch (Exception ex)
         {

--- a/PSA.WebAPI/Services/SmtpNotificationEmailSender.cs
+++ b/PSA.WebAPI/Services/SmtpNotificationEmailSender.cs
@@ -1,37 +1,25 @@
 using PSA.AppCore.Services.Notifications;
-using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
 
 namespace PSA.WebAPI.Services;
 
 public class SmtpNotificationEmailSender : INotificationEmailSender
 {
     private readonly IConfiguration _configuration;
+    private readonly ILogger<SmtpNotificationEmailSender> _logger;
 
-    public SmtpNotificationEmailSender(IConfiguration configuration)
+    public SmtpNotificationEmailSender(IConfiguration configuration, ILogger<SmtpNotificationEmailSender> logger)
     {
         _configuration = configuration;
+        _logger = logger;
     }
 
     public Task SendHtmlAsync(string destino, string asunto, string cuerpoHtml)
     {
-        var smtp = new SmtpSettingsDTO
+        var smtp = SmtpSettingsResolver.Resolve(_configuration);
+        var missingKeys = SmtpSettingsResolver.GetMissingRequiredKeys(smtp);
+        if (missingKeys.Count > 0)
         {
-            Host = _configuration["SmtpSettings:Host"] ?? string.Empty,
-            Port = int.TryParse(_configuration["SmtpSettings:Port"], out var port) ? port : 587,
-            EnableSsl = bool.TryParse(_configuration["SmtpSettings:EnableSsl"], out var ssl) ? ssl : true,
-            FromName = _configuration["SmtpSettings:FromName"] ?? string.Empty,
-            FromEmail = _configuration["SmtpSettings:FromEmail"] ?? string.Empty,
-            Username = _configuration["SmtpSettings:Username"] ?? string.Empty,
-            Password = _configuration["SmtpSettings:Password"] ?? string.Empty
-        };
-
-        var smtpConfigurado = !string.IsNullOrWhiteSpace(smtp.Host)
-            && !string.IsNullOrWhiteSpace(smtp.FromEmail)
-            && !string.IsNullOrWhiteSpace(smtp.Username)
-            && !string.IsNullOrWhiteSpace(smtp.Password);
-
-        if (!smtpConfigurado)
-        {
+            _logger.LogWarning("Notificación por correo omitida por configuración SMTP incompleta. Variables faltantes: {MissingKeys}", string.Join(", ", missingKeys));
             return Task.CompletedTask;
         }
 

--- a/PSA.WebAPI/Services/SmtpSettingsResolver.cs
+++ b/PSA.WebAPI/Services/SmtpSettingsResolver.cs
@@ -1,0 +1,62 @@
+using PSA.EntidadesDTO.DTOs.RecuperacionContrasena;
+
+namespace PSA.WebAPI.Services;
+
+public static class SmtpSettingsResolver
+{
+    public static SmtpSettingsDTO Resolve(IConfiguration configuration)
+    {
+        var hostRaw = Normalize(configuration["SmtpSettings:Host"]);
+        var portRaw = Normalize(configuration["SmtpSettings:Port"]);
+        var enableSslRaw = Normalize(configuration["SmtpSettings:EnableSsl"]);
+        var fromNameRaw = Normalize(configuration["SmtpSettings:FromName"]);
+        var fromEmailRaw = Normalize(configuration["SmtpSettings:FromEmail"]);
+        var usernameRaw = Normalize(configuration["SmtpSettings:Username"]);
+        var passwordRaw = Normalize(configuration["SmtpSettings:Password"]);
+
+        return new SmtpSettingsDTO
+        {
+            Host = hostRaw,
+            Port = int.TryParse(portRaw, out var port) ? port : 587,
+            EnableSsl = bool.TryParse(enableSslRaw, out var ssl) ? ssl : true,
+            FromName = fromNameRaw,
+            FromEmail = fromEmailRaw,
+            Username = usernameRaw,
+            Password = passwordRaw
+        };
+    }
+
+    public static List<string> GetMissingRequiredKeys(SmtpSettingsDTO smtp)
+    {
+        var missing = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(smtp.Host))
+            missing.Add("SmtpSettings__Host");
+        if (string.IsNullOrWhiteSpace(smtp.FromEmail))
+            missing.Add("SmtpSettings__FromEmail");
+        if (string.IsNullOrWhiteSpace(smtp.Username))
+            missing.Add("SmtpSettings__Username");
+        if (string.IsNullOrWhiteSpace(smtp.Password))
+            missing.Add("SmtpSettings__Password");
+
+        return missing;
+    }
+
+    private static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = value.Trim();
+
+        if ((trimmed.StartsWith('"') && trimmed.EndsWith('"'))
+            || (trimmed.StartsWith('\'') && trimmed.EndsWith('\'')))
+        {
+            trimmed = trimmed[1..^1].Trim();
+        }
+
+        return trimmed;
+    }
+}

--- a/PSA.WebApp/Controllers/AppControllerBase.cs
+++ b/PSA.WebApp/Controllers/AppControllerBase.cs
@@ -70,15 +70,37 @@ public abstract class AppControllerBase : Controller
         ViewBag.BreadcrumbItems = breadcrumbs;
     }
 
-    private string ResolverInicioPorRol()
+    protected bool UsuarioAutenticado => User?.Identity?.IsAuthenticated ?? false;
+
+    protected IActionResult RedirectToRoleDashboard()
     {
-        var rol = User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value;
-        return rol switch
+        return RedirectToAction(GetDashboardActionByRoleClaim(User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value), "Dashboard");
+    }
+
+    protected static string GetDashboardActionByRoleClaim(string? rolClaim)
+    {
+        return rolClaim switch
         {
             "1" => "Administrador",
             "3" => "Ingeniero",
             _ => "Dueno"
         };
+    }
+
+    protected static string GetDashboardActionByRoleId(int idRol)
+    {
+        return idRol switch
+        {
+            1 => "Administrador",
+            3 => "Ingeniero",
+            _ => "Dueno"
+        };
+    }
+
+    private string ResolverInicioPorRol()
+    {
+        var rol = User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value;
+        return GetDashboardActionByRoleClaim(rol);
     }
 
     private static string Humanizar(string texto)

--- a/PSA.WebApp/Controllers/AutenticacionController.cs
+++ b/PSA.WebApp/Controllers/AutenticacionController.cs
@@ -19,16 +19,35 @@ namespace PSA.WebApp.Controllers
             _httpClientFactory = httpClientFactory;
         }
 
-        [HttpGet] public IActionResult IniciarSesion() => View(new InicioSesionDTO());
-        [HttpGet] public IActionResult RegistroUsuario() => View(new RegistrarUsuarioDTO());
-        [HttpGet] public IActionResult RecuperarContrasena() => View(new RecuperarContrasenaDTO());
+        [HttpGet]
+        public IActionResult IniciarSesion(string? returnUrl = null)
+        {
+            if (UsuarioAutenticado)
+            {
+                return RedirectToRoleDashboard();
+            }
+
+            ViewBag.ReturnUrl = returnUrl;
+            return View(new InicioSesionDTO());
+        }
+
+        [HttpGet]
+        public IActionResult RegistroUsuario()
+            => UsuarioAutenticado ? RedirectToRoleDashboard() : View(new RegistrarUsuarioDTO());
+
+        [HttpGet]
+        public IActionResult RecuperarContrasena()
+            => UsuarioAutenticado ? RedirectToRoleDashboard() : View(new RecuperarContrasenaDTO());
+
         [HttpGet]
         public IActionResult ValidarTokenRecuperacion(string? email = null)
-            => View(new ValidarTokenRecuperacionDTO { Email = email ?? string.Empty });
+            => UsuarioAutenticado
+                ? RedirectToRoleDashboard()
+                : View(new ValidarTokenRecuperacionDTO { Email = email ?? string.Empty });
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> IniciarSesion(InicioSesionDTO dto)
+        public async Task<IActionResult> IniciarSesion(InicioSesionDTO dto, string? returnUrl = null)
         {
             if (!ModelState.IsValid) return View(dto);
 
@@ -51,7 +70,11 @@ namespace PSA.WebApp.Controllers
                 }
 
                 await IniciarSesionWebAsync(respuesta);
-                return RedirectToAction(GetDashboardActionByRole(respuesta.IdRol), "Dashboard");
+                if (!string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
+                {
+                    return LocalRedirect(returnUrl);
+                }
+                return RedirectToAction(GetDashboardActionByRoleId(respuesta.IdRol), "Dashboard");
             }
             catch (HttpRequestException)
             {
@@ -95,9 +118,29 @@ namespace PSA.WebApp.Controllers
         public async Task<IActionResult> RecuperarContrasena(RecuperarContrasenaDTO dto)
         {
             if (!ModelState.IsValid) return View(dto);
-            var response = await _httpClientFactory.CreateClient("AuthApi").PostAsJsonAsync("api/RecuperacionContrasena/solicitar", dto);
-            TempData[response.IsSuccessStatusCode ? "MensajeExito" : "MensajeError"] = response.IsSuccessStatusCode ? "Se procesó la solicitud de recuperación." : "No fue posible procesar la solicitud.";
-            return RedirectToAction(nameof(ValidarTokenRecuperacion), new { email = dto.Email });
+            try
+            {
+                var response = await _httpClientFactory.CreateClient("AuthApi").PostAsJsonAsync("api/RecuperacionContrasena/solicitar", dto);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorBody = await response.Content.ReadAsStringAsync();
+                    ModelState.AddModelError(string.Empty, TryReadErrorMessage(errorBody));
+                    return View(dto);
+                }
+
+                TempData["MensajeExito"] = "Si el correo existe y está habilitado, recibirá instrucciones.";
+                return RedirectToAction(nameof(ValidarTokenRecuperacion), new { email = dto.Email });
+            }
+            catch (HttpRequestException)
+            {
+                ModelState.AddModelError(string.Empty, "No se pudo conectar con el API. Verifique la disponibilidad de PSA.WebAPI.");
+                return View(dto);
+            }
+            catch (TaskCanceledException)
+            {
+                ModelState.AddModelError(string.Empty, "El API tardó demasiado en responder. Intente nuevamente.");
+                return View(dto);
+            }
         }
 
         [HttpPost]
@@ -106,13 +149,20 @@ namespace PSA.WebApp.Controllers
         {
             if (!ModelState.IsValid) return View(dto);
             var response = await _httpClientFactory.CreateClient("AuthApi").PostAsJsonAsync("api/RecuperacionContrasena/validar-token", dto);
-            if (!response.IsSuccessStatusCode) { ModelState.AddModelError(string.Empty, "Token inválido."); return View(dto); }
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync();
+                ModelState.AddModelError(string.Empty, TryReadErrorMessage(errorBody));
+                return View(dto);
+            }
             return RedirectToAction(nameof(RestablecerContrasena), new { tokenRecuperacion = dto.Token, email = dto.Email });
         }
 
         [HttpGet]
         public IActionResult RestablecerContrasena(string? tokenRecuperacion = null, string? email = null)
-            => View(new RestablecerContrasenaDTO { Token = tokenRecuperacion ?? string.Empty, Email = email ?? string.Empty });
+            => UsuarioAutenticado
+                ? RedirectToRoleDashboard()
+                : View(new RestablecerContrasenaDTO { Token = tokenRecuperacion ?? string.Empty, Email = email ?? string.Empty });
 
         [HttpPost]
         [ValidateAntiForgeryToken]
@@ -137,8 +187,6 @@ namespace PSA.WebApp.Controllers
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
             return RedirectToAction("Producto", "Home");
         }
-
-        private static string GetDashboardActionByRole(int idRol) => idRol switch { 1 => "Administrador", 2 => "Dueno", 3 => "Ingeniero", _ => "Dueno" };
 
         private async Task IniciarSesionWebAsync(RespuestaInicioSesionDTO respuesta)
         {

--- a/PSA.WebApp/Controllers/EvaluacionesController.cs
+++ b/PSA.WebApp/Controllers/EvaluacionesController.cs
@@ -264,7 +264,7 @@ namespace PSA.WebApp.Controllers
 
             TempData[resultado.IsSuccessStatusCode ? "MensajeExito" : "MensajeError"] = resultado.IsSuccessStatusCode
                 ? "Plan de pago activado correctamente."
-                : "No fue posible activar el plan. Verifique que esté en PendienteAprobacionFinal y tenga cuenta válida.";
+                : "No fue posible activar el plan. Verifique que esté en Pendiente de Aprobación Final y tenga una cuenta válida.";
 
             return RedirectToAction(nameof(DetalleEvaluacion), new { idEvaluacion });
         }

--- a/PSA.WebApp/Controllers/HomeController.cs
+++ b/PSA.WebApp/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace PSA.WebApp.Controllers
 {
@@ -6,21 +7,44 @@ namespace PSA.WebApp.Controllers
     {
         public IActionResult Index()
         {
+            if (UsuarioAutenticado)
+            {
+                return RedirectToRoleDashboard();
+            }
+
             return View();
         }
 
         public IActionResult Equipo()
         {
+            if (UsuarioAutenticado)
+            {
+                return RedirectToRoleDashboard();
+            }
+
             return View();
         }
 
         public IActionResult Producto()
         {
+            if (UsuarioAutenticado)
+            {
+                return RedirectToRoleDashboard();
+            }
+
             return View();
         }
 
-        public IActionResult AccessDenied()
+        [Authorize]
+        public IActionResult AccessDenied(string? returnUrl = null)
         {
+            if (!UsuarioAutenticado)
+            {
+                return RedirectToAction("IniciarSesion", "Autenticacion", new { returnUrl });
+            }
+
+            ViewBag.DashboardAction = GetDashboardActionByRoleClaim(User?.Claims.FirstOrDefault(c => c.Type.EndsWith("role", StringComparison.OrdinalIgnoreCase))?.Value);
+            ViewBag.ReturnUrl = returnUrl;
             return View();
         }
     }

--- a/PSA.WebApp/Helpers/EstadoDisplayHelper.cs
+++ b/PSA.WebApp/Helpers/EstadoDisplayHelper.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace PSA.WebApp.Helpers;
+
+public static class EstadoDisplayHelper
+{
+    private static readonly Dictionary<string, string> EstadosConocidos = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["EnProceso"] = "En Proceso",
+        ["En_Proceso"] = "En Proceso",
+        ["EnRevision"] = "En Revisión",
+        ["PendienteRevision"] = "Pendiente de Revisión",
+        ["PendienteAprobacion"] = "Pendiente de Aprobación",
+        ["PendienteAprobacionFinal"] = "Pendiente de Aprobación Final",
+        ["PendienteDatosBancarios"] = "Pendiente de Datos Bancarios",
+        ["NoCalifica"] = "No Califica",
+        ["EvaluacionCompletada"] = "Evaluación Completada",
+        ["PlanActivo"] = "Plan Activo",
+        ["PlanVencido"] = "Plan Vencido",
+        ["PlanCompletado"] = "Plan Completado",
+        ["PagoPendiente"] = "Pago Pendiente",
+        ["PagoRealizado"] = "Pago Realizado",
+        ["NoLeida"] = "No Leída",
+        ["Leida"] = "Leída",
+        ["EnMora"] = "En Mora",
+        ["BorradorGenerado"] = "Borrador Generado"
+    };
+
+    public static string FormatearEstado(this string? estado)
+    {
+        if (string.IsNullOrWhiteSpace(estado))
+        {
+            return string.Empty;
+        }
+
+        var valor = estado.Trim();
+        if (EstadosConocidos.TryGetValue(valor, out var conocido))
+        {
+            return conocido;
+        }
+
+        var normalizado = valor.Replace('_', ' ').Replace('-', ' ');
+        normalizado = Regex.Replace(normalizado, "([a-záéíóúñ])([A-ZÁÉÍÓÚÑ])", "$1 $2", RegexOptions.CultureInvariant);
+        normalizado = Regex.Replace(normalizado, "\\s+", " ", RegexOptions.CultureInvariant).Trim();
+
+        if (string.IsNullOrWhiteSpace(normalizado))
+        {
+            return valor;
+        }
+
+        var enMayusculas = normalizado.Equals(normalizado.ToUpperInvariant(), StringComparison.Ordinal);
+        normalizado = enMayusculas ? normalizado.ToLowerInvariant() : normalizado;
+
+        var enTitulo = CultureInfo.GetCultureInfo("es-CR").TextInfo.ToTitleCase(normalizado.ToLowerInvariant());
+        enTitulo = AjustarPalabrasFrecuentes(enTitulo);
+        return enTitulo;
+    }
+
+    private static string AjustarPalabrasFrecuentes(string texto)
+    {
+        return texto
+            .Replace(" De ", " de ", StringComparison.Ordinal)
+            .Replace(" Del ", " del ", StringComparison.Ordinal)
+            .Replace(" Y ", " y ", StringComparison.Ordinal)
+            .Replace(" O ", " o ", StringComparison.Ordinal);
+    }
+}

--- a/PSA.WebApp/PSA.WebApp.csproj
+++ b/PSA.WebApp/PSA.WebApp.csproj
@@ -28,6 +28,7 @@
     <Compile Include="Models\EvaluacionesViewModels.cs" />
     <Compile Include="Models\ReportesViewModels.cs" />
     <Compile Include="Models\NotificacionesViewModel.cs" />
+    <Compile Include="Helpers\EstadoDisplayHelper.cs" />
     <Compile Include="Models\RecuperarContrasenaViewModel.cs" />
     <Compile Include="Models\RestablecerContrasenaViewModel.cs" />
     <Compile Include="Services\HttpClientService.cs" />

--- a/PSA.WebApp/Program.cs
+++ b/PSA.WebApp/Program.cs
@@ -64,6 +64,17 @@ app.UseStaticFiles();
 app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
+app.Use(async (context, next) =>
+{
+    await next();
+
+    if (context.User.Identity?.IsAuthenticated == true)
+    {
+        context.Response.Headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0";
+        context.Response.Headers["Pragma"] = "no-cache";
+        context.Response.Headers["Expires"] = "0";
+    }
+});
 
 app.MapControllerRoute(
     name: "default",

--- a/PSA.WebApp/Views/Administracion/GestionUsuarios.cshtml
+++ b/PSA.WebApp/Views/Administracion/GestionUsuarios.cshtml
@@ -45,7 +45,7 @@
                                 <td>@usuario.Email</td>
                                 <td>@usuario.NombreRol</td>
                                 <td>
-                                    <span class="badge-estado @(activo ? "badge-exito" : "badge-pendiente")">@usuario.Estado</span>
+                                    <span class="badge-estado @(activo ? "badge-exito" : "badge-pendiente")">@usuario.Estado.FormatearEstado()</span>
                                 </td>
                                 <td>@(usuario.UltimoAcceso?.ToString("yyyy-MM-dd HH:mm") ?? "Sin registro")</td>
                                 <td>

--- a/PSA.WebApp/Views/Administracion/ValidacionCuentasBancarias.cshtml
+++ b/PSA.WebApp/Views/Administracion/ValidacionCuentasBancarias.cshtml
@@ -37,7 +37,7 @@
                                 <td>@cuenta.NombreUsuario</td>
                                 <td>@cuenta.Banco</td>
                                 <td>@cuenta.NumeroCuenta</td>
-                                <td><span class="badge-estado @(cuenta.EstadoValidacion == "Pendiente" ? "badge-pendiente" : "badge-activa")">@cuenta.EstadoValidacion</span></td>
+                                <td><span class="badge-estado @(cuenta.EstadoValidacion == "Pendiente" ? "badge-pendiente" : "badge-activa")">@cuenta.EstadoValidacion.FormatearEstado()</span></td>
                                 <td>
                                     @if (cuenta.EstadoValidacion == "Pendiente")
                                     {

--- a/PSA.WebApp/Views/Autenticacion/IniciarSesion.cshtml
+++ b/PSA.WebApp/Views/Autenticacion/IniciarSesion.cshtml
@@ -3,6 +3,7 @@
 @{
     Layout = "~/Views/Shared/_LayoutAutenticacion.cshtml";
     ViewData["Title"] = "Iniciar sesión";
+    var returnUrl = ViewBag.ReturnUrl as string;
 }
 <div class="tarjeta-autenticacion">
     @if (TempData["MensajeExito"] is string mensajeExito && !string.IsNullOrWhiteSpace(mensajeExito))
@@ -22,6 +23,10 @@
 
     <form class="formulario-base" id="formularioIniciarSesion" novalidate method="post" asp-controller="Autenticacion" asp-action="IniciarSesion">
         @Html.AntiForgeryToken()
+        @if (!string.IsNullOrWhiteSpace(returnUrl))
+        {
+            <input type="hidden" name="returnUrl" value="@returnUrl" />
+        }
         <div class="campo-formulario">
             <label asp-for="Email">Correo electrónico</label>
             <input asp-for="Email" type="email" placeholder="usuario@correo.com" />

--- a/PSA.WebApp/Views/Dashboard/Ingeniero.cshtml
+++ b/PSA.WebApp/Views/Dashboard/Ingeniero.cshtml
@@ -99,7 +99,7 @@
                                 <td>#@item.IdEvaluacion</td>
                                 <td>@item.NombreFinca</td>
                                 <td>@item.Provincia, @item.Canton, @item.Distrito</td>
-                                <td>@item.EstadoEvaluacion</td>
+                                <td>@item.EstadoEvaluacion.FormatearEstado()</td>
                                 <td>
                                     <a class="boton-link" asp-controller="Evaluaciones" asp-action="NuevaEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">
                                         @(item.EstadoEvaluacion == "En proceso" ? "Continuar" : "Iniciar")

--- a/PSA.WebApp/Views/Evaluaciones/DetalleEvaluacion.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/DetalleEvaluacion.cshtml
@@ -22,7 +22,7 @@
                 <li>Pendiente: @Model.PendienteOriginal</li>
                 <li>Ríos/Quebradas: @(Model.TieneRiosOQuebradasOriginal ? "Sí" : "No")</li>
                 <li>Cantidad de nacientes: @Model.CantidadNacientesOriginal</li>
-                <li>Estado evaluación: @Model.EstadoEvaluacion</li>
+                <li>Estado evaluación: @Model.EstadoEvaluacion.FormatearEstado()</li>
             </ul>
         </section>
 
@@ -31,7 +31,7 @@
             <ul class="lista-timeline">
                 <li>Fecha visita: @(Model.FechaVisita?.ToString("dd/MM/yyyy") ?? "N/A")</li>
                 <li>Fecha decisión: @(Model.FechaDecision?.ToString("dd/MM/yyyy") ?? "N/A")</li>
-                <li>Decisión técnica: @(string.IsNullOrWhiteSpace(Model.DecisionTecnica) ? "N/A" : Model.DecisionTecnica)</li>
+                <li>Decisión técnica: @(string.IsNullOrWhiteSpace(Model.DecisionTecnica) ? "N/A" : Model.DecisionTecnica.FormatearEstado())</li>
                 <li>Observaciones: @(string.IsNullOrWhiteSpace(Model.Observaciones) ? "N/A" : Model.Observaciones)</li>
             </ul>
         </section>
@@ -61,10 +61,10 @@
         else
         {
             <ul class="lista-timeline">
-                <li>Decisión técnica: @impacto.DecisionTecnica</li>
+                <li>Decisión técnica: @impacto.DecisionTecnica.FormatearEstado()</li>
                 <li>¿Generó plan?: @(impacto.GeneroPlan ? "Sí" : "No")</li>
-                <li>Estado de continuidad: @impacto.EstadoContinuidad</li>
-                <li>Cuenta bancaria: @impacto.EstadoCuentaBancaria (solo indicador)</li>
+                <li>Estado de continuidad: @impacto.EstadoContinuidad.FormatearEstado()</li>
+                <li>Cuenta bancaria: @impacto.EstadoCuentaBancaria.FormatearEstado() (solo indicador)</li>
                 <li>Monto mensual referencial: @(impacto.MontoMensualReferencial.HasValue ? $"₡{impacto.MontoMensualReferencial.Value:N2}" : "No aplica")</li>
                 <li>Monto anual referencial: @(impacto.MontoAnualReferencial.HasValue ? $"₡{impacto.MontoAnualReferencial.Value:N2}" : "No aplica")</li>
             </ul>

--- a/PSA.WebApp/Views/Evaluaciones/FincasIngeniero.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/FincasIngeniero.cshtml
@@ -34,8 +34,8 @@
                                 <td>#@item.IdEvaluacion</td>
                                 <td>@item.NombreFinca</td>
                                 <td>@item.Provincia, @item.Canton, @item.Distrito</td>
-                                <td>@item.EstadoEvaluacion</td>
-                                <td>@(string.IsNullOrWhiteSpace(item.DecisionTecnica) ? "N/A" : item.DecisionTecnica)</td>
+                                <td>@item.EstadoEvaluacion.FormatearEstado()</td>
+                                <td>@(string.IsNullOrWhiteSpace(item.DecisionTecnica) ? "N/A" : item.DecisionTecnica.FormatearEstado())</td>
                                 <td><a class="boton-link" asp-controller="Evaluaciones" asp-action="DetalleEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">Ver detalle</a></td>
                             </tr>
                         }

--- a/PSA.WebApp/Views/Evaluaciones/FincasPendientes.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/FincasPendientes.cshtml
@@ -48,7 +48,7 @@
                             <td>@item.NombreFinca</td>
                             <td>@item.Provincia, @item.Canton, @item.Distrito</td>
                             <td>@item.Hectareas.ToString("N2")</td>
-                            <td><span class="badge-estado @(item.EstadoEvaluacion == "En proceso" ? "badge-info" : "badge-pendiente")">@item.EstadoEvaluacion</span></td>
+                            <td><span class="badge-estado @(item.EstadoEvaluacion == "En proceso" ? "badge-info" : "badge-pendiente")">@item.EstadoEvaluacion.FormatearEstado()</span></td>
                             <td>
                                 <a class="boton-link me-2" asp-controller="Evaluaciones" asp-action="NuevaEvaluacion" asp-route-idEvaluacion="@item.IdEvaluacion">
                                     @(item.EstadoEvaluacion == "En proceso" ? "Continuar" : "Evaluar")

--- a/PSA.WebApp/Views/Evaluaciones/HistorialEvaluaciones.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/HistorialEvaluaciones.cshtml
@@ -147,8 +147,8 @@
                                 <td>#@item.IdEvaluacion</td>
                                 <td>@item.NombreFinca</td>
                                 <td>@item.Provincia, @item.Canton, @item.Distrito</td>
-                                <td>@item.EstadoEvaluacion</td>
-                                <td>@(string.IsNullOrWhiteSpace(item.DecisionTecnica) ? "N/A" : item.DecisionTecnica)</td>
+                                <td>@item.EstadoEvaluacion.FormatearEstado()</td>
+                                <td>@(string.IsNullOrWhiteSpace(item.DecisionTecnica) ? "N/A" : item.DecisionTecnica.FormatearEstado())</td>
                                 <td>@(item.FechaVisita?.ToString("dd/MM/yyyy") ?? "N/A")</td>
                                 <td>@(item.FechaDecision?.ToString("dd/MM/yyyy") ?? "N/A")</td>
                                 <td>

--- a/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
+++ b/PSA.WebApp/Views/Evaluaciones/NuevaEvaluacion.cshtml
@@ -26,11 +26,11 @@
                         {
                             if (string.Equals(opcion, Model.Detalle.Pendiente, System.StringComparison.OrdinalIgnoreCase))
                             {
-                                <option selected="selected">@opcion</option>
+                                <option selected="selected">@opcion.FormatearEstado()</option>
                             }
                             else
                             {
-                                <option>@opcion</option>
+                                <option>@opcion.FormatearEstado()</option>
                             }
                         }
                     </select>
@@ -247,4 +247,3 @@
 @section Scripts {
     <script src="~/js/evaluaciones.js" asp-append-version="true"></script>
 }
-

--- a/PSA.WebApp/Views/Fincas/DetalleFinca.cshtml
+++ b/PSA.WebApp/Views/Fincas/DetalleFinca.cshtml
@@ -28,7 +28,7 @@
 
         <div class="grid-dos-columnas detalle-resumen-grid">
             <div><strong>Propietario</strong><div>@Model.PropietarioNombre</div></div>
-            <div><strong>Estado de finca</strong><div>@Model.EstadoFinca</div></div>
+            <div><strong>Estado de finca</strong><div>@Model.EstadoFinca.FormatearEstado()</div></div>
             <div><strong>Provincia</strong><div>@Model.Provincia</div></div>
             <div><strong>Cantón</strong><div>@Model.Canton</div></div>
             <div><strong>Distrito</strong><div>@Model.Distrito</div></div>
@@ -36,7 +36,7 @@
             <div><strong>Vegetación</strong><div>@Model.Vegetacion</div></div>
             <div><strong>Uso de suelo</strong><div>@Model.UsoSuelo</div></div>
             <div><strong>Pendiente</strong><div>@Model.Pendiente</div></div>
-            <div><strong>Estado de evaluación</strong><div>@Model.EstadoEvaluacion</div></div>
+            <div><strong>Estado de evaluación</strong><div>@Model.EstadoEvaluacion.FormatearEstado()</div></div>
             <div><strong>Fecha de registro</strong><div>@Model.FechaRegistro.ToString("dd/MM/yyyy HH:mm")</div></div>
             <div><strong>Última actualización</strong><div>@Model.FechaActualizacion.ToString("dd/MM/yyyy HH:mm")</div></div>
         </div>

--- a/PSA.WebApp/Views/Fincas/MisFincas.cshtml
+++ b/PSA.WebApp/Views/Fincas/MisFincas.cshtml
@@ -83,8 +83,8 @@
                                 <td>@finca.NombreFinca</td>
                                 <td>@expediente</td>
                                 <td>@finca.Provincia, @finca.Canton</td>
-                                <td><span class="badge-estado @badgeClase">@finca.EstadoFinca</span></td>
-                                <td>@finca.EstadoEvaluacion</td>
+                                <td><span class="badge-estado @badgeClase">@finca.EstadoFinca.FormatearEstado()</span></td>
+                                <td>@finca.EstadoEvaluacion.FormatearEstado()</td>
                                 <td><a class="boton-link" asp-controller="Fincas" asp-action="DetalleFinca" asp-route-id="@finca.IdFinca">Ver detalle</a></td>
                             </tr>
                         }

--- a/PSA.WebApp/Views/Home/AccessDenied.cshtml
+++ b/PSA.WebApp/Views/Home/AccessDenied.cshtml
@@ -1,5 +1,6 @@
 @{
     ViewData["Title"] = "Acceso denegado";
+    var dashboardAction = ViewBag.DashboardAction as string ?? "Dueno";
 }
 
 <section class="container py-5">
@@ -7,5 +8,5 @@
         <h2 class="h4 mb-2">Acceso denegado</h2>
         <p class="mb-0">Su sesión está activa, pero su rol actual no tiene permisos para acceder a esta pantalla.</p>
     </div>
-    <a asp-controller="Home" asp-action="Index" class="btn btn-primary">Volver al inicio</a>
+    <a asp-controller="Dashboard" asp-action="@dashboardAction" class="btn btn-primary">Ir a mi inicio</a>
 </section>

--- a/PSA.WebApp/Views/MiPerfil/Index.cshtml
+++ b/PSA.WebApp/Views/MiPerfil/Index.cshtml
@@ -28,7 +28,7 @@
                 <p>@Model.Email</p>
                 <div class="perfil-resumen__meta">
                     <span class="badge-estado badge-info">@Model.RolNombre</span>
-                    <span class="badge-estado badge-exito">@Model.Estado</span>
+                    <span class="badge-estado badge-exito">@Model.Estado.FormatearEstado()</span>
                 </div>
             </div>
         </article>

--- a/PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml
+++ b/PSA.WebApp/Views/Pagos/CuentaBancaria.cshtml
@@ -42,7 +42,7 @@
                                 <td>@cuenta.NumeroCuenta</td>
                                 <td>@cuenta.TipoCuenta</td>
                                 <td>@cuenta.Titular</td>
-                                <td><span class="badge-estado badge-pendiente">@cuenta.EstadoValidacion</span></td>
+                                <td><span class="badge-estado badge-pendiente">@cuenta.EstadoValidacion.FormatearEstado()</span></td>
                             </tr>
                         }
                     }

--- a/PSA.WebApp/Views/Pagos/DetallePlanPagoAdmin.cshtml
+++ b/PSA.WebApp/Views/Pagos/DetallePlanPagoAdmin.cshtml
@@ -29,8 +29,8 @@
                     <tr><td>Finca</td><td>@Model.Plan.NombreFinca</td></tr>
                     <tr><td>Propietario</td><td>@Model.Plan.Propietario</td></tr>
                     <tr><td>Ingeniero</td><td>@Model.Plan.Ingeniero</td></tr>
-                    <tr><td>Estado del plan</td><td>@Model.Plan.EstadoPlan</td></tr>
-                    <tr><td>Estado bancario</td><td>@Model.Plan.EstadoBancario (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</td></tr>
+                    <tr><td>Estado del plan</td><td>@Model.Plan.EstadoPlan.FormatearEstado()</td></tr>
+                    <tr><td>Estado bancario</td><td>@Model.Plan.EstadoBancario.FormatearEstado() (@(Model.Plan.CuentaBancariaMascara ?? "Sin cuenta"))</td></tr>
                     <tr><td>Monto mensual</td><td>₡@Model.Plan.MontoMensual.ToString("N2")</td></tr>
                     <tr><td>Monto anual</td><td>₡@Model.Plan.MontoAnual.ToString("N2")</td></tr>
                     <tr><td>Versión de configuración</td><td>@Model.Plan.VersionConfiguracion</td></tr>
@@ -110,7 +110,7 @@
                     {
                         <tr>
                             <td>@Model.Plan.Anio-@cuota.Mes.ToString("00")</td>
-                            <td>@cuota.EstadoCuota</td>
+                            <td>@cuota.EstadoCuota.FormatearEstado()</td>
                             <td>@cuota.FechaProgramada.ToString("dd/MM/yyyy")</td>
                             <td>@(cuota.FechaPago?.ToString("dd/MM/yyyy") ?? "Pendiente")</td>
                             <td>₡@cuota.MontoProgramado.ToString("N2")</td>

--- a/PSA.WebApp/Views/Pagos/DetallePlanPagoDueno.cshtml
+++ b/PSA.WebApp/Views/Pagos/DetallePlanPagoDueno.cshtml
@@ -35,6 +35,6 @@
 </tbody></table></div></section>
 }
 <section class="tarjeta-panel"><h3>Cuotas mensuales</h3><div class="tabla-responsive"><table class="tabla-base"><thead><tr><th>Periodo</th><th>Estado</th><th>Programada</th><th>Ejecución</th><th>Monto</th></tr></thead><tbody>
-@foreach (var cuota in Model.Cuotas){<tr><td>@Model.Plan.Anio-@cuota.Mes.ToString("00")</td><td>@cuota.EstadoCuota</td><td>@cuota.FechaProgramada.ToString("dd/MM/yyyy")</td><td>@(cuota.FechaPago?.ToString("dd/MM/yyyy")??"Pendiente")</td><td>₡@cuota.MontoProgramado.ToString("N2")</td></tr>}
+@foreach (var cuota in Model.Cuotas){<tr><td>@Model.Plan.Anio-@cuota.Mes.ToString("00")</td><td>@cuota.EstadoCuota.FormatearEstado()</td><td>@cuota.FechaProgramada.ToString("dd/MM/yyyy")</td><td>@(cuota.FechaPago?.ToString("dd/MM/yyyy")??"Pendiente")</td><td>₡@cuota.MontoProgramado.ToString("N2")</td></tr>}
 </tbody></table></div></section>
 </section>

--- a/PSA.WebApp/Views/Pagos/HistorialPagos.cshtml
+++ b/PSA.WebApp/Views/Pagos/HistorialPagos.cshtml
@@ -41,7 +41,7 @@
                                 <td>@cuota.NombreFinca</td>
                                 <td>@periodo</td>
                                 <td>₡@cuota.MontoProgramado.ToString("N2")</td>
-                                <td><span class="badge-estado @estadoCss">@cuota.EstadoCuota</span></td>
+                                <td><span class="badge-estado @estadoCss">@cuota.EstadoCuota.FormatearEstado()</span></td>
                                 <td><a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="@cuota.IdPlanPago">Ver plan</a></td>
                             </tr>
                         }

--- a/PSA.WebApp/Views/Pagos/PlanesDueno.cshtml
+++ b/PSA.WebApp/Views/Pagos/PlanesDueno.cshtml
@@ -42,10 +42,10 @@
                             <tr>
                                 <td>@plan.NombreFinca</td>
                                 <td>@plan.Anio</td>
-                                <td>@plan.EstadoPlan</td>
+                                <td>@plan.EstadoPlan.FormatearEstado()</td>
                                 <td>₡@plan.MontoMensual.ToString("N2")</td>
                                 <td>₡@plan.MontoAnual.ToString("N2")</td>
-                                <td>@plan.EstadoCuentaBancaria (@(plan.CuentaBancariaMascara ?? "Sin cuenta"))</td>
+                                <td>@plan.EstadoCuentaBancaria.FormatearEstado() (@(plan.CuentaBancariaMascara ?? "Sin cuenta"))</td>
                                 <td>
                                     <a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="@plan.IdPlanPago">Ver detalle</a>
                                     @if (string.Equals(plan.EstadoPlan, "PendienteDatosBancarios", StringComparison.OrdinalIgnoreCase)

--- a/PSA.WebApp/Views/Pagos/PlanesIngenieroPendientes.cshtml
+++ b/PSA.WebApp/Views/Pagos/PlanesIngenieroPendientes.cshtml
@@ -18,8 +18,8 @@
             <input type="number" name="anio" value="@anio" min="2000" max="2100" class="form-control filtro-w-180" placeholder="Año" />
             <select name="estadoPlan" class="form-select filtro-w-280">
                 <option value="" selected="@(string.IsNullOrWhiteSpace(estadoPlan) ? "selected" : null)">Pendientes (default)</option>
-                <option value="PendienteDatosBancarios" selected="@(string.Equals(estadoPlan, "PendienteDatosBancarios", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">PendienteDatosBancarios</option>
-                <option value="PendienteAprobacionFinal" selected="@(string.Equals(estadoPlan, "PendienteAprobacionFinal", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">PendienteAprobacionFinal</option>
+                <option value="PendienteDatosBancarios" selected="@(string.Equals(estadoPlan, "PendienteDatosBancarios", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">@("PendienteDatosBancarios".FormatearEstado())</option>
+                <option value="PendienteAprobacionFinal" selected="@(string.Equals(estadoPlan, "PendienteAprobacionFinal", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">@("PendienteAprobacionFinal".FormatearEstado())</option>
                 <option value="Activo" selected="@(string.Equals(estadoPlan, "Activo", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">Activo</option>
                 <option value="Finalizado" selected="@(string.Equals(estadoPlan, "Finalizado", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">Finalizado</option>
                 <option value="Cancelado" selected="@(string.Equals(estadoPlan, "Cancelado", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">Cancelado</option>
@@ -54,7 +54,7 @@
                                 <td>@plan.Anio</td>
                                 <td>₡@plan.MontoMensualCalculado.ToString("N2")</td>
                                 <td>₡@plan.MontoAnualEstimado.ToString("N2")</td>
-                                <td><span class="badge-estado badge-pendiente">@plan.EstadoPlan</span></td>
+                                <td><span class="badge-estado badge-pendiente">@plan.EstadoPlan.FormatearEstado()</span></td>
                                 <td>@(plan.IdCuentaBancaria.HasValue ? $"#{plan.IdCuentaBancaria}" : "Sin cuenta")</td>
                                 <td>
                                     <a class="boton-link" asp-controller="Pagos" asp-action="DetallePlanPago" asp-route-id="@plan.IdPlanPago">Ver detalle</a>

--- a/PSA.WebApp/Views/Pagos/PlanesPago.cshtml
+++ b/PSA.WebApp/Views/Pagos/PlanesPago.cshtml
@@ -19,8 +19,8 @@
             <input class="form-control filtro-w-180" type="text" name="distrito" value="@ViewBag.Distrito" placeholder="Distrito" />
             <select class="form-select filtro-w-220" name="estadoPlan">
                 <option value="">Estado plan (todos)</option>
-                <option value="PendienteDatosBancarios">PendienteDatosBancarios</option>
-                <option value="PendienteAprobacionFinal">PendienteAprobacionFinal</option>
+                <option value="PendienteDatosBancarios">@("PendienteDatosBancarios".FormatearEstado())</option>
+                <option value="PendienteAprobacionFinal">@("PendienteAprobacionFinal".FormatearEstado())</option>
                 <option value="Activo">Activo</option>
                 <option value="Finalizado">Finalizado</option>
                 <option value="Cancelado">Cancelado</option>
@@ -62,8 +62,8 @@
                             <td>@plan.NombreFinca</td>
                             <td>@plan.Propietario</td>
                             <td>@plan.Provincia, @plan.Canton, @plan.Distrito</td>
-                            <td>@plan.EstadoPlan</td>
-                            <td>@plan.EstadoBancario (@(plan.CuentaBancariaMascara ?? "Sin cuenta"))</td>
+                            <td>@plan.EstadoPlan.FormatearEstado()</td>
+                            <td>@plan.EstadoBancario.FormatearEstado() (@(plan.CuentaBancariaMascara ?? "Sin cuenta"))</td>
                             <td>₡@plan.MontoMensual.ToString("N2")</td>
                             <td><a class="boton-link" asp-action="DetallePlanPago" asp-route-id="@plan.IdPlanPago">Ver detalle</a></td>
                         </tr>

--- a/PSA.WebApp/Views/Reportes/AdminEvaluaciones.cshtml
+++ b/PSA.WebApp/Views/Reportes/AdminEvaluaciones.cshtml
@@ -46,7 +46,7 @@
         <tbody>
             @foreach (var i in Model.Items)
             {
-                <tr><td>@i.IdEvaluacion</td><td>@i.NombreFinca</td><td>@i.Ingeniero</td><td>@i.EstadoEvaluacion</td><td>@i.DecisionTecnica</td><td>@((i.FechaDecision ?? i.FechaVisita)?.ToString("yyyy-MM-dd"))</td></tr>
+                <tr><td>@i.IdEvaluacion</td><td>@i.NombreFinca</td><td>@i.Ingeniero</td><td>@i.EstadoEvaluacion.FormatearEstado()</td><td>@i.DecisionTecnica.FormatearEstado()</td><td>@((i.FechaDecision ?? i.FechaVisita)?.ToString("yyyy-MM-dd"))</td></tr>
             }
         </tbody>
     </table>

--- a/PSA.WebApp/Views/Reportes/AdminFincasEstado.cshtml
+++ b/PSA.WebApp/Views/Reportes/AdminFincasEstado.cshtml
@@ -8,7 +8,7 @@
         <tbody>
             @foreach (var i in Model.Items)
             {
-                <tr><td>@i.EstadoFinca</td><td>@i.Cantidad</td></tr>
+                <tr><td>@i.EstadoFinca.FormatearEstado()</td><td>@i.Cantidad</td></tr>
             }
         </tbody>
     </table>

--- a/PSA.WebApp/Views/Reportes/AdminUsuarios.cshtml
+++ b/PSA.WebApp/Views/Reportes/AdminUsuarios.cshtml
@@ -32,7 +32,7 @@
         <tbody>
             @foreach (var i in Model.Items)
             {
-                <tr><td>@i.NombreCompleto</td><td>@i.Email</td><td>@i.Rol</td><td>@i.Estado</td></tr>
+                <tr><td>@i.NombreCompleto</td><td>@i.Email</td><td>@i.Rol</td><td>@i.Estado.FormatearEstado()</td></tr>
             }
         </tbody>
     </table>

--- a/PSA.WebApp/Views/Reportes/DuenoFincas.cshtml
+++ b/PSA.WebApp/Views/Reportes/DuenoFincas.cshtml
@@ -34,7 +34,7 @@
         <tbody>
             @foreach (var i in Model.Items)
             {
-                <tr><td>@i.NombreFinca</td><td>@i.Provincia, @i.Canton, @i.Distrito</td><td>@i.EstadoFinca</td><td>@i.EstadoEvaluacion</td><td>@i.ObservacionesEvaluacion</td></tr>
+                <tr><td>@i.NombreFinca</td><td>@i.Provincia, @i.Canton, @i.Distrito</td><td>@i.EstadoFinca.FormatearEstado()</td><td>@i.EstadoEvaluacion.FormatearEstado()</td><td>@i.ObservacionesEvaluacion</td></tr>
             }
         </tbody>
     </table>

--- a/PSA.WebApp/Views/Reportes/DuenoPagos.cshtml
+++ b/PSA.WebApp/Views/Reportes/DuenoPagos.cshtml
@@ -41,7 +41,7 @@
                 <tr>
                     <td>@i.NombreFinca</td>
                     <td>@i.Anio/@i.Mes</td>
-                    <td>@i.EstadoCuota</td>
+                    <td>@i.EstadoCuota.FormatearEstado()</td>
                     <td>@i.MontoMensualCalculado.ToString("N2")</td>
                     <td>@(i.FechaPago?.ToString("yyyy-MM-dd") ?? i.FechaProgramada.ToString("yyyy-MM-dd"))</td>
                 </tr>
@@ -66,7 +66,7 @@
         <tbody>
             @foreach (var i in Model.Transacciones)
             {
-                <tr><td>@i.FechaTransaccion.ToString("yyyy-MM-dd")</td><td>@i.NombreFinca</td><td>@i.MontoTotal.ToString("N2")</td><td>@i.EstadoTransaccion</td></tr>
+                <tr><td>@i.FechaTransaccion.ToString("yyyy-MM-dd")</td><td>@i.NombreFinca</td><td>@i.MontoTotal.ToString("N2")</td><td>@i.EstadoTransaccion.FormatearEstado()</td></tr>
             }
         </tbody>
     </table>

--- a/PSA.WebApp/Views/Reportes/IngenieroEvaluaciones.cshtml
+++ b/PSA.WebApp/Views/Reportes/IngenieroEvaluaciones.cshtml
@@ -52,7 +52,7 @@
         <tbody>
             @foreach (var i in Model.Reporte.Evaluaciones)
             {
-                <tr><td>@i.IdEvaluacion</td><td>@i.NombreFinca</td><td>@i.EstadoEvaluacion</td><td>@i.DecisionTecnica</td><td>@((i.FechaDecision ?? i.FechaVisita)?.ToString("yyyy-MM-dd"))</td></tr>
+                <tr><td>@i.IdEvaluacion</td><td>@i.NombreFinca</td><td>@i.EstadoEvaluacion.FormatearEstado()</td><td>@i.DecisionTecnica.FormatearEstado()</td><td>@((i.FechaDecision ?? i.FechaVisita)?.ToString("yyyy-MM-dd"))</td></tr>
             }
         </tbody>
     </table>

--- a/PSA.WebApp/Views/Reportes/IngenieroPendientes.cshtml
+++ b/PSA.WebApp/Views/Reportes/IngenieroPendientes.cshtml
@@ -25,7 +25,7 @@
         <tbody>
             @foreach (var i in Model.Items)
             {
-                <tr><td>@i.IdEvaluacion</td><td>@i.NombreFinca</td><td>@i.Provincia, @i.Canton, @i.Distrito</td><td>@i.EstadoEvaluacion</td></tr>
+                <tr><td>@i.IdEvaluacion</td><td>@i.NombreFinca</td><td>@i.Provincia, @i.Canton, @i.Distrito</td><td>@i.EstadoEvaluacion.FormatearEstado()</td></tr>
             }
         </tbody>
     </table>

--- a/PSA.WebApp/Views/_ViewImports.cshtml
+++ b/PSA.WebApp/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 @using PSA.WebApp
 @using PSA.EntidadesDTO.DTOs
+@using PSA.WebApp.Helpers
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
### Motivation

- Ensure SMTP configuration is validated and failures are logged so password recovery emails are only attempted when properly configured.  
- Improve observability and error handling for the password recovery flow with structured logging.  
- Provide a consistent, human-friendly display for many internal state strings and improve UX by redirecting authenticated users away from auth pages and preventing caching of authenticated responses.

### Description

- Added `SmtpSettingsResolver` with `Resolve` and `GetMissingRequiredKeys` to centralize SMTP configuration parsing and normalization and included it in `PSA.WebAPI.csproj`.  
- Updated `PasswordRecoveryEmailSender` to use `SmtpSettingsResolver`, log missing SMTP keys, throw on misconfiguration, and catch `SmtpException` to log SMTP rejections.  
- Added logging to `RecuperacionContrasenaController` by injecting `ILogger<RecuperacionContrasenaController>` and logging controlled (`LogWarning`) and uncontrolled (`LogError`) failures; throttle service registration remains unchanged.  
- Updated `SmtpNotificationEmailSender` to use the `SmtpSettingsResolver`, injected an `ILogger` and skip sending when SMTP is incomplete while logging a warning.  
- In `Program.cs` for `PSA.WebAPI` added a production-time SMTP check that writes missing keys to `Console.Error`.  
- Introduced `EstadoDisplayHelper` with `FormatearEstado()` to humanize and title-case known state identifiers and applied it across many Razor views to normalize displayed statuses; added to `PSA.WebApp.csproj` and `_ViewImports.cshtml`.  
- Improved web app auth UX: added `UsuarioAutenticado`, `RedirectToRoleDashboard`, `GetDashboardActionByRoleId` to `AppControllerBase`; updated `AutenticacionController` to accept `returnUrl`, redirect authenticated users from auth pages, and handle API errors/timeouts more gracefully.  
- Added middleware in `PSA.WebApp/Program.cs` to add no-cache headers for authenticated responses.  

### Testing

- Executed `dotnet build` for the solution and for `PSA.WebAPI` and `PSA.WebApp` projects and the builds completed successfully.  
- No automated unit tests were run as part of this change set (no test projects were executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eade376d18832d853be39b2ab91ad8)